### PR TITLE
Add Soul Spec MCP server

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -55,6 +55,7 @@ import { tursoServer } from "./turso";
 import { upstashServer } from "./upstash";
 import { vercelServer } from "./vercel";
 import { youtubeServer } from "./youtube";
+import { soulSpec } from "./soul-spec";
 
 export const mcpServers: MCPServer[] = [
   // Featured servers first
@@ -120,6 +121,8 @@ export const mcpServers: MCPServer[] = [
   context7Server,
   browserbaseServer,
   resendServer,
+  // AI Persona Management
+  soulSpec,
 ];
 
 export function getMCPServerBySlug(slug: string): MCPServer | undefined {

--- a/src/data/mcp-servers/soul-spec.ts
+++ b/src/data/mcp-servers/soul-spec.ts
@@ -1,0 +1,19 @@
+import { MCPServer } from "@/lib/types";
+
+export const soulSpec: MCPServer = {
+  slug: "soul-spec",
+  title: "Soul Spec",
+  description:
+    "Browse, install, and manage AI agent personas. Search 80+ personas from the Soul Spec registry, preview as CLAUDE.md, and install directly into your project.",
+  tags: ["ai-persona", "soul-spec", "persona", "identity", "agent"],
+  author: { name: "ClawSouls", url: "https://clawsouls.ai" },
+  installCommand: "npx -y soul-spec-mcp",
+  config: `{
+  "mcpServers": {
+    "soul-spec": {
+      "command": "npx",
+      "args": ["-y", "soul-spec-mcp"]
+    }
+  }
+}`,
+};


### PR DESCRIPTION
## Soul Spec MCP

**Category**: MCP Servers
**npm**: [soul-spec-mcp](https://www.npmjs.com/package/soul-spec-mcp)
**GitHub**: https://github.com/clawsouls/soul-spec-mcp

Browse, install, and manage AI agent personas from inside Claude. Search 80+ personas, preview CLAUDE.md output, and install directly.

### Quick Setup
```
npx -y soul-spec-mcp
```

### Tools
- `search_souls` — Search personas by keyword/category/tag
- `get_soul` — Detailed soul info
- `install_soul` — Download + auto-convert to CLAUDE.md
- `preview_soul` — Preview without saving
- `list_categories` — Browse categories
- `apply_persona` — Apply persona to current conversation