### PR TITLE
Add commands to all plugins and add 18 new marketplace plugins

### DIFF
--- a/src/data/plugins/asana.ts
+++ b/src/data/plugins/asana.ts
@@ -17,4 +17,13 @@ export const asanaPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/asana",
+  commands: [
+    { name: "/asana-task", description: "Create, view, or update Asana tasks" },
+    { name: "/asana-project", description: "Manage projects and sections" },
+    { name: "/asana-search", description: "Search tasks across workspaces" },
+    { name: "/asana-assign", description: "Assign tasks and set due dates" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "asana", relationship: "requires" },
+  ],
 };

--- a/src/data/plugins/aws.ts
+++ b/src/data/plugins/aws.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const awsPlugin: Plugin = {
+  slug: "aws",
+  title: "AWS",
+  description: "Amazon Web Services integration. Manage S3, Lambda, DynamoDB, EC2, and other AWS services. Deploy serverless functions, manage infrastructure, and query databases.",
+  tags: ["aws", "cloud", "serverless", "infrastructure", "official"],
+  featured: false,
+  author: {
+    name: "Amazon",
+    url: "https://aws.amazon.com",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/aws",
+  installCommand: "claude plugins add aws@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "aws@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/aws-deploy", description: "Deploy to AWS Lambda or other services" },
+    { name: "/s3", description: "Manage S3 buckets and objects" },
+    { name: "/dynamodb", description: "Query and manage DynamoDB tables" },
+    { name: "/cloudwatch", description: "View CloudWatch logs and metrics" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "aws", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/chrome-devtools.ts
+++ b/src/data/plugins/chrome-devtools.ts
@@ -1,0 +1,30 @@
+import { Plugin } from "@/lib/types";
+
+export const chromeDevtoolsPlugin: Plugin = {
+  slug: "chrome-devtools",
+  title: "Chrome DevTools",
+  description: "Chrome browser testing and performance analysis using Chrome DevTools Protocol (CDP). 27 professional-grade tools for web testing, performance measurement, accessibility validation, and browser automation.",
+  tags: ["testing", "browser", "performance", "accessibility", "official"],
+  featured: true,
+  author: {
+    name: "Google",
+    url: "https://developer.chrome.com/docs/devtools",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/chrome-devtools",
+  installCommand: "claude plugins add chrome-devtools@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "chrome-devtools@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/lighthouse", description: "Run Lighthouse performance audit" },
+    { name: "/a11y", description: "Run accessibility audit on page" },
+    { name: "/perf", description: "Capture and analyze performance trace" },
+    { name: "/network", description: "Analyze network requests and waterfall" },
+    { name: "/console", description: "Capture and analyze console output" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "playwright", relationship: "works-with" },
+  ],
+};

--- a/src/data/plugins/clangd-lsp.ts
+++ b/src/data/plugins/clangd-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const clangdLspPlugin: Plugin = {
+  slug: "clangd-lsp",
+  title: "C/C++ LSP (clangd)",
+  description: "C and C++ language server with header resolution and memory safety hints. LLVM-based tooling with intelligent completions, diagnostics, and code navigation.",
+  tags: ["c", "cpp", "lsp", "llvm", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/clangd-lsp",
+  installCommand: "claude plugins add clangd-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/clang-check", description: "Run clang static analyzer" },
+    { name: "/clang-format", description: "Format C/C++ code" },
+    { name: "/cmake", description: "Generate and manage CMake builds" },
+  ],
+};

--- a/src/data/plugins/code-review.ts
+++ b/src/data/plugins/code-review.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const codeReviewPlugin: Plugin = {
   slug: "code-review",
   title: "Code Review",
-  description: "Automated code review for pull requests with detailed feedback and suggestions",
-  tags: ["code-review", "pr", "quality", "official"],
+  description: "Multi-agent code review system with confidence-based filtering. Provides comprehensive PR analysis across security, performance, maintainability, and correctness dimensions with intelligent prioritization of high-impact issues.",
+  tags: ["code-review", "pr", "quality", "official", "agents"],
   featured: true,
   author: {
     name: "Anthropic",
@@ -17,4 +17,13 @@ export const codeReviewPlugin: Plugin = {
     "code-review@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/code-review", description: "Launch comprehensive code review on current changes or specified PR" },
+    { name: "/review", description: "Quick review of staged changes with confidence scoring" },
+    { name: "/review-file", description: "Deep review of a specific file" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "pr-review-toolkit", relationship: "works-with" },
+    { type: "how-to", slug: "plugins", relationship: "documented-by" },
+  ],
 };

--- a/src/data/plugins/commit-commands.ts
+++ b/src/data/plugins/commit-commands.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const commitCommandsPlugin: Plugin = {
   slug: "commit-commands",
   title: "Git Commit Commands",
-  description: "Git workflow automation with /commit, /commit-push-pr, and /clean_gone commands for streamlined version control",
+  description: "Git workflow automation with intelligent commit message generation, branch management, and PR creation. Follows conventional commits and analyzes changes to generate meaningful commit messages automatically.",
   tags: ["git", "workflow", "automation", "vcs", "official"],
   featured: true,
   author: {
@@ -17,4 +17,15 @@ export const commitCommandsPlugin: Plugin = {
     "commit-commands@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/commit", description: "Stage changes and create commit with AI-generated message" },
+    { name: "/commit-push-pr", description: "Commit, push, and create a pull request in one command" },
+    { name: "/clean_gone", description: "Clean up local branches that no longer exist on remote" },
+    { name: "/amend", description: "Amend the last commit with new changes" },
+    { name: "/stash", description: "Intelligently stash changes with descriptive names" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "github", relationship: "works-with" },
+    { type: "how-to", slug: "plugins", relationship: "documented-by" },
+  ],
 };

--- a/src/data/plugins/context7.ts
+++ b/src/data/plugins/context7.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const context7Plugin: Plugin = {
   slug: "context7",
   title: "Context7",
-  description: "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
+  description: "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context. Never work with outdated docs again.",
   tags: ["documentation", "context", "upstash", "official"],
   featured: false,
   author: {
@@ -17,4 +17,12 @@ export const context7Plugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/context7",
+  commands: [
+    { name: "/docs", description: "Fetch current documentation for a library or framework" },
+    { name: "/context7", description: "Pull context from Context7 sources" },
+    { name: "/api-ref", description: "Get API reference for specific functions or methods" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "context7", relationship: "requires" },
+  ],
 };

--- a/src/data/plugins/csharp-lsp.ts
+++ b/src/data/plugins/csharp-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const csharpLspPlugin: Plugin = {
+  slug: "csharp-lsp",
+  title: "C# LSP (OmniSharp)",
+  description: "C# language server with NuGet package awareness and .NET targeting. Full IntelliSense, refactoring, and debugging support for .NET development.",
+  tags: ["csharp", "dotnet", "lsp", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/csharp-lsp",
+  installCommand: "claude plugins add csharp-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "csharp-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/dotnet-build", description: "Build .NET solution or project" },
+    { name: "/dotnet-test", description: "Run .NET tests" },
+    { name: "/nuget", description: "Manage NuGet packages" },
+  ],
+};

--- a/src/data/plugins/datadog.ts
+++ b/src/data/plugins/datadog.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const datadogPlugin: Plugin = {
+  slug: "datadog",
+  title: "Datadog",
+  description: "Datadog observability platform integration. Query metrics, view logs, analyze traces, and monitor application performance directly from Claude Code.",
+  tags: ["monitoring", "observability", "apm", "logs", "official"],
+  featured: false,
+  author: {
+    name: "Datadog",
+    url: "https://datadoghq.com",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/datadog",
+  installCommand: "claude plugins add datadog@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "datadog@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/dd-metrics", description: "Query and visualize metrics" },
+    { name: "/dd-logs", description: "Search and analyze logs" },
+    { name: "/dd-traces", description: "View APM traces" },
+    { name: "/dd-alerts", description: "Check active alerts and monitors" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "datadog", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/docker.ts
+++ b/src/data/plugins/docker.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const dockerPlugin: Plugin = {
+  slug: "docker",
+  title: "Docker",
+  description: "Docker container management and orchestration. Build images, manage containers, work with Docker Compose, and handle container networking directly from Claude Code.",
+  tags: ["docker", "containers", "devops", "official"],
+  featured: false,
+  author: {
+    name: "Docker",
+    url: "https://docker.com",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/docker",
+  installCommand: "claude plugins add docker@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "docker@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/docker-build", description: "Build Docker image from Dockerfile" },
+    { name: "/docker-compose", description: "Manage Docker Compose services" },
+    { name: "/docker-run", description: "Run container with configuration" },
+    { name: "/docker-logs", description: "View container logs" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "docker", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/figma.ts
+++ b/src/data/plugins/figma.ts
@@ -1,0 +1,30 @@
+import { Plugin } from "@/lib/types";
+
+export const figmaPlugin: Plugin = {
+  slug: "figma",
+  title: "Figma",
+  description: "Figma design tool integration. Extract design specs, generate code from designs, access component libraries, and bridge the gap between design and development.",
+  tags: ["design", "ui", "collaboration", "official"],
+  featured: false,
+  author: {
+    name: "Figma",
+    url: "https://figma.com",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/figma",
+  installCommand: "claude plugins add figma@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "figma@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/figma-inspect", description: "Extract design specs from Figma file" },
+    { name: "/figma-code", description: "Generate code from Figma component" },
+    { name: "/figma-tokens", description: "Export design tokens" },
+    { name: "/figma-assets", description: "Download assets from Figma" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "frontend-design", relationship: "works-with" },
+    { type: "mcp-server", slug: "figma", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/firebase.ts
+++ b/src/data/plugins/firebase.ts
@@ -17,4 +17,13 @@ export const firebasePlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/firebase",
+  commands: [
+    { name: "/firebase-query", description: "Query Firestore collections and documents" },
+    { name: "/firebase-deploy", description: "Deploy to Firebase Hosting or Functions" },
+    { name: "/firebase-auth", description: "Manage Firebase Authentication users" },
+    { name: "/firebase-rules", description: "Edit and deploy security rules" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "firebase", relationship: "requires" },
+  ],
 };

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const frontendDesignPlugin: Plugin = {
   slug: "frontend-design",
   title: "Frontend Design",
-  description: "Create distinctive, production-grade frontend interfaces with high design quality",
-  tags: ["frontend", "design", "ui", "community"],
+  description: "Create distinctive, production-grade frontend interfaces with high design quality. UI/UX specialist plugin that generates polished, creative code avoiding generic AI aesthetics. Supports React, Vue, Svelte, and vanilla HTML/CSS with modern design patterns.",
+  tags: ["frontend", "design", "ui", "ux", "react", "official"],
   featured: true,
   author: {
     name: "Claude Code Plugins",
@@ -17,4 +17,13 @@ export const frontendDesignPlugin: Plugin = {
     "frontend-design@claude-code-plugins": true
   }
 }`,
+  commands: [
+    { name: "/frontend-design", description: "Launch guided frontend design workflow for components and pages" },
+    { name: "/design", description: "Quick design mode for UI components" },
+    { name: "/ui", description: "Generate UI component with design system awareness" },
+    { name: "/layout", description: "Create responsive layouts and page structures" },
+  ],
+  relatedItems: [
+    { type: "how-to", slug: "plugins", relationship: "documented-by" },
+  ],
 };

--- a/src/data/plugins/github.ts
+++ b/src/data/plugins/github.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const githubPlugin: Plugin = {
   slug: "github",
   title: "GitHub",
-  description: "GitHub repository management. Create issues, manage pull requests, review code, search repositories, and interact with GitHub's full API directly from Claude Code.",
+  description: "GitHub repository management. Create issues, manage pull requests, review code, search repositories, and interact with GitHub's full API directly from Claude Code. Includes workflow automation and Actions integration.",
   tags: ["git", "version-control", "integration", "official"],
   featured: true,
   author: {
@@ -17,7 +17,14 @@ export const githubPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/github",
+  commands: [
+    { name: "/gh-issue", description: "Create, view, or update GitHub issues" },
+    { name: "/gh-pr", description: "Create, review, or merge pull requests" },
+    { name: "/gh-actions", description: "View and manage GitHub Actions workflows" },
+    { name: "/gh-search", description: "Search repositories, code, and issues" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "github" },
+    { type: "mcp-server", slug: "github", relationship: "requires" },
+    { type: "plugin", slug: "commit-commands", relationship: "works-with" },
   ],
 };

--- a/src/data/plugins/gitlab.ts
+++ b/src/data/plugins/gitlab.ts
@@ -17,4 +17,13 @@ export const gitlabPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/gitlab",
+  commands: [
+    { name: "/gl-mr", description: "Create, review, or merge GitLab merge requests" },
+    { name: "/gl-pipeline", description: "View and manage CI/CD pipelines" },
+    { name: "/gl-issue", description: "Create and manage GitLab issues" },
+    { name: "/gl-search", description: "Search across projects and code" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "gitlab", relationship: "requires" },
+  ],
 };

--- a/src/data/plugins/gopls-lsp.ts
+++ b/src/data/plugins/gopls-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const goplsLspPlugin: Plugin = {
+  slug: "gopls-lsp",
+  title: "Go LSP (gopls)",
+  description: "Go language server with module resolution and interface checks. Real-time diagnostics, code navigation, and refactoring support for Go development.",
+  tags: ["go", "golang", "lsp", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/gopls-lsp",
+  installCommand: "claude plugins add gopls-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "gopls-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/go-check", description: "Run go vet and staticcheck" },
+    { name: "/go-mod", description: "Manage Go modules and dependencies" },
+    { name: "/go-test", description: "Run Go tests with coverage" },
+  ],
+};

--- a/src/data/plugins/greptile.ts
+++ b/src/data/plugins/greptile.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const greptilePlugin: Plugin = {
   slug: "greptile",
   title: "Greptile",
-  description: "AI code review agent for GitHub and GitLab. View and resolve Greptile's PR review comments directly from Claude Code with intelligent code analysis and suggestions.",
-  tags: ["code-review", "ai", "github", "gitlab", "official"],
+  description: "AI code review agent for GitHub and GitLab. View and resolve Greptile's PR review comments directly from Claude Code. Natural language codebase search and intelligent code analysis.",
+  tags: ["code-review", "ai", "github", "gitlab", "official", "search"],
   featured: false,
   author: {
     name: "Greptile",
@@ -17,4 +17,12 @@ export const greptilePlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/greptile",
+  commands: [
+    { name: "/greptile-search", description: "Natural language search across your codebase" },
+    { name: "/greptile-review", description: "Get AI review of current changes" },
+    { name: "/greptile-ask", description: "Ask questions about your codebase" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "code-review", relationship: "works-with" },
+  ],
 };

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -27,20 +27,39 @@ import { superclaudePlugin } from "./superclaude";
 import { swiftLspPlugin } from "./swift-lsp";
 import { testWriterPlugin } from "./test-writer";
 import { ultrathinkPlugin } from "./ultrathink";
+// LSP plugins
+import { typescriptLspPlugin } from "./typescript-lsp";
+import { pyrightLspPlugin } from "./pyright-lsp";
+import { rustAnalyzerLspPlugin } from "./rust-analyzer-lsp";
+import { goplsLspPlugin } from "./gopls-lsp";
+import { jdtlsLspPlugin } from "./jdtls-lsp";
+import { csharpLspPlugin } from "./csharp-lsp";
+import { phpLspPlugin } from "./php-lsp";
+import { clangdLspPlugin } from "./clangd-lsp";
 // External plugins (official integrations)
 import { asanaPlugin } from "./asana";
+import { awsPlugin } from "./aws";
+import { chromeDevtoolsPlugin } from "./chrome-devtools";
 import { context7Plugin } from "./context7";
+import { datadogPlugin } from "./datadog";
+import { dockerPlugin } from "./docker";
+import { figmaPlugin } from "./figma";
 import { firebasePlugin } from "./firebase";
 import { githubPlugin } from "./github";
 import { gitlabPlugin } from "./gitlab";
 import { greptilePlugin } from "./greptile";
+import { jiraPlugin } from "./jira";
 import { laravelBoostPlugin } from "./laravel-boost";
 import { linearPlugin } from "./linear";
+import { notionPlugin } from "./notion";
 import { playwrightPlugin } from "./playwright";
+import { prismaPlugin } from "./prisma";
+import { sentryPlugin } from "./sentry";
 import { serenaPlugin } from "./serena";
 import { slackPlugin } from "./slack";
 import { stripePlugin } from "./stripe";
 import { supabasePlugin } from "./supabase";
+import { vercelPlugin } from "./vercel";
 
 export const plugins: Plugin[] = [
   // Featured plugins first
@@ -58,13 +77,25 @@ export const plugins: Plugin[] = [
   linearPlugin,
   supabasePlugin,
   playwrightPlugin,
-  // Non-featured plugins
+  vercelPlugin,
+  chromeDevtoolsPlugin,
+  // LSP plugins
+  typescriptLspPlugin,
+  pyrightLspPlugin,
+  rustAnalyzerLspPlugin,
+  goplsLspPlugin,
+  jdtlsLspPlugin,
+  csharpLspPlugin,
+  phpLspPlugin,
+  clangdLspPlugin,
   swiftLspPlugin,
+  // Non-featured plugins
   claudekitPlugin,
   superclaudePlugin,
   codexSettingsPlugin,
   ccpmPlugin,
   contextkitPlugin,
+  prReviewToolkitPlugin,
   // Community plugins
   ultrathinkPlugin,
   bugDetectivePlugin,
@@ -76,11 +107,19 @@ export const plugins: Plugin[] = [
   deploymentEngineerPlugin,
   // External plugins
   asanaPlugin,
+  awsPlugin,
   context7Plugin,
+  datadogPlugin,
+  dockerPlugin,
+  figmaPlugin,
   firebasePlugin,
   gitlabPlugin,
   greptilePlugin,
+  jiraPlugin,
   laravelBoostPlugin,
+  notionPlugin,
+  prismaPlugin,
+  sentryPlugin,
   serenaPlugin,
   slackPlugin,
   stripePlugin,

--- a/src/data/plugins/jdtls-lsp.ts
+++ b/src/data/plugins/jdtls-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const jdtlsLspPlugin: Plugin = {
+  slug: "jdtls-lsp",
+  title: "Java LSP (jdtls)",
+  description: "Java language server with Maven and Gradle dependency resolution. Eclipse JDT-based tooling with intelligent code completion, refactoring, and project management.",
+  tags: ["java", "lsp", "maven", "gradle", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/jdtls-lsp",
+  installCommand: "claude plugins add jdtls-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "jdtls-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/java-build", description: "Build Java project with Maven or Gradle" },
+    { name: "/java-test", description: "Run JUnit tests" },
+    { name: "/java-deps", description: "Manage project dependencies" },
+  ],
+};

--- a/src/data/plugins/jira.ts
+++ b/src/data/plugins/jira.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const jiraPlugin: Plugin = {
+  slug: "jira",
+  title: "Jira",
+  description: "Atlassian Jira integration for issue tracking and project management. Create issues, update tickets, search across projects, and link commits to Jira tickets.",
+  tags: ["issue-tracking", "project-management", "atlassian", "official"],
+  featured: false,
+  author: {
+    name: "Atlassian",
+    url: "https://www.atlassian.com/software/jira",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/jira",
+  installCommand: "claude plugins add jira@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "jira@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/jira-issue", description: "Create, view, or update Jira issues" },
+    { name: "/jira-search", description: "Search issues with JQL" },
+    { name: "/jira-sprint", description: "View sprint progress and backlog" },
+    { name: "/jira-link", description: "Link commits and PRs to issues" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "jira", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/laravel-boost.ts
+++ b/src/data/plugins/laravel-boost.ts
@@ -17,4 +17,10 @@ export const laravelBoostPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/laravel-boost",
+  commands: [
+    { name: "/artisan", description: "Run Laravel Artisan commands" },
+    { name: "/eloquent", description: "Generate Eloquent models and relationships" },
+    { name: "/migrate", description: "Create and run database migrations" },
+    { name: "/route", description: "Generate routes and controllers" },
+  ],
 };

--- a/src/data/plugins/linear.ts
+++ b/src/data/plugins/linear.ts
@@ -17,7 +17,13 @@ export const linearPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/linear",
+  commands: [
+    { name: "/linear-issue", description: "Create, view, or update Linear issues" },
+    { name: "/linear-project", description: "Manage Linear projects and cycles" },
+    { name: "/linear-search", description: "Search across issues and projects" },
+    { name: "/linear-status", description: "Update issue status and assignments" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "linear" },
+    { type: "mcp-server", slug: "linear", relationship: "requires" },
   ],
 };

--- a/src/data/plugins/notion.ts
+++ b/src/data/plugins/notion.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const notionPlugin: Plugin = {
+  slug: "notion",
+  title: "Notion",
+  description: "Notion workspace integration. Search pages, create and update content, manage databases, and sync documentation with your development workflow.",
+  tags: ["documentation", "notes", "wiki", "integration", "official"],
+  featured: false,
+  author: {
+    name: "Notion",
+    url: "https://notion.so",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/notion",
+  installCommand: "claude plugins add notion@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "notion@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/notion-search", description: "Search across Notion workspace" },
+    { name: "/notion-create", description: "Create new page or database entry" },
+    { name: "/notion-update", description: "Update existing page content" },
+    { name: "/notion-sync", description: "Sync documentation with codebase" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "notion", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/php-lsp.ts
+++ b/src/data/plugins/php-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const phpLspPlugin: Plugin = {
+  slug: "php-lsp",
+  title: "PHP LSP (Intelephense)",
+  description: "PHP language server with Composer autoloading and namespace resolution. Intelligent code completion, diagnostics, and refactoring for PHP development.",
+  tags: ["php", "lsp", "composer", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/php-lsp",
+  installCommand: "claude plugins add php-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "php-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/php-check", description: "Run PHP static analysis" },
+    { name: "/composer", description: "Manage Composer dependencies" },
+    { name: "/phpunit", description: "Run PHPUnit tests" },
+  ],
+};

--- a/src/data/plugins/playwright.ts
+++ b/src/data/plugins/playwright.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const playwrightPlugin: Plugin = {
   slug: "playwright",
   title: "Playwright",
-  description: "Browser automation and end-to-end testing by Microsoft. Enables Claude to interact with web pages, take screenshots, fill forms, click elements, and perform automated browser testing workflows.",
+  description: "Browser automation and end-to-end testing by Microsoft. Enables Claude to interact with web pages, take screenshots, fill forms, click elements, and perform automated browser testing workflows across Chromium, Firefox, and WebKit.",
   tags: ["testing", "automation", "browser", "e2e", "official"],
   featured: true,
   author: {
@@ -17,7 +17,14 @@ export const playwrightPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/playwright",
+  commands: [
+    { name: "/playwright-test", description: "Run Playwright tests or create new test files" },
+    { name: "/playwright-screenshot", description: "Take screenshots of web pages" },
+    { name: "/playwright-trace", description: "Record and analyze test traces" },
+    { name: "/playwright-codegen", description: "Generate test code from browser interactions" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "playwright" },
+    { type: "mcp-server", slug: "playwright", relationship: "requires" },
+    { type: "plugin", slug: "test-writer", relationship: "works-with" },
   ],
 };

--- a/src/data/plugins/plugin-dev.ts
+++ b/src/data/plugins/plugin-dev.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const pluginDevPlugin: Plugin = {
   slug: "plugin-dev",
   title: "Plugin Development Kit",
-  description: "Comprehensive toolkit for developing Claude Code plugins with 8-phase guided workflow and 7 expert skills",
+  description: "Comprehensive toolkit for developing Claude Code plugins with 8-phase guided workflow and 7 expert skills. Includes plugin scaffolding, manifest validation, testing tools, and publishing assistance for creating production-ready plugins.",
   tags: ["plugin", "development", "sdk", "tools", "official"],
   featured: true,
   author: {
@@ -17,4 +17,14 @@ export const pluginDevPlugin: Plugin = {
     "plugin-dev@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/plugin-dev", description: "Launch 8-phase guided plugin development workflow" },
+    { name: "/plugin-init", description: "Scaffold a new plugin project with boilerplate" },
+    { name: "/plugin-test", description: "Run plugin tests and validation" },
+    { name: "/plugin-validate", description: "Validate plugin manifest and configuration" },
+    { name: "/plugin-publish", description: "Prepare plugin for marketplace publishing" },
+  ],
+  relatedItems: [
+    { type: "how-to", slug: "plugins", relationship: "documented-by" },
+  ],
 };

--- a/src/data/plugins/pr-review-toolkit.ts
+++ b/src/data/plugins/pr-review-toolkit.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const prReviewToolkitPlugin: Plugin = {
   slug: "pr-review-toolkit",
   title: "PR Review Toolkit",
-  description: "Specialized PR review agents for comprehensive code quality analysis covering comments, tests, errors, types, and quality",
+  description: "Specialized PR review agents for comprehensive code quality analysis. Six-dimensional review covering comments, tests, errors, types, quality, and security. Multi-agent approach for thorough analysis.",
   tags: ["code-review", "pr", "quality", "agents", "official"],
   featured: false,
   author: {
@@ -17,4 +17,14 @@ export const prReviewToolkitPlugin: Plugin = {
     "pr-review-toolkit@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/pr-review", description: "Full six-dimensional PR review" },
+    { name: "/pr-comments", description: "Review PR for comment quality and documentation" },
+    { name: "/pr-tests", description: "Analyze test coverage and quality in PR" },
+    { name: "/pr-types", description: "Check type safety and type coverage" },
+    { name: "/pr-security", description: "Security-focused PR review" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "code-review", relationship: "works-with" },
+  ],
 };

--- a/src/data/plugins/prisma.ts
+++ b/src/data/plugins/prisma.ts
@@ -1,0 +1,26 @@
+import { Plugin } from "@/lib/types";
+
+export const prismaPlugin: Plugin = {
+  slug: "prisma",
+  title: "Prisma",
+  description: "Prisma ORM integration for database management. Generate schemas, run migrations, explore data with Prisma Studio, and manage database workflows.",
+  tags: ["database", "orm", "typescript", "official"],
+  featured: false,
+  author: {
+    name: "Prisma",
+    url: "https://prisma.io",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/prisma",
+  installCommand: "claude plugins add prisma@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "prisma@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/prisma-migrate", description: "Create and run database migrations" },
+    { name: "/prisma-generate", description: "Generate Prisma client" },
+    { name: "/prisma-studio", description: "Open Prisma Studio for data exploration" },
+    { name: "/prisma-seed", description: "Seed database with data" },
+  ],
+};

--- a/src/data/plugins/pyright-lsp.ts
+++ b/src/data/plugins/pyright-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const pyrightLspPlugin: Plugin = {
+  slug: "pyright-lsp",
+  title: "Pyright LSP",
+  description: "Python type inference and environment awareness via Pyright. Static type checking, intelligent completions, and type stub support for Python development.",
+  tags: ["python", "lsp", "typing", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/pyright-lsp",
+  installCommand: "claude plugins add pyright-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/py-check", description: "Run Pyright type checker on Python files" },
+    { name: "/py-types", description: "Show type information for symbol" },
+    { name: "/py-stub", description: "Generate type stubs for module" },
+  ],
+};

--- a/src/data/plugins/rust-analyzer-lsp.ts
+++ b/src/data/plugins/rust-analyzer-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const rustAnalyzerLspPlugin: Plugin = {
+  slug: "rust-analyzer-lsp",
+  title: "Rust Analyzer LSP",
+  description: "Rust language server with borrow checker feedback and lifetime analysis. Real-time error detection, macro expansion, and intelligent code completion for Rust development.",
+  tags: ["rust", "lsp", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/rust-analyzer-lsp",
+  installCommand: "claude plugins add rust-analyzer-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/rust-check", description: "Run cargo check with enhanced diagnostics" },
+    { name: "/rust-expand", description: "Expand Rust macros" },
+    { name: "/rust-clippy", description: "Run Clippy lints" },
+  ],
+};

--- a/src/data/plugins/security-guidance.ts
+++ b/src/data/plugins/security-guidance.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const securityGuidancePlugin: Plugin = {
   slug: "security-guidance",
   title: "Security Guidance",
-  description: "Automatic security issue detection during file editing with monitoring for 9 common vulnerability patterns",
-  tags: ["security", "vulnerability", "analysis", "hooks", "official"],
+  description: "Real-time security linter detecting injection vulnerabilities, authentication flaws, and OWASP Top 10 issues. Monitors 9 common vulnerability patterns including SQL injection, XSS, CSRF, and insecure deserialization during file editing.",
+  tags: ["security", "vulnerability", "analysis", "hooks", "official", "owasp"],
   featured: true,
   author: {
     name: "Anthropic",
@@ -17,4 +17,14 @@ export const securityGuidancePlugin: Plugin = {
     "security-guidance@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/security-scan", description: "Run full security scan on codebase or specific files" },
+    { name: "/audit", description: "Security audit with OWASP Top 10 checklist" },
+    { name: "/secrets-check", description: "Scan for hardcoded secrets and credentials" },
+    { name: "/dependency-audit", description: "Check dependencies for known vulnerabilities" },
+  ],
+  relatedItems: [
+    { type: "agent", slug: "security-agent", relationship: "works-with" },
+    { type: "how-to", slug: "plugins", relationship: "documented-by" },
+  ],
 };

--- a/src/data/plugins/sentry.ts
+++ b/src/data/plugins/sentry.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const sentryPlugin: Plugin = {
+  slug: "sentry",
+  title: "Sentry",
+  description: "Sentry error monitoring integration. Track errors, view stack traces, analyze crash reports, and get real-time alerts for application issues.",
+  tags: ["monitoring", "errors", "debugging", "observability", "official"],
+  featured: false,
+  author: {
+    name: "Sentry",
+    url: "https://sentry.io",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/sentry",
+  installCommand: "claude plugins add sentry@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "sentry@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/sentry-issues", description: "View recent errors and issues" },
+    { name: "/sentry-trace", description: "Analyze error stack trace" },
+    { name: "/sentry-fix", description: "Get fix suggestions for an error" },
+    { name: "/sentry-release", description: "Manage Sentry releases" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "sentry", relationship: "requires" },
+  ],
+};

--- a/src/data/plugins/serena.ts
+++ b/src/data/plugins/serena.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const serenaPlugin: Plugin = {
   slug: "serena",
   title: "Serena",
-  description: "Semantic code analysis MCP server. Intelligent code understanding, refactoring suggestions, and codebase navigation through language server protocol integration.",
-  tags: ["code-analysis", "refactoring", "lsp", "official"],
+  description: "Semantic code analysis beyond syntax. Intelligent code understanding, refactoring suggestions, and codebase navigation through deep language analysis. Understands code meaning, not just structure.",
+  tags: ["code-analysis", "refactoring", "semantic", "official"],
   featured: false,
   author: {
     name: "Oraios",
@@ -17,4 +17,9 @@ export const serenaPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/serena",
+  commands: [
+    { name: "/serena-analyze", description: "Deep semantic analysis of code" },
+    { name: "/serena-refactor", description: "Get intelligent refactoring suggestions" },
+    { name: "/serena-explain", description: "Explain what code does semantically" },
+  ],
 };

--- a/src/data/plugins/slack.ts
+++ b/src/data/plugins/slack.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const slackPlugin: Plugin = {
   slug: "slack",
   title: "Slack",
-  description: "Slack workspace integration. Search messages, access channels, read threads, and stay connected with your team's communications while coding.",
+  description: "Slack workspace integration. Search messages, access channels, read threads, and stay connected with your team's communications while coding. Get context from discussions without leaving your terminal.",
   tags: ["communication", "messaging", "team", "integration", "official"],
   featured: false,
   author: {
@@ -17,7 +17,13 @@ export const slackPlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/slack",
+  commands: [
+    { name: "/slack-search", description: "Search messages across channels and threads" },
+    { name: "/slack-channel", description: "Read recent messages from a channel" },
+    { name: "/slack-thread", description: "Get full context from a thread" },
+    { name: "/slack-send", description: "Send a message to a channel or user" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "slack" },
+    { type: "mcp-server", slug: "slack", relationship: "requires" },
   ],
 };

--- a/src/data/plugins/stripe.ts
+++ b/src/data/plugins/stripe.ts
@@ -3,7 +3,7 @@ import { Plugin } from "@/lib/types";
 export const stripePlugin: Plugin = {
   slug: "stripe",
   title: "Stripe",
-  description: "Stripe development plugin. Manage payments, webhooks, and integrate Stripe's API functionality including subscriptions, invoices, and security features directly from Claude Code.",
+  description: "Stripe development plugin. Manage payments, webhooks, and integrate Stripe's API functionality including subscriptions, invoices, customers, and security features directly from Claude Code.",
   tags: ["payments", "fintech", "api", "integration", "official"],
   featured: false,
   author: {
@@ -17,7 +17,13 @@ export const stripePlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/stripe",
+  commands: [
+    { name: "/stripe-test", description: "Test Stripe integration with test mode" },
+    { name: "/stripe-webhook", description: "Set up and verify webhook handlers" },
+    { name: "/stripe-products", description: "Manage products and prices" },
+    { name: "/stripe-customers", description: "View and manage customer data" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "stripe" },
+    { type: "mcp-server", slug: "stripe", relationship: "requires" },
   ],
 };

--- a/src/data/plugins/supabase.ts
+++ b/src/data/plugins/supabase.ts
@@ -17,7 +17,14 @@ export const supabasePlugin: Plugin = {
   }
 }`,
   repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/supabase",
+  commands: [
+    { name: "/supabase-query", description: "Execute SQL queries on your Supabase database" },
+    { name: "/supabase-migrate", description: "Create and run database migrations" },
+    { name: "/supabase-auth", description: "Manage authentication and users" },
+    { name: "/supabase-storage", description: "Manage file storage buckets" },
+    { name: "/supabase-functions", description: "Deploy and manage edge functions" },
+  ],
   relatedItems: [
-    { type: "mcp-server", slug: "supabase" },
+    { type: "mcp-server", slug: "supabase", relationship: "requires" },
   ],
 };

--- a/src/data/plugins/superclaude.ts
+++ b/src/data/plugins/superclaude.ts
@@ -3,9 +3,9 @@ import { Plugin } from "@/lib/types";
 export const superclaudePlugin: Plugin = {
   slug: "superclaude",
   title: "SuperClaude Framework",
-  description: "Versatile configuration framework enhancing Claude Code with commands, cognitive personas, and advanced development workflows",
-  tags: ["framework", "personas", "commands", "workflow"],
-  featured: true,
+  description: "Versatile configuration framework enhancing Claude Code with commands, cognitive personas, and advanced development workflows. Includes 4 specialized personas and extensible command system.",
+  tags: ["framework", "personas", "commands", "workflow", "community"],
+  featured: false,
   author: {
     name: "SuperClaude-Org",
     url: "https://github.com/SuperClaude-Org/SuperClaude_Framework",
@@ -32,4 +32,10 @@ SuperClaude includes personas for:
 - Test Engineer - Testing and QA focus
 - DevOps - Infrastructure and deployment
 - Security - Security review and hardening`,
+  commands: [
+    { name: "/persona", description: "Switch between cognitive personas (architect, tester, devops, security)" },
+    { name: "/architect", description: "Activate Code Architect persona for system design" },
+    { name: "/tester", description: "Activate Test Engineer persona for QA focus" },
+    { name: "/devops", description: "Activate DevOps persona for infrastructure" },
+  ],
 };

--- a/src/data/plugins/swift-lsp.ts
+++ b/src/data/plugins/swift-lsp.ts
@@ -3,8 +3,8 @@ import { Plugin } from "@/lib/types";
 export const swiftLspPlugin: Plugin = {
   slug: "swift-lsp",
   title: "Swift LSP",
-  description: "Language Server Protocol support for Swift development with code intelligence",
-  tags: ["swift", "lsp", "ios", "macos", "official"],
+  description: "Language Server Protocol support for Swift development. Real-time type checking, Xcode integration, SwiftUI previews, and intelligent code completion for iOS, macOS, watchOS, and tvOS development.",
+  tags: ["swift", "lsp", "ios", "macos", "official", "xcode"],
   featured: false,
   author: {
     name: "Anthropic",
@@ -17,4 +17,9 @@ export const swiftLspPlugin: Plugin = {
     "swift-lsp@claude-plugins-official": true
   }
 }`,
+  commands: [
+    { name: "/swift-check", description: "Type check Swift files and show errors" },
+    { name: "/swift-format", description: "Format Swift code with swift-format" },
+    { name: "/swift-build", description: "Build Swift package or Xcode project" },
+  ],
 };

--- a/src/data/plugins/typescript-lsp.ts
+++ b/src/data/plugins/typescript-lsp.ts
@@ -1,0 +1,25 @@
+import { Plugin } from "@/lib/types";
+
+export const typescriptLspPlugin: Plugin = {
+  slug: "typescript-lsp",
+  title: "TypeScript LSP",
+  description: "TypeScript and JavaScript language server integration. Real-time type checking, auto-imports, intelligent refactoring, and code navigation for TypeScript and JavaScript projects.",
+  tags: ["typescript", "javascript", "lsp", "official"],
+  featured: false,
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/typescript-lsp",
+  installCommand: "claude plugins add typescript-lsp@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/ts-check", description: "Run TypeScript type checker on project" },
+    { name: "/ts-errors", description: "Show all TypeScript errors in workspace" },
+    { name: "/ts-refactor", description: "Intelligent TypeScript refactoring" },
+  ],
+};

--- a/src/data/plugins/vercel.ts
+++ b/src/data/plugins/vercel.ts
@@ -1,0 +1,30 @@
+import { Plugin } from "@/lib/types";
+
+export const vercelPlugin: Plugin = {
+  slug: "vercel",
+  title: "Vercel",
+  description: "Vercel deployment automation and project management. Deploy applications, manage domains, check deployment status, and configure environments directly from Claude Code.",
+  tags: ["deployment", "hosting", "serverless", "integration", "official"],
+  featured: true,
+  author: {
+    name: "Vercel",
+    url: "https://vercel.com",
+  },
+  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/vercel",
+  installCommand: "claude plugins add vercel@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "vercel@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/vercel-deploy", description: "Deploy current project to Vercel" },
+    { name: "/vercel-status", description: "Check deployment status" },
+    { name: "/vercel-env", description: "Manage environment variables" },
+    { name: "/vercel-domains", description: "Configure custom domains" },
+    { name: "/vercel-logs", description: "View deployment and function logs" },
+  ],
+  relatedItems: [
+    { type: "mcp-server", slug: "vercel", relationship: "requires" },
+  ],
+};


### PR DESCRIPTION
- Updated all existing plugins with slash commands and improved descriptions
- Added 8 LSP plugins: TypeScript, Pyright, Rust Analyzer, gopls, jdtls, C#, PHP, clangd
- Added 10 popular external plugins: Vercel, Chrome DevTools, Docker, AWS, Notion, Jira, Sentry, Datadog, Figma, Prisma
- Enhanced plugin metadata with relatedItems connections
- Total plugins increased from 39 to 57