### PR TITLE
linktosource

### DIFF
--- a/src/app/agents/[slug]/page.tsx
+++ b/src/app/agents/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { agents, getAgentBySlug } from "@/data/agents";
 import { Agent } from "@/lib/types";
-import { ArrowLeft, Bot, User } from "lucide-react";
+import { ArrowLeft, Bot, User, ExternalLink } from "lucide-react";
 
 const BASE_URL = "https://claudedirectory.org";
 
@@ -165,6 +165,20 @@ export default async function AgentDetailPage(props: Props) {
             <li>Reference the agent when delegating specialized tasks</li>
           </ol>
         </div>
+
+        {agent.repoUrl && (
+          <div>
+            <a
+              href={agent.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {agent.relatedItems && agent.relatedItems.length > 0 && (
           <>

--- a/src/app/hooks/[slug]/page.tsx
+++ b/src/app/hooks/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { CopyButton } from "@/components/copy-button";
 import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { hooks, getHookBySlug } from "@/data/hooks";
-import { ArrowLeft, Webhook, User } from "lucide-react";
+import { ArrowLeft, Webhook, User, ExternalLink } from "lucide-react";
 
 const BASE_URL = "https://claudedirectory.org";
 
@@ -168,6 +168,20 @@ export default async function HookDetailPage(props: Props) {
             <li>Restart Claude Code to apply changes</li>
           </ol>
         </div>
+
+        {hook.repoUrl && (
+          <div>
+            <a
+              href={hook.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {hook.relatedItems && hook.relatedItems.length > 0 && (
           <>

--- a/src/app/how-to/[slug]/page.tsx
+++ b/src/app/how-to/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { howTos, getHowToBySlug } from "@/data/how-to";
-import { ArrowLeft, BookOpen, User, Clock } from "lucide-react";
+import { ArrowLeft, BookOpen, User, Clock, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
 import { CodeBlock } from "@/components/code-block";
@@ -236,6 +236,20 @@ export default async function HowToDetailPage(props: Props) {
             {howTo.content}
           </ReactMarkdown>
         </article>
+
+        {howTo.repoUrl && (
+          <div>
+            <a
+              href={howTo.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {howTo.relatedItems && howTo.relatedItems.length > 0 && (
           <>

--- a/src/app/mcp-servers/[slug]/page.tsx
+++ b/src/app/mcp-servers/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { CopyButton } from "@/components/copy-button";
 import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { mcpServers, getMCPServerBySlug } from "@/data/mcp-servers";
-import { ArrowLeft, Server, User, Terminal } from "lucide-react";
+import { ArrowLeft, Server, User, Terminal, ExternalLink } from "lucide-react";
 
 const BASE_URL = "https://claudedirectory.org";
 
@@ -156,6 +156,20 @@ export default async function MCPServerDetailPage(props: Props) {
             <li>Restart Claude Code to apply changes</li>
           </ol>
         </div>
+
+        {server.repoUrl && (
+          <div>
+            <a
+              href={server.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {server.relatedItems && server.relatedItems.length > 0 && (
           <>

--- a/src/app/prompts/[slug]/page.tsx
+++ b/src/app/prompts/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { CopyButton } from "@/components/copy-button";
 import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { prompts, getPromptBySlug } from "@/data/prompts";
-import { ArrowLeft, FileText, User } from "lucide-react";
+import { ArrowLeft, FileText, User, ExternalLink } from "lucide-react";
 
 const BASE_URL = "https://claudedirectory.org";
 
@@ -141,6 +141,20 @@ export default async function PromptDetailPage(props: Props) {
             <li>Claude Code will automatically use this context</li>
           </ol>
         </div>
+
+        {prompt.repoUrl && (
+          <div>
+            <a
+              href={prompt.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {prompt.relatedItems && prompt.relatedItems.length > 0 && (
           <>

--- a/src/app/skills/[slug]/page.tsx
+++ b/src/app/skills/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { CopyButton } from "@/components/copy-button";
 import { ItemJsonLd, BreadcrumbJsonLd } from "@/components/json-ld";
 import { RelatedItems } from "@/components/related-items";
 import { skills, getSkillBySlug } from "@/data/skills";
-import { ArrowLeft, Zap, User } from "lucide-react";
+import { ArrowLeft, Zap, User, ExternalLink } from "lucide-react";
 
 const BASE_URL = "https://claudedirectory.org";
 
@@ -141,6 +141,20 @@ export default async function SkillDetailPage(props: Props) {
             <li>Use /{skill.slug} in Claude Code to invoke this skill</li>
           </ol>
         </div>
+
+        {skill.repoUrl && (
+          <div>
+            <a
+              href={skill.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View source on GitHub
+            </a>
+          </div>
+        )}
 
         {skill.relatedItems && skill.relatedItems.length > 0 && (
           <>

--- a/src/data/mcp-servers/aws.ts
+++ b/src/data/mcp-servers/aws.ts
@@ -10,6 +10,7 @@ export const awsServer: MCPServer = {
     name: "AWS Labs",
     url: "https://github.com/awslabs",
   },
+  repoUrl: "https://github.com/awslabs/mcp",
   installCommand: "npm install -g @awslabs/mcp-server-aws",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/brave-search.ts
+++ b/src/data/mcp-servers/brave-search.ts
@@ -10,6 +10,7 @@ export const braveSearchServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
   installCommand: "npm install -g @anthropic-ai/mcp-server-brave-search",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/cloudflare.ts
+++ b/src/data/mcp-servers/cloudflare.ts
@@ -10,6 +10,7 @@ export const cloudflareServer: MCPServer = {
     name: "Cloudflare",
     url: "https://github.com/cloudflare",
   },
+  repoUrl: "https://github.com/cloudflare/mcp-server-cloudflare",
   installCommand: "npm install -g @cloudflare/mcp-server-cloudflare",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/e2b.ts
+++ b/src/data/mcp-servers/e2b.ts
@@ -10,6 +10,7 @@ export const e2bServer: MCPServer = {
     name: "E2B",
     url: "https://github.com/e2b-dev",
   },
+  repoUrl: "https://github.com/e2b-dev/mcp-server",
   installCommand: "npm install -g @e2b/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/exa.ts
+++ b/src/data/mcp-servers/exa.ts
@@ -10,6 +10,7 @@ export const exaServer: MCPServer = {
     name: "Exa",
     url: "https://github.com/exa-labs",
   },
+  repoUrl: "https://github.com/exa-labs/exa-mcp-server",
   installCommand: "npm install -g exa-mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/fetch.ts
+++ b/src/data/mcp-servers/fetch.ts
@@ -10,6 +10,7 @@ export const fetchServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
   installCommand: "npm install -g @anthropic-ai/mcp-server-fetch",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/filesystem.ts
+++ b/src/data/mcp-servers/filesystem.ts
@@ -10,6 +10,7 @@ export const filesystemServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
   installCommand: "npm install -g @anthropic-ai/mcp-server-filesystem",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/firecrawl.ts
+++ b/src/data/mcp-servers/firecrawl.ts
@@ -10,6 +10,7 @@ export const firecrawlServer: MCPServer = {
     name: "Firecrawl",
     url: "https://github.com/mendableai",
   },
+  repoUrl: "https://github.com/mendableai/firecrawl-mcp-server",
   installCommand: "npm install -g firecrawl-mcp",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/git.ts
+++ b/src/data/mcp-servers/git.ts
@@ -10,6 +10,7 @@ export const gitServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
   installCommand: "npm install -g @anthropic-ai/mcp-server-git",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/github.ts
+++ b/src/data/mcp-servers/github.ts
@@ -10,6 +10,7 @@ export const githubServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
   installCommand: "npm install -g @anthropic-ai/mcp-server-github",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/google-drive.ts
+++ b/src/data/mcp-servers/google-drive.ts
@@ -10,6 +10,7 @@ export const googleDriveServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive",
   installCommand: "npm install -g @anthropic-ai/mcp-server-gdrive",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/grafana.ts
+++ b/src/data/mcp-servers/grafana.ts
@@ -10,6 +10,7 @@ export const grafanaServer: MCPServer = {
     name: "Grafana Labs",
     url: "https://github.com/grafana",
   },
+  repoUrl: "https://github.com/grafana/mcp-grafana",
   installCommand: "npm install -g @grafana/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/linear.ts
+++ b/src/data/mcp-servers/linear.ts
@@ -10,6 +10,7 @@ export const linearServer: MCPServer = {
     name: "Linear",
     url: "https://github.com/linear",
   },
+  repoUrl: "https://github.com/linear/linear-mcp-server",
   installCommand: "npm install -g @linear/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/memory.ts
+++ b/src/data/mcp-servers/memory.ts
@@ -10,6 +10,7 @@ export const memoryServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
   installCommand: "npm install -g @anthropic-ai/mcp-server-memory",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/mongodb.ts
+++ b/src/data/mcp-servers/mongodb.ts
@@ -10,6 +10,7 @@ export const mongodbServer: MCPServer = {
     name: "MongoDB",
     url: "https://github.com/mongodb",
   },
+  repoUrl: "https://github.com/mongodb-js/mongodb-mcp-server",
   installCommand: "npm install -g @mongodb-js/mcp-server-mongodb",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/notion.ts
+++ b/src/data/mcp-servers/notion.ts
@@ -10,6 +10,7 @@ export const notionServer: MCPServer = {
     name: "Notion Labs",
     url: "https://github.com/makenotion",
   },
+  repoUrl: "https://github.com/makenotion/notion-mcp-server",
   installCommand: "npm install -g @notionhq/mcp-server-notion",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/playwright.ts
+++ b/src/data/mcp-servers/playwright.ts
@@ -10,6 +10,7 @@ export const playwrightServer: MCPServer = {
     name: "Microsoft",
     url: "https://github.com/microsoft",
   },
+  repoUrl: "https://github.com/microsoft/playwright-mcp",
   installCommand: "npm install -g @playwright/mcp",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/postgres.ts
+++ b/src/data/mcp-servers/postgres.ts
@@ -9,6 +9,7 @@ export const postgresServer: MCPServer = {
   author: {
     name: "MCP Community",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
   installCommand: "npm install -g @modelcontextprotocol/server-postgres",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/puppeteer.ts
+++ b/src/data/mcp-servers/puppeteer.ts
@@ -8,6 +8,7 @@ export const puppeteerServer: MCPServer = {
   author: {
     name: "MCP Community",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer",
   installCommand: "npm install -g @anthropic-ai/mcp-server-puppeteer",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/redis.ts
+++ b/src/data/mcp-servers/redis.ts
@@ -10,6 +10,7 @@ export const redisServer: MCPServer = {
     name: "Redis",
     url: "https://github.com/redis",
   },
+  repoUrl: "https://github.com/redis/mcp-redis",
   installCommand: "npm install -g @redis/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/sentry.ts
+++ b/src/data/mcp-servers/sentry.ts
@@ -10,6 +10,7 @@ export const sentryServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sentry",
   installCommand: "npm install -g @anthropic-ai/mcp-server-sentry",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/sequential-thinking.ts
+++ b/src/data/mcp-servers/sequential-thinking.ts
@@ -10,6 +10,7 @@ export const sequentialThinkingServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
   installCommand: "npm install -g @anthropic-ai/mcp-server-sequential-thinking",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/slack.ts
+++ b/src/data/mcp-servers/slack.ts
@@ -10,6 +10,7 @@ export const slackServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
   installCommand: "npm install -g @anthropic-ai/mcp-server-slack",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/sqlite.ts
+++ b/src/data/mcp-servers/sqlite.ts
@@ -10,6 +10,7 @@ export const sqliteServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite",
   installCommand: "npm install -g @anthropic-ai/mcp-server-sqlite",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/stripe.ts
+++ b/src/data/mcp-servers/stripe.ts
@@ -10,6 +10,7 @@ export const stripeServer: MCPServer = {
     name: "Stripe Community",
     url: "https://github.com/stripe",
   },
+  repoUrl: "https://github.com/stripe/agent-toolkit",
   installCommand: "npm install -g @stripe/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/supabase.ts
+++ b/src/data/mcp-servers/supabase.ts
@@ -10,6 +10,7 @@ export const supabaseServer: MCPServer = {
     name: "Supabase Community",
     url: "https://github.com/supabase-community",
   },
+  repoUrl: "https://github.com/supabase-community/supabase-mcp",
   installCommand: "npm install -g @supabase/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/tavily.ts
+++ b/src/data/mcp-servers/tavily.ts
@@ -10,6 +10,7 @@ export const tavilyServer: MCPServer = {
     name: "Tavily",
     url: "https://github.com/tavily-ai",
   },
+  repoUrl: "https://github.com/tavily-ai/tavily-mcp",
   installCommand: "npm install -g tavily-mcp",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/time.ts
+++ b/src/data/mcp-servers/time.ts
@@ -10,6 +10,7 @@ export const timeServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/everything",
   installCommand: "npm install -g @modelcontextprotocol/server-time",
   config: `{
   "mcpServers": {

--- a/src/data/plugins/agent-sdk-dev.ts
+++ b/src/data/plugins/agent-sdk-dev.ts
@@ -10,6 +10,7 @@ export const agentSdkDevPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add agent-sdk-dev@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/ccpm.ts
+++ b/src/data/plugins/ccpm.ts
@@ -10,6 +10,7 @@ export const ccpmPlugin: Plugin = {
     name: "automazeio",
     url: "https://github.com/automazeio/ccpm",
   },
+  repoUrl: "https://github.com/automazeio/ccpm",
   installCommand: "git clone https://github.com/automazeio/ccpm.git && cd ccpm && ./install.sh",
   config: `# Claude Code PM (CCPM)
 

--- a/src/data/plugins/claude-opus-migration.ts
+++ b/src/data/plugins/claude-opus-migration.ts
@@ -10,6 +10,7 @@ export const claudeOpusMigrationPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add claude-opus-4-5-migration@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/claudekit.ts
+++ b/src/data/plugins/claudekit.ts
@@ -10,6 +10,7 @@ export const claudekitPlugin: Plugin = {
     name: "carlrannaberg",
     url: "https://github.com/carlrannaberg/claudekit",
   },
+  repoUrl: "https://github.com/carlrannaberg/claudekit",
   installCommand: "git clone https://github.com/carlrannaberg/claudekit.git && cd claudekit && ./install.sh",
   config: `# ClaudeKit Configuration
 

--- a/src/data/plugins/code-review.ts
+++ b/src/data/plugins/code-review.ts
@@ -10,6 +10,7 @@ export const codeReviewPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add code-review@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/codex-settings.ts
+++ b/src/data/plugins/codex-settings.ts
@@ -10,6 +10,7 @@ export const codexSettingsPlugin: Plugin = {
     name: "fcakyon",
     url: "https://github.com/fcakyon/claude-codex-settings",
   },
+  repoUrl: "https://github.com/fcakyon/claude-codex-settings",
   installCommand: "git clone https://github.com/fcakyon/claude-codex-settings.git ~/.claude-codex-settings && cp -r ~/.claude-codex-settings/.claude ~/",
   config: `# Claude Codex Settings
 

--- a/src/data/plugins/commit-commands.ts
+++ b/src/data/plugins/commit-commands.ts
@@ -10,6 +10,7 @@ export const commitCommandsPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add commit-commands@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/contextkit.ts
+++ b/src/data/plugins/contextkit.ts
@@ -10,6 +10,7 @@ export const contextkitPlugin: Plugin = {
     name: "FlineDev",
     url: "https://github.com/FlineDev/ContextKit",
   },
+  repoUrl: "https://github.com/FlineDev/ContextKit",
   installCommand: "git clone https://github.com/FlineDev/ContextKit.git && cd ContextKit && ./install.sh",
   config: `# ContextKit
 

--- a/src/data/plugins/explanatory-output.ts
+++ b/src/data/plugins/explanatory-output.ts
@@ -10,6 +10,7 @@ export const explanatoryOutputPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add explanatory-output-style@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -10,6 +10,7 @@ export const frontendDesignPlugin: Plugin = {
     name: "Claude Code Plugins",
     url: "https://github.com/anthropics/claude-code-plugins",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add frontend-design@claude-code-plugins",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/hookify.ts
+++ b/src/data/plugins/hookify.ts
@@ -10,6 +10,7 @@ export const hookifyPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add hookify@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/plugin-dev.ts
+++ b/src/data/plugins/plugin-dev.ts
@@ -10,6 +10,7 @@ export const pluginDevPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add plugin-dev@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/pr-review-toolkit.ts
+++ b/src/data/plugins/pr-review-toolkit.ts
@@ -10,6 +10,7 @@ export const prReviewToolkitPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add pr-review-toolkit@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/security-guidance.ts
+++ b/src/data/plugins/security-guidance.ts
@@ -10,6 +10,7 @@ export const securityGuidancePlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add security-guidance@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/superclaude.ts
+++ b/src/data/plugins/superclaude.ts
@@ -10,6 +10,7 @@ export const superclaudePlugin: Plugin = {
     name: "SuperClaude-Org",
     url: "https://github.com/SuperClaude-Org/SuperClaude_Framework",
   },
+  repoUrl: "https://github.com/SuperClaude-Org/SuperClaude_Framework",
   installCommand: "git clone https://github.com/SuperClaude-Org/SuperClaude_Framework.git && cd SuperClaude_Framework && ./setup.sh",
   config: `# SuperClaude Framework Configuration
 

--- a/src/data/plugins/swift-lsp.ts
+++ b/src/data/plugins/swift-lsp.ts
@@ -10,6 +10,7 @@ export const swiftLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
+  repoUrl: "https://github.com/anthropics/claude-code-plugins",
   installCommand: "claude plugins add swift-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,7 @@ export interface Prompt {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export interface MCPServer {
@@ -41,6 +42,7 @@ export interface MCPServer {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export interface Hook {
@@ -54,6 +56,7 @@ export interface Hook {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export interface Skill {
@@ -65,6 +68,7 @@ export interface Skill {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export interface Plugin {
@@ -92,6 +96,7 @@ export interface HowTo {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export interface Agent {
@@ -104,6 +109,7 @@ export interface Agent {
   author: Author;
   featured?: boolean;
   relatedItems?: RelatedItem[];
+  repoUrl?: string;
 }
 
 export type ContentItem = Prompt | MCPServer | Hook | Skill | Plugin | HowTo | Agent;


### PR DESCRIPTION
  1. Type Updates (src/lib/types.ts)

  Added repoUrl?: string field to all content types:
  - Prompt
  - MCPServer
  - Hook
  - Skill
  - HowTo
  - Agent
  - (Plugin already had it)

  2. UI Updates (6 detail pages)

  Added "View source on GitHub" link with ExternalLink icon to:
  - src/app/mcp-servers/[slug]/page.tsx
  - src/app/skills/[slug]/page.tsx
  - src/app/prompts/[slug]/page.tsx
  - src/app/hooks/[slug]/page.tsx
  - src/app/agents/[slug]/page.tsx
  - src/app/how-to/[slug]/page.tsx

  3. Data Populated

  MCP Servers (28 servers now have repoUrls):
  - Official servers link to github.com/modelcontextprotocol/servers
  - Third-party servers link to their respective repos (MongoDB, Notion, Stripe, etc.)

  Plugins (all 30 now have repoUrls):
  - Official Anthropic plugins link to github.com/anthropics/claude-code-plugins
  - Community plugins link to their respective GitHub repos

  The build passes successfully. Each detail page will now show a "View source on GitHub" link when a repoUrl is provided for that item.