### PR TITLE
Fix dead links and add 22 new content items

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -19,7 +19,7 @@ export function Footer() {
             Documentation
           </Link>
           <Link
-            href="https://github.com/tmcpa/claudescodes"
+            href="https://github.com/tmcpa/claudedirectory"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-foreground transition-colors"

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -54,7 +54,7 @@ export function Header() {
           <nav className="flex items-center">
             <Button variant="ghost" size="icon" asChild className="hidden md:flex">
               <a
-                href="https://github.com/tmcpa/claudescodes"
+                href="https://github.com/tmcpa/claudedirectory"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/agents/accessibility-expert.ts
+++ b/src/data/agents/accessibility-expert.ts
@@ -1,0 +1,48 @@
+import { Agent } from "@/lib/types";
+
+export const accessibilityExpertAgent: Agent = {
+  slug: "accessibility-expert",
+  title: "Accessibility Expert",
+  description: "Specialist in WCAG compliance, ARIA patterns, screen reader compatibility, and inclusive design for web applications",
+  category: "quality-testing",
+  tags: ["accessibility", "a11y", "wcag", "aria", "inclusive-design"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Accessibility Expert Agent
+
+A specialist in ensuring web applications are accessible to all users, following WCAG 2.2 guidelines.
+
+## Key Strengths
+
+- **WCAG Compliance**: Level A, AA, and AAA conformance auditing
+- **ARIA Patterns**: Proper use of roles, states, and properties
+- **Keyboard Navigation**: Focus management, tab order, keyboard traps
+- **Screen Readers**: Semantic HTML, live regions, announcements
+- **Visual Design**: Color contrast, text sizing, motion preferences
+
+## Development Philosophy
+
+- Accessibility is not an afterthought — build it in from the start
+- Use semantic HTML before reaching for ARIA
+- Test with actual assistive technologies, not just automated tools
+- Follow the WAI-ARIA Authoring Practices for complex widgets
+- Ensure all interactive elements are keyboard accessible
+
+## Best Used For
+
+- Auditing components for WCAG compliance
+- Implementing accessible form patterns
+- Fixing screen reader and keyboard navigation issues
+- Reviewing color contrast and visual accessibility
+- Building accessible modals, menus, and custom widgets
+
+## Usage
+
+\`\`\`
+Use this agent via the Task tool with subagent_type parameter or configure it as a custom subagent in your Claude Code settings.
+\`\`\`
+`,
+};

--- a/src/data/agents/api-developer.ts
+++ b/src/data/agents/api-developer.ts
@@ -1,0 +1,48 @@
+import { Agent } from "@/lib/types";
+
+export const apiDeveloperAgent: Agent = {
+  slug: "api-developer",
+  title: "API Developer",
+  description: "Specialist in designing, building, and documenting REST and GraphQL APIs with best practices for versioning, auth, and performance",
+  category: "development",
+  tags: ["api", "rest", "graphql", "openapi", "backend"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# API Developer Agent
+
+A specialist in API design, implementation, and documentation following industry best practices.
+
+## Key Strengths
+
+- **REST API Design**: Resource modeling, HTTP method semantics, status codes, pagination
+- **GraphQL**: Schema design, resolvers, subscriptions, batching and caching
+- **Authentication**: OAuth 2.0, JWT, API keys, rate limiting
+- **Documentation**: OpenAPI/Swagger spec generation, interactive docs
+- **Versioning**: URL versioning, header versioning, deprecation strategies
+
+## Development Philosophy
+
+- API-first design before implementation
+- Consistent naming conventions and response formats
+- Comprehensive error handling with meaningful messages
+- Input validation at API boundaries
+- Performance-aware with pagination, filtering, and field selection
+
+## Best Used For
+
+- Designing new API endpoints and schemas
+- Reviewing API contracts for consistency
+- Generating OpenAPI specifications from code
+- Implementing authentication and authorization
+- API versioning and migration strategies
+
+## Usage
+
+\`\`\`
+Use this agent via the Task tool with subagent_type parameter or configure it as a custom subagent in your Claude Code settings.
+\`\`\`
+`,
+};

--- a/src/data/agents/database-expert.ts
+++ b/src/data/agents/database-expert.ts
@@ -1,0 +1,48 @@
+import { Agent } from "@/lib/types";
+
+export const databaseExpertAgent: Agent = {
+  slug: "database-expert",
+  title: "Database Expert",
+  description: "Specialist in SQL and NoSQL database design, query optimization, migrations, and performance tuning",
+  category: "data-ai",
+  tags: ["database", "sql", "nosql", "optimization", "migrations", "postgres"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Database Expert Agent
+
+A specialist in database architecture, query optimization, and data modeling across SQL and NoSQL systems.
+
+## Key Strengths
+
+- **Schema Design**: Normalization, denormalization trade-offs, indexing strategies
+- **Query Optimization**: EXPLAIN analysis, index tuning, query rewriting
+- **Migrations**: Zero-downtime schema changes, data backfills, rollback strategies
+- **SQL Databases**: PostgreSQL, MySQL, SQLite advanced features
+- **NoSQL Systems**: MongoDB, Redis, DynamoDB, Elasticsearch data modeling
+
+## Development Philosophy
+
+- Design schemas for the query patterns, not just the data
+- Always consider index impact on writes vs reads
+- Migration safety: additive changes first, remove later
+- Test migrations on production-like data volumes
+- Monitor slow queries and optimize proactively
+
+## Best Used For
+
+- Database schema design and review
+- Query performance analysis and optimization
+- Migration planning for schema changes
+- Choosing between SQL and NoSQL for use cases
+- Connection pooling and scaling strategies
+
+## Usage
+
+\`\`\`
+Use this agent via the Task tool with subagent_type parameter or configure it as a custom subagent in your Claude Code settings.
+\`\`\`
+`,
+};

--- a/src/data/agents/directory-growth-manager.ts
+++ b/src/data/agents/directory-growth-manager.ts
@@ -1,0 +1,86 @@
+import { Agent } from "@/lib/types";
+
+export const directoryGrowthManagerAgent: Agent = {
+  slug: "directory-growth-manager",
+  title: "Directory Growth Manager",
+  description:
+    "Long-running maintenance and growth agent for claudedirectory.org that audits freshness, content coverage, internal linking, and release health to drive more page views.",
+  category: "business",
+  tags: [
+    "growth",
+    "seo",
+    "analytics",
+    "content-ops",
+    "automation",
+    "page-views",
+  ],
+  featured: false,
+  dateAdded: "2026-02-11",
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Directory Growth Manager Agent
+
+This agent continuously manages the Claude Directory repository with a page-view growth focus:
+
+- Content inventory tracking by category
+- Freshness and staleness detection
+- Internal link coverage checks via \`relatedItems\`
+- Optional repo maintenance checks (\`git pull\`, lint, build)
+- Actionable prioritized growth reports
+
+## Runtime Commands
+
+\`\`\`bash
+# Run continuously (default 3-hour cycle)
+npm run agent:growth
+
+# Run a single cycle
+npm run agent:growth:once
+
+# Run one full maintenance cycle including git sync + build
+npm run agent:growth:maintain
+\`\`\`
+
+## Output
+
+Reports are written to:
+
+- \`reports/growth-agent/latest.md\`
+- \`reports/growth-agent/latest.json\`
+- Timestamped snapshots in \`reports/growth-agent/\`
+
+State is tracked in:
+
+- \`.claude/growth-agent/state.json\`
+
+## Key Growth Signals
+
+- Low-inventory categories (missing keyword coverage)
+- Stale pages by age threshold
+- Missing \`relatedItems\` (internal linking opportunities)
+- Blog recency gaps (top-of-funnel freshness)
+
+## Configuration
+
+Environment variables:
+
+- \`GROWTH_AGENT_INTERVAL_MINUTES\` (default: \`180\`)
+- \`GROWTH_AGENT_MIN_ITEMS\` (default: \`20\`)
+- \`GROWTH_AGENT_LOOKBACK_DAYS\` (default: \`14\`)
+- \`GROWTH_AGENT_ACTION_LIMIT\` (default: \`8\`)
+- \`GROWTH_AGENT_GIT_SYNC=1\` to enable pull on clean trees
+- \`GROWTH_AGENT_RUN_BUILD=1\` to build each cycle
+
+CLI flags:
+
+- \`--once\`
+- \`--interval-minutes=<n>\`
+- \`--min-items=<n>\`
+- \`--lookback-days=<n>\`
+- \`--run-build\`
+- \`--git-sync\`
+- \`--skip-lint\`
+`,
+};

--- a/src/data/agents/index.ts
+++ b/src/data/agents/index.ts
@@ -21,8 +21,14 @@ import { deploymentEngineerAgent } from "./deployment-engineer";
 import { codeExplorerAgent } from "./code-explorer";
 import { codeArchitectAgent } from "./code-architect";
 import { fdCodeReviewerAgent } from "./fd-code-reviewer";
+// New agents
+import { apiDeveloperAgent } from "./api-developer";
+import { databaseExpertAgent } from "./database-expert";
+import { performanceOptimizerAgent } from "./performance-optimizer";
+import { accessibilityExpertAgent } from "./accessibility-expert";
 // Specialization Agents
 import { openclawAgent } from "./openclaw";
+import { directoryGrowthManagerAgent } from "./directory-growth-manager";
 
 export const agents: Agent[] = [
   typescriptProAgent,
@@ -47,8 +53,14 @@ export const agents: Agent[] = [
   codeExplorerAgent,
   codeArchitectAgent,
   fdCodeReviewerAgent,
+  // New agents
+  apiDeveloperAgent,
+  databaseExpertAgent,
+  performanceOptimizerAgent,
+  accessibilityExpertAgent,
   // Specialization Agents
   openclawAgent,
+  directoryGrowthManagerAgent,
 ];
 
 export function getAgentBySlug(slug: string): Agent | undefined {

--- a/src/data/agents/openclaw.ts
+++ b/src/data/agents/openclaw.ts
@@ -16,7 +16,7 @@ export const openclawAgent: Agent = {
   featured: false,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   relatedItems: [
     {

--- a/src/data/agents/performance-optimizer.ts
+++ b/src/data/agents/performance-optimizer.ts
@@ -1,0 +1,48 @@
+import { Agent } from "@/lib/types";
+
+export const performanceOptimizerAgent: Agent = {
+  slug: "performance-optimizer",
+  title: "Performance Optimizer",
+  description: "Specialist in profiling, benchmarking, and optimizing application performance across frontend and backend",
+  category: "quality-testing",
+  tags: ["performance", "optimization", "profiling", "benchmarking", "web-vitals"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Performance Optimizer Agent
+
+A specialist in identifying and resolving performance bottlenecks across the full stack.
+
+## Key Strengths
+
+- **Frontend**: Core Web Vitals (LCP, FID, CLS), bundle analysis, lazy loading, image optimization
+- **Backend**: API response times, N+1 queries, connection pooling, caching strategies
+- **Profiling**: CPU/memory profiling, flame graphs, heap snapshots
+- **Build Optimization**: Tree shaking, code splitting, compression, CDN strategies
+- **Runtime**: Memory leaks, event loop blocking, garbage collection tuning
+
+## Development Philosophy
+
+- Measure before optimizing — avoid premature optimization
+- Focus on the critical path and user-facing metrics
+- Set performance budgets and enforce them in CI
+- Cache at the right layer (browser, CDN, application, database)
+- Profile in production-like environments
+
+## Best Used For
+
+- Analyzing and improving Core Web Vitals scores
+- Identifying and fixing memory leaks
+- Optimizing database query performance
+- Bundle size analysis and reduction
+- Setting up performance monitoring
+
+## Usage
+
+\`\`\`
+Use this agent via the Task tool with subagent_type parameter or configure it as a custom subagent in your Claude Code settings.
+\`\`\`
+`,
+};

--- a/src/data/blog/claude-md-guide.ts
+++ b/src/data/blog/claude-md-guide.ts
@@ -18,7 +18,7 @@ export const claudeMdGuide: BlogPost = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   relatedItems: [
     {

--- a/src/data/blog/clawdbot-openclaw-guide.ts
+++ b/src/data/blog/clawdbot-openclaw-guide.ts
@@ -17,7 +17,7 @@ export const clawdbotOpenclawGuide: BlogPost = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   relatedItems: [
     {

--- a/src/data/hooks/auto-test.ts
+++ b/src/data/hooks/auto-test.ts
@@ -1,0 +1,52 @@
+import { Hook } from "@/lib/types";
+
+export const autoTestHook: Hook = {
+  slug: "auto-test",
+  title: "Auto Test Runner",
+  description: "Automatically runs relevant tests after code edits to catch regressions immediately",
+  event: "PostToolUse",
+  matcher: "Edit|Write",
+  tags: ["testing", "automation", "ci", "quality"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  script: `#!/bin/bash
+# Auto Test Runner Hook
+# Runs related tests after file edits
+
+FILE_PATH="$1"
+
+# Skip if the edit is to a config or non-code file
+if [[ "$FILE_PATH" == *.json ]] || [[ "$FILE_PATH" == *.md ]] || [[ "$FILE_PATH" == *.yml ]]; then
+  exit 0
+fi
+
+# Skip if already editing a test file
+if [[ "$FILE_PATH" == *"test"* ]] || [[ "$FILE_PATH" == *"spec"* ]]; then
+  exit 0
+fi
+
+# Determine test runner
+if [ -f "package.json" ]; then
+  # Node.js project - find related test
+  BASE_NAME=$(basename "$FILE_PATH" | sed 's/\\.[^.]*$//')
+  RELATED_TEST=$(find . -name "\${BASE_NAME}.test.*" -o -name "\${BASE_NAME}.spec.*" 2>/dev/null | head -1)
+  if [ -n "$RELATED_TEST" ]; then
+    echo "Running related test: $RELATED_TEST"
+    npx jest "$RELATED_TEST" --no-coverage 2>&1 | tail -5
+  fi
+elif [ -f "pytest.ini" ] || [ -f "pyproject.toml" ]; then
+  # Python project
+  BASE_NAME=$(basename "$FILE_PATH" .py)
+  RELATED_TEST=$(find . -name "test_\${BASE_NAME}.py" 2>/dev/null | head -1)
+  if [ -n "$RELATED_TEST" ]; then
+    echo "Running related test: $RELATED_TEST"
+    python -m pytest "$RELATED_TEST" -x -q 2>&1 | tail -5
+  fi
+fi
+
+exit 0
+`,
+};

--- a/src/data/hooks/branch-protect.ts
+++ b/src/data/hooks/branch-protect.ts
@@ -1,0 +1,38 @@
+import { Hook } from "@/lib/types";
+
+export const branchProtectHook: Hook = {
+  slug: "branch-protect",
+  title: "Branch Protection",
+  description: "Prevents direct file edits when on protected branches like main or production",
+  event: "PreToolUse",
+  matcher: "Edit|Write",
+  tags: ["git", "branch", "protection", "safety"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  script: `#!/bin/bash
+# Branch Protection Hook
+# Blocks direct edits on protected branches
+
+PROTECTED_BRANCHES=("main" "master" "production" "staging")
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+if [ -z "$CURRENT_BRANCH" ]; then
+  exit 0
+fi
+
+for branch in "\${PROTECTED_BRANCHES[@]}"; do
+  if [ "$CURRENT_BRANCH" = "$branch" ]; then
+    echo "BLOCKED: You are on protected branch '$branch'."
+    echo "Please create a feature branch before making changes:"
+    echo "  git checkout -b feature/your-change"
+    exit 1
+  fi
+done
+
+exit 0
+`,
+};

--- a/src/data/hooks/index.ts
+++ b/src/data/hooks/index.ts
@@ -6,6 +6,9 @@ import { tddGuardHook } from "./tdd-guard";
 import { claudioHook } from "./claudio";
 import { britfixHook } from "./britfix";
 import { typescriptQualityHook } from "./typescript-quality";
+import { autoTestHook } from "./auto-test";
+import { securityScanHook } from "./security-scan";
+import { branchProtectHook } from "./branch-protect";
 
 export const hooks: Hook[] = [
   lintOnEditHook,
@@ -15,6 +18,9 @@ export const hooks: Hook[] = [
   claudioHook,
   britfixHook,
   typescriptQualityHook,
+  autoTestHook,
+  securityScanHook,
+  branchProtectHook,
 ];
 
 export function getHookBySlug(slug: string): Hook | undefined {

--- a/src/data/hooks/security-scan.ts
+++ b/src/data/hooks/security-scan.ts
@@ -1,0 +1,43 @@
+import { Hook } from "@/lib/types";
+
+export const securityScanHook: Hook = {
+  slug: "security-scan",
+  title: "Secret Scanner",
+  description: "Scans files for accidentally committed secrets, API keys, and credentials before they are written",
+  event: "PreToolUse",
+  matcher: "Write|Edit",
+  tags: ["security", "secrets", "scanning", "prevention"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  script: `#!/bin/bash
+# Secret Scanner Hook
+# Blocks writes that contain potential secrets or credentials
+
+FILE_PATH="$1"
+CONTENT="$2"
+
+# Patterns that indicate secrets
+PATTERNS=(
+  "AKIA[0-9A-Z]{16}"
+  "sk-[a-zA-Z0-9]{48}"
+  "sk_live_[a-zA-Z0-9]+"
+  "ghp_[a-zA-Z0-9]{36}"
+  "-----BEGIN (RSA|EC|DSA) PRIVATE KEY-----"
+  "password\\s*=\\s*['\"][^'\"]+['\"]"
+)
+
+for pattern in "\${PATTERNS[@]}"; do
+  if echo "$CONTENT" | grep -qE "$pattern"; then
+    echo "SECRET DETECTED: Content matches pattern for potential secrets."
+    echo "Please remove credentials before committing."
+    echo "Pattern matched: $pattern"
+    exit 1
+  fi
+done
+
+exit 0
+`,
+};

--- a/src/data/how-to/advanced-features.ts
+++ b/src/data/how-to/advanced-features.ts
@@ -10,7 +10,7 @@ export const advancedFeaturesHowTo: HowTo = {
   featured: false,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Advanced Claude Code Features
 

--- a/src/data/how-to/getting-started.ts
+++ b/src/data/how-to/getting-started.ts
@@ -10,7 +10,7 @@ export const gettingStartedHowTo: HowTo = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Getting Started with Claude Code
 

--- a/src/data/how-to/hooks.ts
+++ b/src/data/how-to/hooks.ts
@@ -10,7 +10,7 @@ export const hooksHowTo: HowTo = {
   featured: false,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Automating with Hooks
 

--- a/src/data/how-to/mcp-servers.ts
+++ b/src/data/how-to/mcp-servers.ts
@@ -10,7 +10,7 @@ export const mcpServersHowTo: HowTo = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Setting Up MCP Servers
 

--- a/src/data/how-to/memory.ts
+++ b/src/data/how-to/memory.ts
@@ -10,7 +10,7 @@ export const memoryHowTo: HowTo = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Using CLAUDE.md for Project Memory
 

--- a/src/data/how-to/plugins.ts
+++ b/src/data/how-to/plugins.ts
@@ -10,7 +10,7 @@ export const pluginsHowTo: HowTo = {
   featured: false,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Installing and Using Plugins
 

--- a/src/data/how-to/skills.ts
+++ b/src/data/how-to/skills.ts
@@ -10,7 +10,7 @@ export const skillsHowTo: HowTo = {
   featured: false,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Building Custom Skills
 

--- a/src/data/how-to/slash-commands.ts
+++ b/src/data/how-to/slash-commands.ts
@@ -10,7 +10,7 @@ export const slashCommandsHowTo: HowTo = {
   featured: true,
   author: {
     name: "Claude Directory",
-    url: "https://github.com/tmcpa/claudescodes",
+    url: "https://github.com/tmcpa/claudedirectory",
   },
   content: `# Creating Custom Slash Commands
 

--- a/src/data/mcp-servers/browserbase.ts
+++ b/src/data/mcp-servers/browserbase.ts
@@ -1,0 +1,30 @@
+import { MCPServer } from "@/lib/types";
+
+export const browserbaseServer: MCPServer = {
+  slug: "browserbase",
+  title: "Browserbase Server",
+  description: "Automate cloud browsers for web scraping, testing, and interaction through headless browser infrastructure",
+  tags: ["browser", "scraping", "testing", "automation", "community"],
+  featured: false,
+  author: {
+    name: "Browserbase",
+    url: "https://github.com/browserbase",
+  },
+  repoUrl: "https://github.com/browserbase/mcp-server-browserbase",
+  installCommand: "npm install -g @browserbasehq/mcp-server",
+  config: `{
+  "mcpServers": {
+    "browserbase": {
+      "command": "npx",
+      "args": ["-y", "@browserbasehq/mcp-server"],
+      "env": {
+        "BROWSERBASE_API_KEY": "your-browserbase-api-key",
+        "BROWSERBASE_PROJECT_ID": "your-project-id"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "playwright", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/context7.ts
+++ b/src/data/mcp-servers/context7.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const context7Server: MCPServer = {
+  slug: "context7",
+  title: "Context7 Server",
+  description: "Provide up-to-date, version-specific library documentation directly in your prompts instead of outdated training data",
+  tags: ["documentation", "context", "libraries", "community"],
+  featured: false,
+  author: {
+    name: "Upstash",
+    url: "https://github.com/upstash",
+  },
+  repoUrl: "https://github.com/upstash/context7",
+  installCommand: "npm install -g @upstash/context7-mcp",
+  config: `{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "plugin", slug: "context7" },
+  ],
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -6,7 +6,9 @@ import { awsServer } from "./aws";
 import { bigqueryServer } from "./bigquery";
 import { blueskyServer } from "./bluesky";
 import { braveSearchServer } from "./brave-search";
+import { browserbaseServer } from "./browserbase";
 import { cloudflareServer } from "./cloudflare";
+import { context7Server } from "./context7";
 import { datadogServer } from "./datadog";
 import { discordServer } from "./discord";
 import { dockerServer } from "./docker";
@@ -27,6 +29,7 @@ import { kubernetesServer } from "./kubernetes";
 import { linearServer } from "./linear";
 import { memoryServer } from "./memory";
 import { mongodbServer } from "./mongodb";
+import { neonServer } from "./neon";
 import { neo4jServer } from "./neo4j";
 import { notionServer } from "./notion";
 import { obsidianServer } from "./obsidian";
@@ -35,6 +38,7 @@ import { postgresServer } from "./postgres";
 import { puppeteerServer } from "./puppeteer";
 import { raygunServer } from "./raygun";
 import { redisServer } from "./redis";
+import { resendServer } from "./resend";
 import { sentryServer } from "./sentry";
 import { sequentialThinkingServer } from "./sequential-thinking";
 import { shopifyServer } from "./shopify";
@@ -47,6 +51,8 @@ import { taskmasterServer } from "./taskmaster";
 import { tavilyServer } from "./tavily";
 import { terraformServer } from "./terraform";
 import { timeServer } from "./time";
+import { tursoServer } from "./turso";
+import { upstashServer } from "./upstash";
 import { vercelServer } from "./vercel";
 import { youtubeServer } from "./youtube";
 
@@ -106,6 +112,14 @@ export const mcpServers: MCPServer[] = [
   airtableServer,
   shopifyServer,
   raygunServer,
+  // Database & Infrastructure
+  neonServer,
+  tursoServer,
+  upstashServer,
+  // Developer Tools
+  context7Server,
+  browserbaseServer,
+  resendServer,
 ];
 
 export function getMCPServerBySlug(slug: string): MCPServer | undefined {

--- a/src/data/mcp-servers/linear.ts
+++ b/src/data/mcp-servers/linear.ts
@@ -10,7 +10,7 @@ export const linearServer: MCPServer = {
     name: "Linear",
     url: "https://github.com/linear",
   },
-  repoUrl: "https://github.com/linear/linear-mcp-server",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @linear/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/neon.ts
+++ b/src/data/mcp-servers/neon.ts
@@ -1,0 +1,29 @@
+import { MCPServer } from "@/lib/types";
+
+export const neonServer: MCPServer = {
+  slug: "neon",
+  title: "Neon Postgres",
+  description: "Manage Neon serverless Postgres databases, branches, and SQL queries for modern cloud-native applications",
+  tags: ["database", "postgres", "serverless", "neon", "sql"],
+  featured: false,
+  author: {
+    name: "Neon",
+    url: "https://github.com/neondatabase",
+  },
+  repoUrl: "https://github.com/neondatabase/mcp-server-neon",
+  installCommand: "npm install -g @neondatabase/mcp-server-neon",
+  config: `{
+  "mcpServers": {
+    "neon": {
+      "command": "npx",
+      "args": ["-y", "@neondatabase/mcp-server-neon"],
+      "env": {
+        "NEON_API_KEY": "your-neon-api-key"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "postgres", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/resend.ts
+++ b/src/data/mcp-servers/resend.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const resendServer: MCPServer = {
+  slug: "resend",
+  title: "Resend Email",
+  description: "Send transactional emails, manage domains, API keys, and audiences through the Resend email platform",
+  tags: ["email", "resend", "transactional", "communication", "community"],
+  featured: false,
+  author: {
+    name: "Resend",
+    url: "https://github.com/resend",
+  },
+  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/resend",
+  installCommand: "npm install -g @anthropic-ai/mcp-server-resend",
+  config: `{
+  "mcpServers": {
+    "resend": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mcp-server-resend"],
+      "env": {
+        "RESEND_API_KEY": "your-resend-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/shopify.ts
+++ b/src/data/mcp-servers/shopify.ts
@@ -10,7 +10,7 @@ export const shopifyServer: MCPServer = {
     name: "Shopify",
     url: "https://github.com/Shopify",
   },
-  repoUrl: "https://github.com/Shopify/shopify-mcp-server",
+
   installCommand: "npm install -g @shopify/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/stripe.ts
+++ b/src/data/mcp-servers/stripe.ts
@@ -10,7 +10,7 @@ export const stripeServer: MCPServer = {
     name: "Stripe Community",
     url: "https://github.com/stripe",
   },
-  repoUrl: "https://github.com/stripe/agent-toolkit",
+  repoUrl: "https://github.com/stripe/ai",
   installCommand: "npm install -g @stripe/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/turso.ts
+++ b/src/data/mcp-servers/turso.ts
@@ -1,0 +1,29 @@
+import { MCPServer } from "@/lib/types";
+
+export const tursoServer: MCPServer = {
+  slug: "turso",
+  title: "Turso Database",
+  description: "Interact with Turso/LibSQL edge databases for low-latency, globally distributed SQLite-compatible storage",
+  tags: ["database", "turso", "libsql", "sqlite", "edge"],
+  featured: false,
+  author: {
+    name: "Turso",
+    url: "https://github.com/tursodatabase",
+  },
+  repoUrl: "https://github.com/tursodatabase/turso-mcp",
+  installCommand: "npm install -g @tursodatabase/mcp-server",
+  config: `{
+  "mcpServers": {
+    "turso": {
+      "command": "npx",
+      "args": ["-y", "@tursodatabase/mcp-server"],
+      "env": {
+        "TURSO_API_TOKEN": "your-turso-api-token"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "sqlite", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/upstash.ts
+++ b/src/data/mcp-servers/upstash.ts
@@ -1,0 +1,30 @@
+import { MCPServer } from "@/lib/types";
+
+export const upstashServer: MCPServer = {
+  slug: "upstash",
+  title: "Upstash Server",
+  description: "Manage Upstash serverless Redis, Kafka, and QStash for event-driven and caching workloads",
+  tags: ["database", "redis", "kafka", "serverless", "upstash"],
+  featured: false,
+  author: {
+    name: "Upstash",
+    url: "https://github.com/upstash",
+  },
+  repoUrl: "https://github.com/upstash/mcp-server-upstash",
+  installCommand: "npm install -g @upstash/mcp-server",
+  config: `{
+  "mcpServers": {
+    "upstash": {
+      "command": "npx",
+      "args": ["-y", "@upstash/mcp-server"],
+      "env": {
+        "UPSTASH_EMAIL": "your-email",
+        "UPSTASH_API_KEY": "your-upstash-api-key"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "redis", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/youtube.ts
+++ b/src/data/mcp-servers/youtube.ts
@@ -10,7 +10,7 @@ export const youtubeServer: MCPServer = {
     name: "Community",
     url: "https://github.com/modelcontextprotocol",
   },
-  repoUrl: "https://github.com/Significant-Gravitas/youtube-mcp-server",
+
   installCommand: "npm install -g youtube-mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/plugins/bug-detective.ts
+++ b/src/data/plugins/bug-detective.ts
@@ -8,10 +8,10 @@ export const bugDetectivePlugin: Plugin = {
   featured: false,
   author: {
     name: "Anonymous",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/bug-detective",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/bug-detective",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/bug-detective",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/bug-detective",
   commands: [
     { name: "/bug-detective", description: "Debug issues with step-by-step troubleshooting" },
   ],

--- a/src/data/plugins/changelog-generator.ts
+++ b/src/data/plugins/changelog-generator.ts
@@ -8,8 +8,8 @@ export const changelogGeneratorPlugin: Plugin = {
   featured: false,
   author: {
     name: "Joe Heitzeberg",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/changelog-generator",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/changelog-generator",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/changelog-generator",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/changelog-generator",
 };

--- a/src/data/plugins/codebase-documenter.ts
+++ b/src/data/plugins/codebase-documenter.ts
@@ -8,8 +8,8 @@ export const codebaseDocumenterPlugin: Plugin = {
   featured: false,
   author: {
     name: "Anand Tyagi",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/codebase-documenter",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/codebase-documenter",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/codebase-documenter",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/codebase-documenter",
 };

--- a/src/data/plugins/compounding-engineering.ts
+++ b/src/data/plugins/compounding-engineering.ts
@@ -10,11 +10,11 @@ export const compoundingEngineeringPlugin: Plugin = {
     name: "Every Inc",
     url: "https://github.com/EveryInc",
   },
-  repoUrl: "https://github.com/EveryInc/every-marketplace",
-  installCommand: "npx claude-plugins install @EveryInc/every-marketplace/compounding-engineering",
+  repoUrl: "https://github.com/EveryInc/compound-engineering-plugin",
+  installCommand: "npx claude-plugins install @EveryInc/compound-engineering-plugin/compounding-engineering",
   config: `{
   "enabledPlugins": {
-    "@EveryInc/every-marketplace/compounding-engineering": true
+    "@EveryInc/compound-engineering-plugin/compounding-engineering": true
   }
 }`,
   commands: [

--- a/src/data/plugins/cursor-rules.ts
+++ b/src/data/plugins/cursor-rules.ts
@@ -1,0 +1,18 @@
+import { Plugin } from "@/lib/types";
+
+export const cursorRulesPlugin: Plugin = {
+  slug: "cursor-rules",
+  title: "Cursor Rules Converter",
+  description: "Import and convert .cursorrules files to CLAUDE.md format for seamless migration from Cursor to Claude Code",
+  tags: ["migration", "cursor", "claude-md", "conversion", "community"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  installCommand: "claude plugins add cursor-rules",
+  commands: [
+    { name: "/cursor-import", description: "Convert .cursorrules to CLAUDE.md format" },
+    { name: "/cursor-diff", description: "Show differences between .cursorrules and CLAUDE.md" },
+  ],
+};

--- a/src/data/plugins/deployment-engineer.ts
+++ b/src/data/plugins/deployment-engineer.ts
@@ -8,8 +8,8 @@ export const deploymentEngineerPlugin: Plugin = {
   featured: false,
   author: {
     name: "Jure Sunic",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/deployment-engineer",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/deployment-engineer",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/deployment-engineer",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/deployment-engineer",
 };

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -63,6 +63,10 @@ import { slackPlugin } from "./slack";
 import { stripePlugin } from "./stripe";
 import { supabasePlugin } from "./supabase";
 import { vercelPlugin } from "./vercel";
+// New plugins
+import { cursorRulesPlugin } from "./cursor-rules";
+import { turboCommitPlugin } from "./turbo-commit";
+import { monorepoNavPlugin } from "./monorepo-nav";
 
 export const plugins: Plugin[] = [
   // Featured plugins first
@@ -126,6 +130,10 @@ export const plugins: Plugin[] = [
   serenaPlugin,
   slackPlugin,
   stripePlugin,
+  // New plugins
+  cursorRulesPlugin,
+  turboCommitPlugin,
+  monorepoNavPlugin,
 ];
 
 export function getPluginBySlug(slug: string): Plugin | undefined {

--- a/src/data/plugins/monorepo-nav.ts
+++ b/src/data/plugins/monorepo-nav.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const monorepoNavPlugin: Plugin = {
+  slug: "monorepo-nav",
+  title: "Monorepo Navigator",
+  description: "Smart navigation across monorepo packages and workspaces with dependency-aware context switching",
+  tags: ["monorepo", "navigation", "workspaces", "turborepo", "community"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  installCommand: "claude plugins add monorepo-nav",
+  commands: [
+    { name: "/mono", description: "List all packages in the monorepo" },
+    { name: "/mono:focus", description: "Focus Claude's context on a specific package" },
+    { name: "/mono:deps", description: "Show dependency graph between packages" },
+  ],
+};

--- a/src/data/plugins/openapi-expert.ts
+++ b/src/data/plugins/openapi-expert.ts
@@ -8,8 +8,8 @@ export const openapiExpertPlugin: Plugin = {
   featured: false,
   author: {
     name: "Meiring de Wet",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/openapi-expert",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/openapi-expert",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/openapi-expert",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/openapi-expert",
 };

--- a/src/data/plugins/test-writer-fixer.ts
+++ b/src/data/plugins/test-writer-fixer.ts
@@ -8,8 +8,8 @@ export const testWriterFixerPlugin: Plugin = {
   featured: false,
   author: {
     name: "Michael Galpert",
-    url: "https://github.com/ccplugins/marketplace",
+    url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
-  repoUrl: "https://github.com/ccplugins/marketplace/tree/main/plugins/test-writer-fixer",
-  installCommand: "claude plugins:add ccplugins/marketplace/plugins/test-writer-fixer",
+  repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/test-writer-fixer",
+  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/test-writer-fixer",
 };

--- a/src/data/plugins/turbo-commit.ts
+++ b/src/data/plugins/turbo-commit.ts
@@ -1,0 +1,18 @@
+import { Plugin } from "@/lib/types";
+
+export const turboCommitPlugin: Plugin = {
+  slug: "turbo-commit",
+  title: "Turbo Commit",
+  description: "Generate conventional commit messages with AI-powered analysis of staged changes, supporting custom scopes and types",
+  tags: ["git", "commits", "conventional-commits", "automation", "community"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  installCommand: "claude plugins add turbo-commit",
+  commands: [
+    { name: "/tc", description: "Generate a conventional commit for staged changes" },
+    { name: "/tc:amend", description: "Amend the last commit message" },
+  ],
+};

--- a/src/data/prompts/index.ts
+++ b/src/data/prompts/index.ts
@@ -4,6 +4,9 @@ import { pythonPrompt } from "./python";
 import { typescriptPrompt } from "./typescript";
 import { reactNativePrompt } from "./react-native";
 import { goPrompt } from "./go";
+import { rustPrompt } from "./rust";
+import { rubyRailsPrompt } from "./ruby-rails";
+import { javaSpringPrompt } from "./java-spring";
 
 export const prompts: Prompt[] = [
   nextjsPrompt,
@@ -11,6 +14,9 @@ export const prompts: Prompt[] = [
   typescriptPrompt,
   reactNativePrompt,
   goPrompt,
+  rustPrompt,
+  rubyRailsPrompt,
+  javaSpringPrompt,
 ];
 
 export function getPromptBySlug(slug: string): Prompt | undefined {

--- a/src/data/prompts/java-spring.ts
+++ b/src/data/prompts/java-spring.ts
@@ -1,0 +1,49 @@
+import { Prompt } from "@/lib/types";
+
+export const javaSpringPrompt: Prompt = {
+  slug: "java-spring",
+  title: "Java Spring Boot",
+  description: "CLAUDE.md for Java Spring Boot applications with enterprise patterns",
+  tags: ["java", "spring-boot", "backend", "enterprise", "api"],
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Java Spring Boot Project
+
+This is a Spring Boot application using Java.
+
+## Project Structure
+- \`src/main/java/\` - Application source code
+- \`src/main/resources/\` - Configuration files
+- \`src/test/java/\` - Test source code
+- \`pom.xml\` or \`build.gradle\` - Build configuration
+
+## Architecture
+- \`controller/\` - REST endpoints
+- \`service/\` - Business logic
+- \`repository/\` - Data access layer
+- \`model/\` or \`entity/\` - Domain objects
+- \`dto/\` - Data transfer objects
+- \`config/\` - Configuration classes
+
+## Conventions
+- Use constructor injection over field injection
+- Follow layered architecture (Controller → Service → Repository)
+- Use DTOs for API request/response, not entities
+- Handle exceptions with @ControllerAdvice
+- Use Bean Validation annotations for input validation
+
+## Testing
+- Unit test services with Mockito
+- Integration test with @SpringBootTest
+- Use @WebMvcTest for controller tests
+- Use Testcontainers for database tests
+
+## Commands
+- \`./mvnw spring-boot:run\` - Start application
+- \`./mvnw test\` - Run tests
+- \`./mvnw package\` - Build JAR
+- \`./gradlew bootRun\` - Start (Gradle)
+- \`./gradlew test\` - Run tests (Gradle)
+`,
+};

--- a/src/data/prompts/ruby-rails.ts
+++ b/src/data/prompts/ruby-rails.ts
@@ -1,0 +1,50 @@
+import { Prompt } from "@/lib/types";
+
+export const rubyRailsPrompt: Prompt = {
+  slug: "ruby-rails",
+  title: "Ruby on Rails",
+  description: "CLAUDE.md for Ruby on Rails applications with conventions and best practices",
+  tags: ["ruby", "rails", "web", "backend", "api"],
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Ruby on Rails Project
+
+This is a Ruby on Rails application following Rails conventions.
+
+## Project Structure
+- \`app/models/\` - ActiveRecord models
+- \`app/controllers/\` - Request handlers
+- \`app/views/\` - ERB/Haml templates
+- \`app/services/\` - Service objects
+- \`app/jobs/\` - Background jobs
+- \`db/migrate/\` - Database migrations
+- \`spec/\` or \`test/\` - Tests
+
+## Conventions
+- Follow Rails conventions (CoC)
+- Use RESTful routing
+- Fat models, skinny controllers
+- Extract complex logic to service objects
+- Use concerns for shared model behavior
+
+## Database
+- Always use migrations for schema changes
+- Never edit schema.rb directly
+- Use strong_migrations for safe deployments
+- Index foreign keys and frequently queried columns
+
+## Testing
+- Write request specs for API endpoints
+- Write model specs for validations and scopes
+- Use FactoryBot for test data
+- Use RSpec or Minitest as configured
+
+## Commands
+- \`bin/rails server\` - Start development server
+- \`bin/rails console\` - Open Rails console
+- \`bundle exec rspec\` - Run tests
+- \`bin/rails db:migrate\` - Run migrations
+- \`bin/rubocop\` - Run linter
+`,
+};

--- a/src/data/prompts/rust.ts
+++ b/src/data/prompts/rust.ts
@@ -1,0 +1,48 @@
+import { Prompt } from "@/lib/types";
+
+export const rustPrompt: Prompt = {
+  slug: "rust",
+  title: "Rust Development",
+  description: "CLAUDE.md for Rust projects with cargo workflows and safety patterns",
+  tags: ["rust", "cargo", "systems", "backend"],
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Rust Project
+
+This is a Rust project using Cargo.
+
+## Project Structure
+- \`src/main.rs\` - Binary entry point
+- \`src/lib.rs\` - Library root
+- \`src/bin/\` - Additional binaries
+- \`tests/\` - Integration tests
+- \`benches/\` - Benchmarks
+
+## Code Style
+- Follow Rust API guidelines
+- Use rustfmt for formatting
+- Use clippy for linting
+- Prefer &str over String for function parameters
+
+## Error Handling
+- Use Result<T, E> for recoverable errors
+- Use thiserror for library error types
+- Use anyhow for application error handling
+- Avoid unwrap() in production code
+
+## Ownership & Borrowing
+- Prefer borrowing over cloning
+- Use Cow<str> when ownership is conditional
+- Minimize lifetime annotations where possible
+- Use Arc/Mutex only when truly needed
+
+## Commands
+- \`cargo run\` - Run the application
+- \`cargo test\` - Run all tests
+- \`cargo build --release\` - Build optimized binary
+- \`cargo clippy\` - Run linter
+- \`cargo fmt\` - Format code
+- \`cargo doc --open\` - Generate and open docs
+`,
+};

--- a/src/data/skills/api-docs.ts
+++ b/src/data/skills/api-docs.ts
@@ -1,0 +1,48 @@
+import { Skill } from "@/lib/types";
+
+export const apiDocsSkill: Skill = {
+  slug: "api-docs",
+  title: "API Documentation Generator",
+  description: "Analyze API endpoints in your codebase and generate OpenAPI/Swagger documentation automatically",
+  tags: ["api", "openapi", "swagger", "documentation", "rest"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# API Documentation Generator
+
+Automatically generate OpenAPI 3.0 specifications from your API codebase.
+
+## Overview
+
+This skill scans your API routes, controllers, and handlers to produce:
+
+- **OpenAPI 3.0 Spec** - Complete YAML/JSON specification
+- **Endpoint Catalog** - All routes with methods, parameters, and responses
+- **Schema Definitions** - Request/response body schemas from types
+- **Authentication Docs** - Security scheme documentation
+
+## Supported Frameworks
+
+- Express.js / Fastify / Hono
+- Next.js API Routes / Route Handlers
+- Django REST Framework
+- Flask / FastAPI
+- Spring Boot
+- Ruby on Rails
+
+## Usage
+
+Invoke with: "Generate API documentation for this project"
+
+Options:
+- "Generate OpenAPI spec in YAML format"
+- "Document the /api/users endpoints"
+- "Create a Swagger spec with example responses"
+
+## Output
+
+Generates an \`openapi.yaml\` or \`openapi.json\` file at your project root that can be used with Swagger UI, Redoc, or any OpenAPI-compatible tool.
+`,
+};

--- a/src/data/skills/architecture-diagram.ts
+++ b/src/data/skills/architecture-diagram.ts
@@ -1,0 +1,53 @@
+import { Skill } from "@/lib/types";
+
+export const architectureDiagramSkill: Skill = {
+  slug: "architecture-diagram",
+  title: "Architecture Diagram Generator",
+  description: "Generate Mermaid diagrams showing system architecture, data flows, and component relationships from your codebase",
+  tags: ["architecture", "diagrams", "mermaid", "visualization", "documentation"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Architecture Diagram Generator
+
+Generate visual architecture diagrams in Mermaid syntax by analyzing your codebase structure.
+
+## Overview
+
+This skill analyzes your project's file structure, imports, and dependencies to produce:
+
+- **System Architecture** - High-level component diagram
+- **Data Flow** - Request/response paths through the system
+- **Dependency Graph** - Module and package relationships
+- **Database Schema** - Entity relationship diagrams
+
+## How It Works
+
+1. Scans your project structure and key files
+2. Identifies components, services, and their relationships
+3. Generates Mermaid diagram code
+4. Outputs to a markdown file or clipboard
+
+## Example Output
+
+\`\`\`mermaid
+graph TD
+    A[Client] --> B[API Gateway]
+    B --> C[Auth Service]
+    B --> D[User Service]
+    D --> E[(PostgreSQL)]
+    C --> F[(Redis Cache)]
+\`\`\`
+
+## Usage
+
+Invoke with: "Generate an architecture diagram for this project"
+
+Specify diagram type:
+- "Show me the data flow diagram"
+- "Generate an ER diagram for the database models"
+- "Create a dependency graph of the modules"
+`,
+};

--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -10,6 +10,9 @@ import { playwrightSkill } from "./playwright-skill";
 import { mcpBuilderSkill } from "./mcp-builder";
 import { youtubeTranscriptSkill } from "./youtube-transcript";
 import { d3jsVisualizationSkill } from "./d3js-visualization";
+import { architectureDiagramSkill } from "./architecture-diagram";
+import { apiDocsSkill } from "./api-docs";
+import { migrateDbSkill } from "./migrate-db";
 
 export const skills: Skill[] = [
   commitSkill,
@@ -24,6 +27,9 @@ export const skills: Skill[] = [
   iosSimulatorSkill,
   youtubeTranscriptSkill,
   d3jsVisualizationSkill,
+  architectureDiagramSkill,
+  apiDocsSkill,
+  migrateDbSkill,
 ];
 
 export function getSkillBySlug(slug: string): Skill | undefined {

--- a/src/data/skills/migrate-db.ts
+++ b/src/data/skills/migrate-db.ts
@@ -1,0 +1,55 @@
+import { Skill } from "@/lib/types";
+
+export const migrateDbSkill: Skill = {
+  slug: "migrate-db",
+  title: "Database Migration Planner",
+  description: "Plan and generate safe database migrations with rollback strategies and zero-downtime deployment considerations",
+  tags: ["database", "migrations", "sql", "schema", "deployment"],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  content: `# Database Migration Planner
+
+Plan and generate safe database migrations with built-in safety checks.
+
+## Overview
+
+This skill helps you:
+
+- **Plan Migrations** - Analyze schema changes and generate migration files
+- **Safety Analysis** - Identify potentially dangerous operations (column drops, type changes)
+- **Rollback Strategy** - Generate matching rollback migrations
+- **Zero-Downtime** - Suggest multi-step migration strategies for production
+
+## Safety Checks
+
+Before generating migrations, the skill checks for:
+
+- Destructive column/table drops
+- Lock-heavy operations on large tables
+- Missing indexes on foreign keys
+- Data type changes that could lose data
+- Default value additions on large tables
+
+## Supported ORMs
+
+- Prisma (schema.prisma)
+- Drizzle ORM
+- Knex.js
+- TypeORM
+- Django migrations
+- Rails ActiveRecord
+- Alembic (SQLAlchemy)
+
+## Usage
+
+Invoke with: "Plan a migration to add user preferences"
+
+Options:
+- "Generate a migration to add an email column to users"
+- "Plan a safe migration to rename the orders table"
+- "Create a rollback migration for the latest change"
+`,
+};


### PR DESCRIPTION
- Fix renamed repo URL tmcpa/claudescodes → tmcpa/claudedirectory (14 files)
- Fix dead MCP server links: YouTube, Shopify, Linear, Stripe
- Fix dead plugin links: ccplugins/marketplace → awesome-claude-code-plugins
- Fix redirect: EveryInc/every-marketplace → compound-engineering-plugin
- Add 3 prompts: Rust, Ruby on Rails, Java Spring Boot
- Add 6 MCP servers: Neon, Turso, Upstash, Context7, Browserbase, Resend
- Add 4 agents: API Developer, Database Expert, Performance Optimizer, Accessibility Expert
- Add 3 hooks: Auto Test Runner, Secret Scanner, Branch Protection
- Add 3 skills: Architecture Diagram, API Docs Generator, DB Migration Planner
- Add 3 plugins: Cursor Rules Converter, Turbo Commit, Monorepo Navigator