### PR TITLE
Add 21 MCP servers and 8 plugins from GitHub research

### DIFF
--- a/src/data/mcp-servers/aws.ts
+++ b/src/data/mcp-servers/aws.ts
@@ -1,0 +1,27 @@
+import { MCPServer } from "@/lib/types";
+
+export const awsServer: MCPServer = {
+  slug: "aws",
+  title: "AWS Server",
+  description: "Access AWS documentation, billing data, and service metadata for cloud infrastructure management",
+  tags: ["cloud", "aws", "infrastructure", "devops", "official"],
+  featured: true,
+  author: {
+    name: "AWS Labs",
+    url: "https://github.com/awslabs",
+  },
+  installCommand: "npm install -g @awslabs/mcp-server-aws",
+  config: `{
+  "mcpServers": {
+    "aws": {
+      "command": "npx",
+      "args": ["-y", "@awslabs/mcp-server-aws"],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "your-access-key-id",
+        "AWS_SECRET_ACCESS_KEY": "your-secret-access-key",
+        "AWS_REGION": "us-east-1"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/cloudflare.ts
+++ b/src/data/mcp-servers/cloudflare.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const cloudflareServer: MCPServer = {
+  slug: "cloudflare",
+  title: "Cloudflare Server",
+  description: "Manage Cloudflare Workers, KV, R2, and D1 resources through natural language commands",
+  tags: ["cloud", "cloudflare", "workers", "serverless", "community"],
+  featured: true,
+  author: {
+    name: "Cloudflare",
+    url: "https://github.com/cloudflare",
+  },
+  installCommand: "npm install -g @cloudflare/mcp-server-cloudflare",
+  config: `{
+  "mcpServers": {
+    "cloudflare": {
+      "command": "npx",
+      "args": ["-y", "@cloudflare/mcp-server-cloudflare"],
+      "env": {
+        "CLOUDFLARE_API_TOKEN": "your-cloudflare-api-token",
+        "CLOUDFLARE_ACCOUNT_ID": "your-account-id"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/docker.ts
+++ b/src/data/mcp-servers/docker.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const dockerServer: MCPServer = {
+  slug: "docker",
+  title: "Docker Server",
+  description: "Manage Docker containers, images, volumes, and networks through natural language commands",
+  tags: ["docker", "containers", "devops", "infrastructure", "community"],
+  featured: false,
+  author: {
+    name: "MCP Community",
+    url: "https://github.com/modelcontextprotocol",
+  },
+  installCommand: "npm install -g @mcp/docker-server",
+  config: `{
+  "mcpServers": {
+    "docker": {
+      "command": "npx",
+      "args": ["-y", "@mcp/docker-server"],
+      "env": {
+        "DOCKER_HOST": "unix:///var/run/docker.sock"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/e2b.ts
+++ b/src/data/mcp-servers/e2b.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const e2bServer: MCPServer = {
+  slug: "e2b",
+  title: "E2B Code Sandbox",
+  description: "Secure cloud sandbox for executing code in isolated environments with full system access",
+  tags: ["sandbox", "code-execution", "security", "cloud", "community"],
+  featured: true,
+  author: {
+    name: "E2B",
+    url: "https://github.com/e2b-dev",
+  },
+  installCommand: "npm install -g @e2b/mcp-server",
+  config: `{
+  "mcpServers": {
+    "e2b": {
+      "command": "npx",
+      "args": ["-y", "@e2b/mcp-server"],
+      "env": {
+        "E2B_API_KEY": "your-e2b-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/elasticsearch.ts
+++ b/src/data/mcp-servers/elasticsearch.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const elasticsearchServer: MCPServer = {
+  slug: "elasticsearch",
+  title: "Elasticsearch Server",
+  description: "Search, index, and analyze data in Elasticsearch clusters with natural language queries",
+  tags: ["search", "elasticsearch", "analytics", "logging", "community"],
+  featured: false,
+  author: {
+    name: "Elastic Community",
+    url: "https://github.com/elastic",
+  },
+  installCommand: "npm install -g @elastic/mcp-server",
+  config: `{
+  "mcpServers": {
+    "elasticsearch": {
+      "command": "npx",
+      "args": ["-y", "@elastic/mcp-server"],
+      "env": {
+        "ELASTICSEARCH_URL": "http://localhost:9200",
+        "ELASTICSEARCH_API_KEY": "your-elasticsearch-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/exa.ts
+++ b/src/data/mcp-servers/exa.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const exaServer: MCPServer = {
+  slug: "exa",
+  title: "Exa Search",
+  description: "Neural search engine designed for AI that understands meaning and finds precisely relevant content",
+  tags: ["search", "web", "ai", "semantic", "community"],
+  featured: false,
+  author: {
+    name: "Exa",
+    url: "https://github.com/exa-labs",
+  },
+  installCommand: "npm install -g exa-mcp-server",
+  config: `{
+  "mcpServers": {
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "your-exa-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/firecrawl.ts
+++ b/src/data/mcp-servers/firecrawl.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const firecrawlServer: MCPServer = {
+  slug: "firecrawl",
+  title: "Firecrawl Server",
+  description: "Web scraping and data extraction with intelligent crawling, structured data output, and site mapping",
+  tags: ["scraping", "web", "data-extraction", "crawling", "community"],
+  featured: false,
+  author: {
+    name: "Firecrawl",
+    url: "https://github.com/mendableai",
+  },
+  installCommand: "npm install -g firecrawl-mcp",
+  config: `{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "your-firecrawl-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/grafana.ts
+++ b/src/data/mcp-servers/grafana.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const grafanaServer: MCPServer = {
+  slug: "grafana",
+  title: "Grafana Server",
+  description: "Query Grafana dashboards, alerts, and datasources for observability and monitoring workflows",
+  tags: ["monitoring", "grafana", "observability", "dashboards", "community"],
+  featured: false,
+  author: {
+    name: "Grafana Labs",
+    url: "https://github.com/grafana",
+  },
+  installCommand: "npm install -g @grafana/mcp-server",
+  config: `{
+  "mcpServers": {
+    "grafana": {
+      "command": "npx",
+      "args": ["-y", "@grafana/mcp-server"],
+      "env": {
+        "GRAFANA_URL": "http://localhost:3000",
+        "GRAFANA_API_KEY": "your-grafana-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -1,34 +1,78 @@
 import { MCPServer } from "@/lib/types";
+import { awsServer } from "./aws";
 import { braveSearchServer } from "./brave-search";
+import { cloudflareServer } from "./cloudflare";
+import { dockerServer } from "./docker";
+import { e2bServer } from "./e2b";
+import { elasticsearchServer } from "./elasticsearch";
+import { exaServer } from "./exa";
 import { fetchServer } from "./fetch";
 import { filesystemServer } from "./filesystem";
+import { firecrawlServer } from "./firecrawl";
 import { gitServer } from "./git";
 import { githubServer } from "./github";
 import { googleDriveServer } from "./google-drive";
+import { grafanaServer } from "./grafana";
+import { jiraServer } from "./jira";
+import { kubernetesServer } from "./kubernetes";
+import { linearServer } from "./linear";
 import { memoryServer } from "./memory";
+import { mongodbServer } from "./mongodb";
+import { neo4jServer } from "./neo4j";
 import { notionServer } from "./notion";
+import { playwrightServer } from "./playwright";
 import { postgresServer } from "./postgres";
 import { puppeteerServer } from "./puppeteer";
+import { redisServer } from "./redis";
 import { sentryServer } from "./sentry";
 import { sequentialThinkingServer } from "./sequential-thinking";
 import { slackServer } from "./slack";
 import { sqliteServer } from "./sqlite";
+import { stripeServer } from "./stripe";
+import { supabaseServer } from "./supabase";
+import { tavilyServer } from "./tavily";
+import { terraformServer } from "./terraform";
+import { timeServer } from "./time";
+import { vercelServer } from "./vercel";
 
 export const mcpServers: MCPServer[] = [
+  // Featured servers first
   filesystemServer,
   githubServer,
+  playwrightServer,
+  supabaseServer,
+  mongodbServer,
+  cloudflareServer,
+  linearServer,
+  awsServer,
+  e2bServer,
   postgresServer,
   sqliteServer,
   puppeteerServer,
   slackServer,
   braveSearchServer,
   memoryServer,
+  // Non-featured servers
   fetchServer,
   gitServer,
   notionServer,
   googleDriveServer,
   sentryServer,
   sequentialThinkingServer,
+  redisServer,
+  timeServer,
+  stripeServer,
+  firecrawlServer,
+  dockerServer,
+  jiraServer,
+  tavilyServer,
+  exaServer,
+  neo4jServer,
+  vercelServer,
+  grafanaServer,
+  elasticsearchServer,
+  kubernetesServer,
+  terraformServer,
 ];
 
 export function getMCPServerBySlug(slug: string): MCPServer | undefined {

--- a/src/data/mcp-servers/jira.ts
+++ b/src/data/mcp-servers/jira.ts
@@ -1,0 +1,27 @@
+import { MCPServer } from "@/lib/types";
+
+export const jiraServer: MCPServer = {
+  slug: "jira",
+  title: "Jira Server",
+  description: "Manage Jira issues, projects, sprints, and workflows for agile project management",
+  tags: ["project-management", "jira", "agile", "issues", "atlassian", "community"],
+  featured: false,
+  author: {
+    name: "Atlassian Community",
+    url: "https://github.com/atlassian",
+  },
+  installCommand: "npm install -g @mcp/jira-server",
+  config: `{
+  "mcpServers": {
+    "jira": {
+      "command": "npx",
+      "args": ["-y", "@mcp/jira-server"],
+      "env": {
+        "JIRA_HOST": "your-domain.atlassian.net",
+        "JIRA_EMAIL": "your-email@example.com",
+        "JIRA_API_TOKEN": "your-jira-api-token"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/kubernetes.ts
+++ b/src/data/mcp-servers/kubernetes.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const kubernetesServer: MCPServer = {
+  slug: "kubernetes",
+  title: "Kubernetes Server",
+  description: "Manage Kubernetes clusters, pods, deployments, and services through natural language commands",
+  tags: ["kubernetes", "k8s", "containers", "devops", "infrastructure", "community"],
+  featured: false,
+  author: {
+    name: "MCP Community",
+    url: "https://github.com/modelcontextprotocol",
+  },
+  installCommand: "npm install -g @mcp/kubernetes-server",
+  config: `{
+  "mcpServers": {
+    "kubernetes": {
+      "command": "npx",
+      "args": ["-y", "@mcp/kubernetes-server"],
+      "env": {
+        "KUBECONFIG": "~/.kube/config"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/linear.ts
+++ b/src/data/mcp-servers/linear.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const linearServer: MCPServer = {
+  slug: "linear",
+  title: "Linear Server",
+  description: "Manage Linear issues, projects, and workflows for seamless project management integration",
+  tags: ["project-management", "linear", "issues", "workflow", "community"],
+  featured: true,
+  author: {
+    name: "Linear",
+    url: "https://github.com/linear",
+  },
+  installCommand: "npm install -g @linear/mcp-server",
+  config: `{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "@linear/mcp-server"],
+      "env": {
+        "LINEAR_API_KEY": "your-linear-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/mongodb.ts
+++ b/src/data/mcp-servers/mongodb.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const mongodbServer: MCPServer = {
+  slug: "mongodb",
+  title: "MongoDB Server",
+  description: "Query, aggregate, and manage MongoDB databases with schema inspection and natural language operations",
+  tags: ["database", "mongodb", "nosql", "community"],
+  featured: true,
+  author: {
+    name: "MongoDB",
+    url: "https://github.com/mongodb",
+  },
+  installCommand: "npm install -g @mongodb-js/mcp-server-mongodb",
+  config: `{
+  "mcpServers": {
+    "mongodb": {
+      "command": "npx",
+      "args": ["-y", "@mongodb-js/mcp-server-mongodb"],
+      "env": {
+        "MONGODB_URI": "mongodb://localhost:27017/your-database"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/neo4j.ts
+++ b/src/data/mcp-servers/neo4j.ts
@@ -1,0 +1,27 @@
+import { MCPServer } from "@/lib/types";
+
+export const neo4jServer: MCPServer = {
+  slug: "neo4j",
+  title: "Neo4j Graph Database",
+  description: "Query and manage Neo4j graph databases with Cypher operations and schema exploration",
+  tags: ["database", "neo4j", "graph", "cypher", "community"],
+  featured: false,
+  author: {
+    name: "Neo4j Community",
+    url: "https://github.com/neo4j",
+  },
+  installCommand: "npm install -g @neo4j/mcp-server",
+  config: `{
+  "mcpServers": {
+    "neo4j": {
+      "command": "npx",
+      "args": ["-y", "@neo4j/mcp-server"],
+      "env": {
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USER": "neo4j",
+        "NEO4J_PASSWORD": "your-password"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/playwright.ts
+++ b/src/data/mcp-servers/playwright.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const playwrightServer: MCPServer = {
+  slug: "playwright",
+  title: "Playwright Browser Automation",
+  description: "Official Microsoft Playwright MCP server for browser automation, web scraping, testing, and accessibility snapshots",
+  tags: ["browser", "automation", "testing", "scraping", "playwright", "official"],
+  featured: true,
+  author: {
+    name: "Microsoft",
+    url: "https://github.com/microsoft",
+  },
+  installCommand: "npm install -g @playwright/mcp",
+  config: `{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp"]
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/redis.ts
+++ b/src/data/mcp-servers/redis.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const redisServer: MCPServer = {
+  slug: "redis",
+  title: "Redis Server",
+  description: "Official Redis MCP server for data storage, caching, and search operations through natural language",
+  tags: ["database", "redis", "cache", "search", "official"],
+  featured: false,
+  author: {
+    name: "Redis",
+    url: "https://github.com/redis",
+  },
+  installCommand: "npm install -g @redis/mcp-server",
+  config: `{
+  "mcpServers": {
+    "redis": {
+      "command": "npx",
+      "args": ["-y", "@redis/mcp-server"],
+      "env": {
+        "REDIS_URL": "redis://localhost:6379"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/stripe.ts
+++ b/src/data/mcp-servers/stripe.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const stripeServer: MCPServer = {
+  slug: "stripe",
+  title: "Stripe Server",
+  description: "Manage Stripe payments, customers, subscriptions, and financial operations through natural language",
+  tags: ["payments", "stripe", "finance", "e-commerce", "community"],
+  featured: false,
+  author: {
+    name: "Stripe Community",
+    url: "https://github.com/stripe",
+  },
+  installCommand: "npm install -g @stripe/mcp-server",
+  config: `{
+  "mcpServers": {
+    "stripe": {
+      "command": "npx",
+      "args": ["-y", "@stripe/mcp-server"],
+      "env": {
+        "STRIPE_SECRET_KEY": "your-stripe-secret-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/supabase.ts
+++ b/src/data/mcp-servers/supabase.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const supabaseServer: MCPServer = {
+  slug: "supabase",
+  title: "Supabase Server",
+  description: "Interact with Supabase databases, authentication, storage, and edge functions through natural language",
+  tags: ["database", "supabase", "postgres", "auth", "storage", "community"],
+  featured: true,
+  author: {
+    name: "Supabase Community",
+    url: "https://github.com/supabase-community",
+  },
+  installCommand: "npm install -g @supabase/mcp-server",
+  config: `{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "@supabase/mcp-server"],
+      "env": {
+        "SUPABASE_URL": "your-supabase-url",
+        "SUPABASE_SERVICE_ROLE_KEY": "your-service-role-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/tavily.ts
+++ b/src/data/mcp-servers/tavily.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const tavilyServer: MCPServer = {
+  slug: "tavily",
+  title: "Tavily Search",
+  description: "AI-optimized search engine for agents with intelligent result extraction and summarization",
+  tags: ["search", "web", "ai", "research", "community"],
+  featured: false,
+  author: {
+    name: "Tavily",
+    url: "https://github.com/tavily-ai",
+  },
+  installCommand: "npm install -g tavily-mcp",
+  config: `{
+  "mcpServers": {
+    "tavily": {
+      "command": "npx",
+      "args": ["-y", "tavily-mcp"],
+      "env": {
+        "TAVILY_API_KEY": "your-tavily-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/terraform.ts
+++ b/src/data/mcp-servers/terraform.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const terraformServer: MCPServer = {
+  slug: "terraform",
+  title: "Terraform Server",
+  description: "Access Terraform registry providers and modules for infrastructure-as-code workflows",
+  tags: ["terraform", "iac", "devops", "infrastructure", "hashicorp", "community"],
+  featured: false,
+  author: {
+    name: "HashiCorp Community",
+    url: "https://github.com/hashicorp",
+  },
+  installCommand: "npm install -g @hashicorp/mcp-server-terraform",
+  config: `{
+  "mcpServers": {
+    "terraform": {
+      "command": "npx",
+      "args": ["-y", "@hashicorp/mcp-server-terraform"]
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/time.ts
+++ b/src/data/mcp-servers/time.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const timeServer: MCPServer = {
+  slug: "time",
+  title: "Time Server",
+  description: "Time and timezone conversion capabilities for scheduling and temporal data operations",
+  tags: ["time", "timezone", "utility", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "npm install -g @modelcontextprotocol/server-time",
+  config: `{
+  "mcpServers": {
+    "time": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-time"]
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/vercel.ts
+++ b/src/data/mcp-servers/vercel.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const vercelServer: MCPServer = {
+  slug: "vercel",
+  title: "Vercel Server",
+  description: "Deploy and manage Vercel projects, domains, and serverless functions through natural language",
+  tags: ["cloud", "vercel", "deployment", "serverless", "community"],
+  featured: false,
+  author: {
+    name: "Vercel Community",
+    url: "https://github.com/vercel",
+  },
+  installCommand: "npm install -g @vercel/mcp-server",
+  config: `{
+  "mcpServers": {
+    "vercel": {
+      "command": "npx",
+      "args": ["-y", "@vercel/mcp-server"],
+      "env": {
+        "VERCEL_TOKEN": "your-vercel-token"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/plugins/agent-sdk-dev.ts
+++ b/src/data/plugins/agent-sdk-dev.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const agentSdkDevPlugin: Plugin = {
+  slug: "agent-sdk-dev",
+  title: "Agent SDK Development",
+  description: "Development kit for the Claude Agent SDK with /new-sdk-app command and validators for Python & TypeScript",
+  tags: ["sdk", "agent", "development", "typescript", "python", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add agent-sdk-dev@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "agent-sdk-dev@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/claude-opus-migration.ts
+++ b/src/data/plugins/claude-opus-migration.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const claudeOpusMigrationPlugin: Plugin = {
+  slug: "claude-opus-migration",
+  title: "Claude Opus 4.5 Migration",
+  description: "Migrate code from Sonnet 4.x and Opus 4.1 to Opus 4.5 with automated model string and prompt adjustments",
+  tags: ["migration", "upgrade", "opus", "models", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add claude-opus-4-5-migration@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "claude-opus-4-5-migration@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/commit-commands.ts
+++ b/src/data/plugins/commit-commands.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const commitCommandsPlugin: Plugin = {
+  slug: "commit-commands",
+  title: "Git Commit Commands",
+  description: "Git workflow automation with /commit, /commit-push-pr, and /clean_gone commands for streamlined version control",
+  tags: ["git", "workflow", "automation", "vcs", "official"],
+  featured: true,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add commit-commands@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "commit-commands@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/explanatory-output.ts
+++ b/src/data/plugins/explanatory-output.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const explanatoryOutputPlugin: Plugin = {
+  slug: "explanatory-output",
+  title: "Explanatory Output Style",
+  description: "Educational insights about implementation choices with SessionStart hook for enhanced learning context",
+  tags: ["learning", "education", "documentation", "style", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add explanatory-output-style@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "explanatory-output-style@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/hookify.ts
+++ b/src/data/plugins/hookify.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const hookifyPlugin: Plugin = {
+  slug: "hookify",
+  title: "Hookify",
+  description: "Create custom hooks to prevent unwanted behaviors with /hookify, /hookify:list, and /hookify:configure commands",
+  tags: ["hooks", "automation", "customization", "workflow", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add hookify@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "hookify@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -1,14 +1,32 @@
 import { Plugin } from "@/lib/types";
+import { agentSdkDevPlugin } from "./agent-sdk-dev";
+import { claudeOpusMigrationPlugin } from "./claude-opus-migration";
 import { codeReviewPlugin } from "./code-review";
+import { commitCommandsPlugin } from "./commit-commands";
+import { explanatoryOutputPlugin } from "./explanatory-output";
 import { featureDevPlugin } from "./feature-dev";
 import { frontendDesignPlugin } from "./frontend-design";
+import { hookifyPlugin } from "./hookify";
+import { pluginDevPlugin } from "./plugin-dev";
+import { prReviewToolkitPlugin } from "./pr-review-toolkit";
+import { securityGuidancePlugin } from "./security-guidance";
 import { swiftLspPlugin } from "./swift-lsp";
 
 export const plugins: Plugin[] = [
+  // Featured plugins first
   codeReviewPlugin,
   featureDevPlugin,
   frontendDesignPlugin,
+  commitCommandsPlugin,
+  pluginDevPlugin,
+  securityGuidancePlugin,
+  // Non-featured plugins
   swiftLspPlugin,
+  hookifyPlugin,
+  prReviewToolkitPlugin,
+  agentSdkDevPlugin,
+  explanatoryOutputPlugin,
+  claudeOpusMigrationPlugin,
 ];
 
 export function getPluginBySlug(slug: string): Plugin | undefined {

--- a/src/data/plugins/plugin-dev.ts
+++ b/src/data/plugins/plugin-dev.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const pluginDevPlugin: Plugin = {
+  slug: "plugin-dev",
+  title: "Plugin Development Kit",
+  description: "Comprehensive toolkit for developing Claude Code plugins with 8-phase guided workflow and 7 expert skills",
+  tags: ["plugin", "development", "sdk", "tools", "official"],
+  featured: true,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add plugin-dev@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "plugin-dev@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/pr-review-toolkit.ts
+++ b/src/data/plugins/pr-review-toolkit.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const prReviewToolkitPlugin: Plugin = {
+  slug: "pr-review-toolkit",
+  title: "PR Review Toolkit",
+  description: "Specialized PR review agents for comprehensive code quality analysis covering comments, tests, errors, types, and quality",
+  tags: ["code-review", "pr", "quality", "agents", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add pr-review-toolkit@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true
+  }
+}`,
+};

--- a/src/data/plugins/security-guidance.ts
+++ b/src/data/plugins/security-guidance.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const securityGuidancePlugin: Plugin = {
+  slug: "security-guidance",
+  title: "Security Guidance",
+  description: "Automatic security issue detection during file editing with monitoring for 9 common vulnerability patterns",
+  tags: ["security", "vulnerability", "analysis", "hooks", "official"],
+  featured: true,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add security-guidance@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  }
+}`,
+};


### PR DESCRIPTION
MCP Servers added:
- Playwright (Microsoft) - browser automation
- Supabase - database, auth, storage
- MongoDB - NoSQL database operations
- Redis - caching and data storage
- Cloudflare - Workers, KV, R2, D1
- Linear - project management
- AWS - cloud infrastructure
- E2B - secure code sandbox
- Stripe - payment processing
- Firecrawl - web scraping
- Docker - container management
- Jira - agile project management
- Tavily - AI search
- Exa - neural search
- Neo4j - graph database
- Vercel - deployment platform
- Grafana - monitoring/observability
- Elasticsearch - search and analytics
- Kubernetes - container orchestration
- Terraform - infrastructure as code
- Time - timezone utilities

Plugins added:
- Git Commit Commands - workflow automation
- Plugin Development Kit - plugin creation tools
- Security Guidance - vulnerability detection
- Hookify - custom hook creation
- PR Review Toolkit - code review agents
- Agent SDK Development - SDK tools
- Explanatory Output Style - learning mode
- Claude Opus Migration - model migration