### PR TITLE
Add SEO metadata to category pages and crawlable topic pages

### DIFF
--- a/src/app/agents/_components/agents-listing.tsx
+++ b/src/app/agents/_components/agents-listing.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { AgentCard } from "@/components/cards/agent-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { agents, getAllAgentTags, getAllAgentCategories } from "@/data/agents";
+import { Agent } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const categoryLabels: Record<Agent["category"], string> = {
+  development: "Development",
+  "data-ai": "Data & AI",
+  infrastructure: "Infrastructure",
+  "quality-testing": "Quality & Testing",
+  security: "Security",
+  business: "Business",
+  specialization: "Specialization",
+};
+
+export function AgentsListing() {
+  const [search, setSearch] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<Agent["category"] | null>(null);
+  const allTags = getAllAgentTags();
+  const allCategories = getAllAgentCategories();
+
+  const filteredAgents = agents.filter((agent) => {
+    const matchesSearch =
+      search === "" ||
+      agent.title.toLowerCase().includes(search.toLowerCase()) ||
+      agent.description.toLowerCase().includes(search.toLowerCase()) ||
+      agent.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
+
+    const matchesCategory = selectedCategory === null || agent.category === selectedCategory;
+
+    return matchesSearch && matchesCategory;
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search agents..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-muted-foreground mb-2">Categories</p>
+          <div className="flex flex-wrap gap-2">
+            <Badge
+              variant={selectedCategory === null ? "default" : "secondary"}
+              className={cn(
+                "cursor-pointer hover:bg-primary/80",
+                selectedCategory === null && "bg-primary"
+              )}
+              onClick={() => setSelectedCategory(null)}
+            >
+              All
+            </Badge>
+            {allCategories.map((category) => (
+              <Badge
+                key={category}
+                variant={selectedCategory === category ? "default" : "secondary"}
+                className={cn(
+                  "cursor-pointer",
+                  selectedCategory === category
+                    ? "bg-primary hover:bg-primary/80"
+                    : "hover:bg-accent"
+                )}
+                onClick={() => setSelectedCategory(category === selectedCategory ? null : category)}
+              >
+                {categoryLabels[category]}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-sm text-muted-foreground mb-2">Tags</p>
+          <div className="flex flex-wrap gap-2">
+            {allTags.map((tag) => (
+              <Link key={tag} href={`/agents/topic/${tag}`}>
+                <Badge
+                  variant="secondary"
+                  className="cursor-pointer hover:bg-accent"
+                >
+                  {tag}
+                </Badge>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredAgents.map((agent) => (
+          <AgentCard key={agent.slug} agent={agent} />
+        ))}
+      </div>
+
+      {filteredAgents.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No agents found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,139 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { AgentsListing } from "./_components/agents-listing";
 
-import { useState } from "react";
-import { AgentCard } from "@/components/cards/agent-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { agents, getAllAgentTags, getAllAgentCategories } from "@/data/agents";
-import { Agent } from "@/lib/types";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
 
-const categoryLabels: Record<Agent["category"], string> = {
-  development: "Development",
-  "data-ai": "Data & AI",
-  infrastructure: "Infrastructure",
-  "quality-testing": "Quality & Testing",
-  security: "Security",
-  business: "Business",
-  specialization: "Specialization",
+export const metadata: Metadata = {
+  title: "Claude Code Agents & Subagent Configurations",
+  description:
+    "Discover specialized Claude Code agents for development, testing, infrastructure, security, and more. Subagent configurations that give Claude Code deep domain expertise for complex tasks.",
+  keywords: [
+    "claude code agents",
+    "claude code subagents",
+    "ai agents",
+    "specialized agents",
+    "claude code configurations",
+  ],
+  openGraph: {
+    title: "Claude Code Agents & Subagent Configurations",
+    description:
+      "Discover specialized Claude Code agents for development, testing, infrastructure, security, and more.",
+    url: `${BASE_URL}/agents`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code Agents & Subagent Configurations",
+    description:
+      "Discover specialized Claude Code agents for development, testing, infrastructure, security, and more.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/agents`,
+  },
 };
 
 export default function AgentsPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<Agent["category"] | null>(null);
-  const allTags = getAllAgentTags();
-  const allCategories = getAllAgentCategories();
-
-  const filteredAgents = agents.filter((agent) => {
-    const matchesSearch =
-      search === "" ||
-      agent.title.toLowerCase().includes(search.toLowerCase()) ||
-      agent.description.toLowerCase().includes(search.toLowerCase()) ||
-      agent.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || agent.tags.includes(selectedTag);
-    const matchesCategory = selectedCategory === null || agent.category === selectedCategory;
-
-    return matchesSearch && matchesTag && matchesCategory;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Agents</h1>
-        <p className="text-muted-foreground">
-          Specialized Claude Code subagents for development, testing, DevOps, and more
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Agents</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Focused subagent configurations that give Claude Code deep expertise in specific
+          domains — from database migrations and security audits to infrastructure
+          automation and data pipelines. Each agent includes the full configuration needed
+          to create specialized workflows. Browse by category or tag to find the right
+          agent for your task.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search agents..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <div>
-            <p className="text-sm text-muted-foreground mb-2">Categories</p>
-            <div className="flex flex-wrap gap-2">
-              <Badge
-                variant={selectedCategory === null ? "default" : "secondary"}
-                className={cn(
-                  "cursor-pointer hover:bg-primary/80",
-                  selectedCategory === null && "bg-primary"
-                )}
-                onClick={() => setSelectedCategory(null)}
-              >
-                All
-              </Badge>
-              {allCategories.map((category) => (
-                <Badge
-                  key={category}
-                  variant={selectedCategory === category ? "default" : "secondary"}
-                  className={cn(
-                    "cursor-pointer",
-                    selectedCategory === category
-                      ? "bg-primary hover:bg-primary/80"
-                      : "hover:bg-accent"
-                  )}
-                  onClick={() => setSelectedCategory(category === selectedCategory ? null : category)}
-                >
-                  {categoryLabels[category]}
-                </Badge>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <p className="text-sm text-muted-foreground mb-2">Tags</p>
-            <div className="flex flex-wrap gap-2">
-              <Badge
-                variant={selectedTag === null ? "default" : "secondary"}
-                className={cn(
-                  "cursor-pointer hover:bg-primary/80",
-                  selectedTag === null && "bg-primary"
-                )}
-                onClick={() => setSelectedTag(null)}
-              >
-                All
-              </Badge>
-              {allTags.map((tag) => (
-                <Badge
-                  key={tag}
-                  variant={selectedTag === tag ? "default" : "secondary"}
-                  className={cn(
-                    "cursor-pointer",
-                    selectedTag === tag
-                      ? "bg-primary hover:bg-primary/80"
-                      : "hover:bg-accent"
-                  )}
-                  onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-                >
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredAgents.map((agent) => (
-            <AgentCard key={agent.slug} agent={agent} />
-          ))}
-        </div>
-
-        {filteredAgents.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No agents found matching your criteria
-          </div>
-        )}
-      </div>
+      <AgentsListing />
     </div>
   );
 }

--- a/src/app/agents/topic/[tag]/page.tsx
+++ b/src/app/agents/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AgentCard } from "@/components/cards/agent-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllAgentTags, getAgentsByTag } from "@/data/agents";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllAgentTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getAgentsByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/agents/topic/${tag}`;
+  const title = `${displayName} Agents for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code agents tagged with "${tag}". Specialized subagent configurations for ${displayName}.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code agents`, `${tag} subagents`, "claude code", "agents"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function AgentTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getAgentsByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllAgentTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Agents", url: `${BASE_URL}/agents` },
+          { name: displayName, url: `${BASE_URL}/agents/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/agents">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Agents
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Agents for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "agent" : "agents"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((agent) => (
+          <AgentCard key={agent.slug} agent={agent} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/agents/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/_components/blog-listing.tsx
+++ b/src/app/blog/_components/blog-listing.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { BlogCard } from "@/components/cards/blog-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { blogPosts, getAllBlogPostTags } from "@/data/blog";
+
+export function BlogListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllBlogPostTags();
+
+  const filteredPosts = blogPosts.filter((post) => {
+    return (
+      search === "" ||
+      post.title.toLowerCase().includes(search.toLowerCase()) ||
+      post.description.toLowerCase().includes(search.toLowerCase()) ||
+      post.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search posts..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <span className="text-sm text-muted-foreground mr-2">Topic:</span>
+          {allTags.map((tag) => (
+            <Link key={tag} href={`/blog/topic/${tag}`}>
+              <Badge
+                variant="secondary"
+                className="cursor-pointer hover:bg-accent"
+              >
+                {tag}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredPosts.map((post) => (
+          <BlogCard key={post.slug} post={post} />
+        ))}
+      </div>
+
+      {filteredPosts.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No posts found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,92 +1,51 @@
-"use client";
+import type { Metadata } from "next";
+import { BlogListing } from "./_components/blog-listing";
 
-import { useState } from "react";
-import { BlogCard } from "@/components/cards/blog-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { blogPosts, getAllBlogPostTags } from "@/data/blog";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Claude Code Blog - Tips, Guides & Insights",
+  description:
+    "Read the latest news, guides, and insights about Claude Code and AI-assisted development. Practical tips, productivity workflows, deep dives into hooks and MCP servers, and more.",
+  keywords: [
+    "claude code blog",
+    "claude code tips",
+    "claude code guides",
+    "ai development blog",
+    "claude code tutorials",
+  ],
+  openGraph: {
+    title: "Claude Code Blog - Tips, Guides & Insights",
+    description:
+      "Read the latest news, guides, and insights about Claude Code and AI-assisted development.",
+    url: `${BASE_URL}/blog`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code Blog - Tips, Guides & Insights",
+    description:
+      "Read the latest news, guides, and insights about Claude Code and AI-assisted development.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/blog`,
+  },
+};
 
 export default function BlogPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllBlogPostTags();
-
-  const filteredPosts = blogPosts.filter((post) => {
-    const matchesSearch =
-      search === "" ||
-      post.title.toLowerCase().includes(search.toLowerCase()) ||
-      post.description.toLowerCase().includes(search.toLowerCase()) ||
-      post.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || post.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Blog</h1>
-        <p className="text-muted-foreground">
-          News, guides, and insights about Claude Code and the AI development ecosystem
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Blog</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Practical tips, deep dives into hooks and MCP servers, productivity workflows,
+          and analysis of the AI coding landscape. Written for developers who want to
+          ship better code faster with Claude Code. Browse by topic to find posts on
+          tutorials, best practices, developer tools, and more.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search posts..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            <span className="text-sm text-muted-foreground mr-2">Topic:</span>
-            <Badge
-              variant={selectedTag === null ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer hover:bg-primary/80",
-                selectedTag === null && "bg-primary"
-              )}
-              onClick={() => setSelectedTag(null)}
-            >
-              All
-            </Badge>
-            {allTags.map((tag) => (
-              <Badge
-                key={tag}
-                variant={selectedTag === tag ? "default" : "secondary"}
-                className={cn(
-                  "cursor-pointer",
-                  selectedTag === tag
-                    ? "bg-primary hover:bg-primary/80"
-                    : "hover:bg-accent"
-                )}
-                onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-              >
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredPosts.map((post) => (
-            <BlogCard key={post.slug} post={post} />
-          ))}
-        </div>
-
-        {filteredPosts.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No posts found matching your criteria
-          </div>
-        )}
-      </div>
+      <BlogListing />
     </div>
   );
 }

--- a/src/app/blog/topic/[tag]/page.tsx
+++ b/src/app/blog/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BlogCard } from "@/components/cards/blog-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllBlogPostTags, getBlogPostsByTag } from "@/data/blog";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllBlogPostTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getBlogPostsByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/blog/topic/${tag}`;
+  const title = `${displayName} - Claude Code Blog`;
+  const description = `Read ${tagItems.length} blog ${tagItems.length === 1 ? "post" : "posts"} about ${displayName}. Guides, tips, and insights for Claude Code developers.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code`, `${tag} guide`, "claude code", "blog"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function BlogTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getBlogPostsByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllBlogPostTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Blog", url: `${BASE_URL}/blog` },
+          { name: displayName, url: `${BASE_URL}/blog/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/blog">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Posts
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} - Claude Code Blog
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "post" : "posts"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((post) => (
+          <BlogCard key={post.slug} post={post} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/blog/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hooks/_components/hooks-listing.tsx
+++ b/src/app/hooks/_components/hooks-listing.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { HookCard } from "@/components/cards/hook-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { hooks, getAllHookTags } from "@/data/hooks";
+
+export function HooksListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllHookTags();
+
+  const filteredHooks = hooks.filter((hook) => {
+    return (
+      search === "" ||
+      hook.title.toLowerCase().includes(search.toLowerCase()) ||
+      hook.description.toLowerCase().includes(search.toLowerCase()) ||
+      hook.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search hooks..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <Link key={tag} href={`/hooks/topic/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredHooks.map((hook) => (
+          <HookCard key={hook.slug} hook={hook} />
+        ))}
+      </div>
+
+      {filteredHooks.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No hooks found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/hooks/page.tsx
+++ b/src/app/hooks/page.tsx
@@ -1,89 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { HooksListing } from "./_components/hooks-listing";
 
-import { useState } from "react";
-import { HookCard } from "@/components/cards/hook-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { hooks, getAllHookTags } from "@/data/hooks";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Claude Code Hooks Guide - Automate Your Workflow",
+  description:
+    "Explore Claude Code hooks to automate tasks and enforce project standards. Pre and post tool-use automation scripts for formatting, linting, testing, notifications, and more.",
+  keywords: [
+    "claude code hooks",
+    "claude code automation",
+    "PreToolUse hooks",
+    "PostToolUse hooks",
+    "claude code workflow",
+  ],
+  openGraph: {
+    title: "Claude Code Hooks Guide - Automate Your Workflow",
+    description:
+      "Explore Claude Code hooks to automate tasks and enforce project standards. Pre and post tool-use automation scripts for your development workflow.",
+    url: `${BASE_URL}/hooks`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code Hooks Guide - Automate Your Workflow",
+    description:
+      "Explore Claude Code hooks to automate tasks and enforce project standards.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/hooks`,
+  },
+};
 
 export default function HooksPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllHookTags();
-
-  const filteredHooks = hooks.filter((hook) => {
-    const matchesSearch =
-      search === "" ||
-      hook.title.toLowerCase().includes(search.toLowerCase()) ||
-      hook.description.toLowerCase().includes(search.toLowerCase()) ||
-      hook.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || hook.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Hooks</h1>
-        <p className="text-muted-foreground">
-          Automate workflows with pre and post tool-use hooks
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Hooks</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Shell scripts that run automatically before or after Claude Code uses a tool.
+          Use hooks to auto-format code, enforce linting, block risky file edits, run
+          tests, or send notifications — all without manual intervention. Supports
+          PreToolUse, PostToolUse, Notification, and Stop events. Each hook below
+          includes a ready-to-use script and configuration.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search hooks..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Badge
-            variant={selectedTag === null ? "default" : "secondary"}
-            className={cn(
-              "cursor-pointer hover:bg-primary/80",
-              selectedTag === null && "bg-primary"
-            )}
-            onClick={() => setSelectedTag(null)}
-          >
-            All
-          </Badge>
-          {allTags.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTag === tag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer",
-                selectedTag === tag
-                  ? "bg-primary hover:bg-primary/80"
-                  : "hover:bg-accent"
-              )}
-              onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredHooks.map((hook) => (
-            <HookCard key={hook.slug} hook={hook} />
-          ))}
-        </div>
-
-        {filteredHooks.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No hooks found matching your criteria
-          </div>
-        )}
-      </div>
+      <HooksListing />
     </div>
   );
 }

--- a/src/app/hooks/topic/[tag]/page.tsx
+++ b/src/app/hooks/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { HookCard } from "@/components/cards/hook-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllHookTags, getHooksByTag } from "@/data/hooks";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllHookTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getHooksByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/hooks/topic/${tag}`;
+  const title = `${displayName} Hooks for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code hooks tagged with "${tag}". Ready-to-use automation scripts for ${displayName}.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code hooks`, `${tag} automation`, "claude code", "hooks"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function HookTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getHooksByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllHookTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Hooks", url: `${BASE_URL}/hooks` },
+          { name: displayName, url: `${BASE_URL}/hooks/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/hooks">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Hooks
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Hooks for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "hook" : "hooks"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((hook) => (
+          <HookCard key={hook.slug} hook={hook} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/hooks/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/how-to/_components/how-to-listing.tsx
+++ b/src/app/how-to/_components/how-to-listing.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { HowToCard } from "@/components/cards/how-to-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { howTos, getAllHowToTags } from "@/data/how-to";
+import { cn } from "@/lib/utils";
+
+const difficulties = ["beginner", "intermediate", "advanced"] as const;
+
+export function HowToListing() {
+  const [search, setSearch] = useState("");
+  const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
+  const allTags = getAllHowToTags();
+
+  const filteredHowTos = howTos.filter((howTo) => {
+    const matchesSearch =
+      search === "" ||
+      howTo.title.toLowerCase().includes(search.toLowerCase()) ||
+      howTo.description.toLowerCase().includes(search.toLowerCase()) ||
+      howTo.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
+
+    const matchesDifficulty = selectedDifficulty === null || howTo.difficulty === selectedDifficulty;
+
+    return matchesSearch && matchesDifficulty;
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search guides..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <span className="text-sm text-muted-foreground mr-2">Difficulty:</span>
+          <Badge
+            variant={selectedDifficulty === null ? "default" : "secondary"}
+            className={cn(
+              "cursor-pointer hover:bg-primary/80",
+              selectedDifficulty === null && "bg-primary"
+            )}
+            onClick={() => setSelectedDifficulty(null)}
+          >
+            All
+          </Badge>
+          {difficulties.map((difficulty) => (
+            <Badge
+              key={difficulty}
+              variant={selectedDifficulty === difficulty ? "default" : "secondary"}
+              className={cn(
+                "cursor-pointer capitalize",
+                selectedDifficulty === difficulty
+                  ? "bg-primary hover:bg-primary/80"
+                  : "hover:bg-accent"
+              )}
+              onClick={() => setSelectedDifficulty(difficulty === selectedDifficulty ? null : difficulty)}
+            >
+              {difficulty}
+            </Badge>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <span className="text-sm text-muted-foreground mr-2">Topic:</span>
+          {allTags.map((tag) => (
+            <Link key={tag} href={`/how-to/topic/${tag}`}>
+              <Badge
+                variant="secondary"
+                className="cursor-pointer hover:bg-accent"
+              >
+                {tag}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredHowTos.map((howTo) => (
+          <HowToCard key={howTo.slug} howTo={howTo} />
+        ))}
+      </div>
+
+      {filteredHowTos.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No guides found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/how-to/page.tsx
+++ b/src/app/how-to/page.tsx
@@ -1,125 +1,51 @@
-"use client";
+import type { Metadata } from "next";
+import { HowToListing } from "./_components/how-to-listing";
 
-import { useState } from "react";
-import { HowToCard } from "@/components/cards/how-to-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { howTos, getAllHowToTags } from "@/data/how-to";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
 
-const difficulties = ["beginner", "intermediate", "advanced"] as const;
+export const metadata: Metadata = {
+  title: "Claude Code Tutorials & How-To Guides",
+  description:
+    "Learn how to use Claude Code with step-by-step tutorials. From setup and configuration to advanced workflows, automation patterns, and multi-agent orchestration. Guides for every skill level.",
+  keywords: [
+    "claude code tutorials",
+    "how to use claude code",
+    "claude code guides",
+    "claude code setup",
+    "claude code workflow",
+  ],
+  openGraph: {
+    title: "Claude Code Tutorials & How-To Guides",
+    description:
+      "Learn how to use Claude Code with step-by-step tutorials. Guides for every skill level from beginner to advanced.",
+    url: `${BASE_URL}/how-to`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code Tutorials & How-To Guides",
+    description:
+      "Learn how to use Claude Code with step-by-step tutorials. Guides for every skill level.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/how-to`,
+  },
+};
 
 export default function HowToPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
-  const allTags = getAllHowToTags();
-
-  const filteredHowTos = howTos.filter((howTo) => {
-    const matchesSearch =
-      search === "" ||
-      howTo.title.toLowerCase().includes(search.toLowerCase()) ||
-      howTo.description.toLowerCase().includes(search.toLowerCase()) ||
-      howTo.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || howTo.tags.includes(selectedTag);
-    const matchesDifficulty = selectedDifficulty === null || howTo.difficulty === selectedDifficulty;
-
-    return matchesSearch && matchesTag && matchesDifficulty;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">How To Guides</h1>
-        <p className="text-muted-foreground">
-          Learn how to get the most out of Claude Code with step-by-step tutorials
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">How To Guides</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Step-by-step tutorials covering everything from initial setup to advanced
+          workflows and multi-agent orchestration. Organized by difficulty — beginner,
+          intermediate, and advanced — with estimated completion times. Each guide walks
+          through real-world scenarios with clear instructions and examples.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search guides..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            <span className="text-sm text-muted-foreground mr-2">Difficulty:</span>
-            <Badge
-              variant={selectedDifficulty === null ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer hover:bg-primary/80",
-                selectedDifficulty === null && "bg-primary"
-              )}
-              onClick={() => setSelectedDifficulty(null)}
-            >
-              All
-            </Badge>
-            {difficulties.map((difficulty) => (
-              <Badge
-                key={difficulty}
-                variant={selectedDifficulty === difficulty ? "default" : "secondary"}
-                className={cn(
-                  "cursor-pointer capitalize",
-                  selectedDifficulty === difficulty
-                    ? "bg-primary hover:bg-primary/80"
-                    : "hover:bg-accent"
-                )}
-                onClick={() => setSelectedDifficulty(difficulty === selectedDifficulty ? null : difficulty)}
-              >
-                {difficulty}
-              </Badge>
-            ))}
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <span className="text-sm text-muted-foreground mr-2">Topic:</span>
-            <Badge
-              variant={selectedTag === null ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer hover:bg-primary/80",
-                selectedTag === null && "bg-primary"
-              )}
-              onClick={() => setSelectedTag(null)}
-            >
-              All
-            </Badge>
-            {allTags.map((tag) => (
-              <Badge
-                key={tag}
-                variant={selectedTag === tag ? "default" : "secondary"}
-                className={cn(
-                  "cursor-pointer",
-                  selectedTag === tag
-                    ? "bg-primary hover:bg-primary/80"
-                    : "hover:bg-accent"
-                )}
-                onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-              >
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredHowTos.map((howTo) => (
-            <HowToCard key={howTo.slug} howTo={howTo} />
-          ))}
-        </div>
-
-        {filteredHowTos.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No guides found matching your criteria
-          </div>
-        )}
-      </div>
+      <HowToListing />
     </div>
   );
 }

--- a/src/app/how-to/topic/[tag]/page.tsx
+++ b/src/app/how-to/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { HowToCard } from "@/components/cards/how-to-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllHowToTags, getHowTosByTag } from "@/data/how-to";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllHowToTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getHowTosByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/how-to/topic/${tag}`;
+  const title = `${displayName} Tutorials for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code ${tagItems.length === 1 ? "tutorial" : "tutorials"} about ${displayName}. Step-by-step guides and how-to articles.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code tutorial`, `${tag} guide`, "claude code", "how to"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function HowToTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getHowTosByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllHowToTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "How To Guides", url: `${BASE_URL}/how-to` },
+          { name: displayName, url: `${BASE_URL}/how-to/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/how-to">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Guides
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Tutorials for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "guide" : "guides"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((howTo) => (
+          <HowToCard key={howTo.slug} howTo={howTo} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/how-to/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/mcp-servers/_components/mcp-servers-listing.tsx
+++ b/src/app/mcp-servers/_components/mcp-servers-listing.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { MCPCard } from "@/components/cards/mcp-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { mcpServers, getAllMCPServerTags } from "@/data/mcp-servers";
+
+export function MCPServersListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllMCPServerTags();
+
+  const filteredServers = mcpServers.filter((server) => {
+    return (
+      search === "" ||
+      server.title.toLowerCase().includes(search.toLowerCase()) ||
+      server.description.toLowerCase().includes(search.toLowerCase()) ||
+      server.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search MCP servers..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <Link key={tag} href={`/mcp-servers/topic/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredServers.map((server) => (
+          <MCPCard key={server.slug} server={server} />
+        ))}
+      </div>
+
+      {filteredServers.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No MCP servers found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/mcp-servers/page.tsx
+++ b/src/app/mcp-servers/page.tsx
@@ -1,89 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { MCPServersListing } from "./_components/mcp-servers-listing";
 
-import { useState } from "react";
-import { MCPCard } from "@/components/cards/mcp-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { mcpServers, getAllMCPServerTags } from "@/data/mcp-servers";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Best MCP Servers for Claude Code",
+  description:
+    "Discover the best MCP servers for Claude Code. Connect to GitHub, databases, cloud platforms, and 60+ services with ready-to-use Model Context Protocol configurations.",
+  keywords: [
+    "mcp servers",
+    "claude code mcp",
+    "model context protocol",
+    "best mcp servers",
+    "claude code integrations",
+  ],
+  openGraph: {
+    title: "Best MCP Servers for Claude Code",
+    description:
+      "Discover the best MCP servers for Claude Code. Connect to GitHub, databases, cloud platforms, and 60+ services with ready-to-use Model Context Protocol configurations.",
+    url: `${BASE_URL}/mcp-servers`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Best MCP Servers for Claude Code",
+    description:
+      "Discover the best MCP servers for Claude Code. Connect to GitHub, databases, cloud platforms, and 60+ services.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/mcp-servers`,
+  },
+};
 
 export default function MCPServersPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllMCPServerTags();
-
-  const filteredServers = mcpServers.filter((server) => {
-    const matchesSearch =
-      search === "" ||
-      server.title.toLowerCase().includes(search.toLowerCase()) ||
-      server.description.toLowerCase().includes(search.toLowerCase()) ||
-      server.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || server.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">MCP Servers</h1>
-        <p className="text-muted-foreground">
-          Model Context Protocol servers to extend Claude Code capabilities
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">MCP Servers</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Model Context Protocol servers that connect Claude Code to databases, APIs,
+          cloud platforms, and development tools. Each listing includes a ready-to-paste
+          JSON configuration — add it to your settings, restart Claude Code, and the
+          integration is live. Browse 60+ servers for GitHub, Slack, PostgreSQL, AWS,
+          and more.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search MCP servers..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Badge
-            variant={selectedTag === null ? "default" : "secondary"}
-            className={cn(
-              "cursor-pointer hover:bg-primary/80",
-              selectedTag === null && "bg-primary"
-            )}
-            onClick={() => setSelectedTag(null)}
-          >
-            All
-          </Badge>
-          {allTags.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTag === tag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer",
-                selectedTag === tag
-                  ? "bg-primary hover:bg-primary/80"
-                  : "hover:bg-accent"
-              )}
-              onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredServers.map((server) => (
-            <MCPCard key={server.slug} server={server} />
-          ))}
-        </div>
-
-        {filteredServers.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No MCP servers found matching your criteria
-          </div>
-        )}
-      </div>
+      <MCPServersListing />
     </div>
   );
 }

--- a/src/app/mcp-servers/topic/[tag]/page.tsx
+++ b/src/app/mcp-servers/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { MCPCard } from "@/components/cards/mcp-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllMCPServerTags, getMCPServersByTag } from "@/data/mcp-servers";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllMCPServerTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getMCPServersByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/mcp-servers/topic/${tag}`;
+  const title = `${displayName} MCP Servers for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code MCP servers tagged with "${tag}". Ready-to-use Model Context Protocol configurations for ${displayName}.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} mcp server`, `${tag} claude code`, "mcp", "model context protocol"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function MCPServerTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getMCPServersByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllMCPServerTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "MCP Servers", url: `${BASE_URL}/mcp-servers` },
+          { name: displayName, url: `${BASE_URL}/mcp-servers/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/mcp-servers">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All MCP Servers
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} MCP Servers for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} MCP {tagItems.length === 1 ? "server" : "servers"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((server) => (
+          <MCPCard key={server.slug} server={server} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/mcp-servers/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/plugins/_components/plugins-listing.tsx
+++ b/src/app/plugins/_components/plugins-listing.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { PluginCard } from "@/components/cards/plugin-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { plugins, getAllPluginTags } from "@/data/plugins";
+
+export function PluginsListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllPluginTags();
+
+  const filteredPlugins = plugins.filter((plugin) => {
+    return (
+      search === "" ||
+      plugin.title.toLowerCase().includes(search.toLowerCase()) ||
+      plugin.description.toLowerCase().includes(search.toLowerCase()) ||
+      plugin.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search plugins..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <Link key={tag} href={`/plugins/topic/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredPlugins.map((plugin) => (
+          <PluginCard key={plugin.slug} plugin={plugin} />
+        ))}
+      </div>
+
+      {filteredPlugins.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No plugins found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/plugins/page.tsx
+++ b/src/app/plugins/page.tsx
@@ -1,89 +1,51 @@
-"use client";
+import type { Metadata } from "next";
+import { PluginsListing } from "./_components/plugins-listing";
 
-import { useState } from "react";
-import { PluginCard } from "@/components/cards/plugin-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { plugins, getAllPluginTags } from "@/data/plugins";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Best Claude Code Plugins - Extend Your AI Assistant",
+  description:
+    "Find the best Claude Code plugins to extend your AI coding assistant. Community-built and official plugins for frontend, backend, DevOps, security, and more. Install with a single command.",
+  keywords: [
+    "claude code plugins",
+    "extend claude code",
+    "claude code extensions",
+    "best claude code plugins",
+    "ai coding plugins",
+  ],
+  openGraph: {
+    title: "Best Claude Code Plugins - Extend Your AI Assistant",
+    description:
+      "Find the best Claude Code plugins to extend your AI coding assistant with community-built and official capabilities.",
+    url: `${BASE_URL}/plugins`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Best Claude Code Plugins - Extend Your AI Assistant",
+    description:
+      "Find the best Claude Code plugins to extend your AI coding assistant with community-built and official capabilities.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/plugins`,
+  },
+};
 
 export default function PluginsPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllPluginTags();
-
-  const filteredPlugins = plugins.filter((plugin) => {
-    const matchesSearch =
-      search === "" ||
-      plugin.title.toLowerCase().includes(search.toLowerCase()) ||
-      plugin.description.toLowerCase().includes(search.toLowerCase()) ||
-      plugin.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || plugin.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Plugins</h1>
-        <p className="text-muted-foreground">
-          Extend Claude Code with community and official plugins
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Plugins</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Installable packages that bundle MCP servers, hooks, skills, and configuration
+          to add entire workflows to Claude Code in a single command. Most plugins install
+          with npm or pip and integrate automatically. Browse community-built and official
+          plugins for frontend, backend, DevOps, security, and more.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search plugins..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Badge
-            variant={selectedTag === null ? "default" : "secondary"}
-            className={cn(
-              "cursor-pointer hover:bg-primary/80",
-              selectedTag === null && "bg-primary"
-            )}
-            onClick={() => setSelectedTag(null)}
-          >
-            All
-          </Badge>
-          {allTags.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTag === tag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer",
-                selectedTag === tag
-                  ? "bg-primary hover:bg-primary/80"
-                  : "hover:bg-accent"
-              )}
-              onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredPlugins.map((plugin) => (
-            <PluginCard key={plugin.slug} plugin={plugin} />
-          ))}
-        </div>
-
-        {filteredPlugins.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No plugins found matching your criteria
-          </div>
-        )}
-      </div>
+      <PluginsListing />
     </div>
   );
 }

--- a/src/app/plugins/topic/[tag]/page.tsx
+++ b/src/app/plugins/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PluginCard } from "@/components/cards/plugin-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllPluginTags, getPluginsByTag } from "@/data/plugins";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllPluginTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getPluginsByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/plugins/topic/${tag}`;
+  const title = `${displayName} Plugins for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code plugins tagged with "${tag}". Extend your AI assistant with ${displayName} capabilities.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code plugins`, `${tag} extensions`, "claude code", "plugins"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function PluginTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getPluginsByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllPluginTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Plugins", url: `${BASE_URL}/plugins` },
+          { name: displayName, url: `${BASE_URL}/plugins/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/plugins">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Plugins
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Plugins for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "plugin" : "plugins"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((plugin) => (
+          <PluginCard key={plugin.slug} plugin={plugin} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/plugins/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/prompts/_components/prompts-listing.tsx
+++ b/src/app/prompts/_components/prompts-listing.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { PromptCard } from "@/components/cards/prompt-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { prompts, getAllPromptTags } from "@/data/prompts";
+
+export function PromptsListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllPromptTags();
+
+  const filteredPrompts = prompts.filter((prompt) => {
+    return (
+      search === "" ||
+      prompt.title.toLowerCase().includes(search.toLowerCase()) ||
+      prompt.description.toLowerCase().includes(search.toLowerCase()) ||
+      prompt.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search prompts..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <Link key={tag} href={`/prompts/topic/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredPrompts.map((prompt) => (
+          <PromptCard key={prompt.slug} prompt={prompt} />
+        ))}
+      </div>
+
+      {filteredPrompts.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No prompts found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,89 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { PromptsListing } from "./_components/prompts-listing";
 
-import { useState } from "react";
-import { PromptCard } from "@/components/cards/prompt-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { prompts, getAllPromptTags } from "@/data/prompts";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Best Claude Code Prompts & CLAUDE.md Templates",
+  description:
+    "Find the best Claude Code prompts and CLAUDE.md templates for TypeScript, Python, React, Go, Rust, and more. Community-curated configurations to customize Claude Code for your projects.",
+  keywords: [
+    "claude code prompts",
+    "CLAUDE.md templates",
+    "best claude code prompts",
+    "claude code configuration",
+    "ai coding prompts",
+  ],
+  openGraph: {
+    title: "Best Claude Code Prompts & CLAUDE.md Templates",
+    description:
+      "Find the best Claude Code prompts and CLAUDE.md templates for TypeScript, Python, React, Go, Rust, and more.",
+    url: `${BASE_URL}/prompts`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Best Claude Code Prompts & CLAUDE.md Templates",
+    description:
+      "Find the best Claude Code prompts and CLAUDE.md templates for TypeScript, Python, React, Go, Rust, and more.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/prompts`,
+  },
+};
 
 export default function PromptsPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllPromptTags();
-
-  const filteredPrompts = prompts.filter((prompt) => {
-    const matchesSearch =
-      search === "" ||
-      prompt.title.toLowerCase().includes(search.toLowerCase()) ||
-      prompt.description.toLowerCase().includes(search.toLowerCase()) ||
-      prompt.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || prompt.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Prompts</h1>
-        <p className="text-muted-foreground">
-          CLAUDE.md templates to customize Claude Code for your projects
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Prompts</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Community-curated CLAUDE.md templates that give Claude Code deep understanding
+          of your tech stack. Drop one into your project root and Claude Code automatically
+          picks up your preferences for frameworks, linting, testing, and coding conventions.
+          Browse by language — TypeScript, Python, React, Go, Rust, and more — then
+          customize for your project.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search prompts..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Badge
-            variant={selectedTag === null ? "default" : "secondary"}
-            className={cn(
-              "cursor-pointer hover:bg-primary/80",
-              selectedTag === null && "bg-primary"
-            )}
-            onClick={() => setSelectedTag(null)}
-          >
-            All
-          </Badge>
-          {allTags.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTag === tag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer",
-                selectedTag === tag
-                  ? "bg-primary hover:bg-primary/80"
-                  : "hover:bg-accent"
-              )}
-              onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredPrompts.map((prompt) => (
-            <PromptCard key={prompt.slug} prompt={prompt} />
-          ))}
-        </div>
-
-        {filteredPrompts.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No prompts found matching your criteria
-          </div>
-        )}
-      </div>
+      <PromptsListing />
     </div>
   );
 }

--- a/src/app/prompts/topic/[tag]/page.tsx
+++ b/src/app/prompts/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PromptCard } from "@/components/cards/prompt-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { prompts, getAllPromptTags, getPromptsByTag } from "@/data/prompts";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllPromptTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getPromptsByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/prompts/topic/${tag}`;
+  const title = `${displayName} Prompts for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code CLAUDE.md prompts tagged with "${tag}". Find ready-to-use prompt templates for ${displayName} development.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code`, `${tag} prompts`, "claude code", "CLAUDE.md"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function PromptTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getPromptsByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllPromptTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Prompts", url: `${BASE_URL}/prompts` },
+          { name: displayName, url: `${BASE_URL}/prompts/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/prompts">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Prompts
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Prompts for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} CLAUDE.md {tagItems.length === 1 ? "template" : "templates"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((prompt) => (
+          <PromptCard key={prompt.slug} prompt={prompt} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/prompts/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/skills/_components/skills-listing.tsx
+++ b/src/app/skills/_components/skills-listing.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { SkillCard } from "@/components/cards/skill-card";
+import { Search } from "@/components/search";
+import { Badge } from "@/components/ui/badge";
+import { skills, getAllSkillTags } from "@/data/skills";
+
+export function SkillsListing() {
+  const [search, setSearch] = useState("");
+  const allTags = getAllSkillTags();
+
+  const filteredSkills = skills.filter((skill) => {
+    return (
+      search === "" ||
+      skill.title.toLowerCase().includes(search.toLowerCase()) ||
+      skill.description.toLowerCase().includes(search.toLowerCase()) ||
+      skill.tags.some((tag) =>
+        tag.toLowerCase().includes(search.toLowerCase())
+      )
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Search
+            placeholder="Search skills..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <Link key={tag} href={`/skills/topic/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              {tag}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredSkills.map((skill) => (
+          <SkillCard key={skill.slug} skill={skill} />
+        ))}
+      </div>
+
+      {filteredSkills.length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No skills found matching your criteria
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,89 +1,52 @@
-"use client";
+import type { Metadata } from "next";
+import { SkillsListing } from "./_components/skills-listing";
 
-import { useState } from "react";
-import { SkillCard } from "@/components/cards/skill-card";
-import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { skills, getAllSkillTags } from "@/data/skills";
-import { cn } from "@/lib/utils";
+const BASE_URL = "https://claudedirectory.org";
+
+export const metadata: Metadata = {
+  title: "Claude Code Skills & Custom Slash Commands",
+  description:
+    "Browse custom Claude Code skills and slash commands for code reviews, commit workflows, refactoring, test generation, and more. Add specialized workflows to your development environment.",
+  keywords: [
+    "claude code skills",
+    "claude code slash commands",
+    "claude code workflows",
+    "custom commands",
+    "claude code automation",
+  ],
+  openGraph: {
+    title: "Claude Code Skills & Custom Slash Commands",
+    description:
+      "Browse custom Claude Code skills and slash commands for code reviews, commit workflows, refactoring, and more.",
+    url: `${BASE_URL}/skills`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code Skills & Custom Slash Commands",
+    description:
+      "Browse custom Claude Code skills and slash commands for code reviews, commit workflows, and more.",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/skills`,
+  },
+};
 
 export default function SkillsPage() {
-  const [search, setSearch] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const allTags = getAllSkillTags();
-
-  const filteredSkills = skills.filter((skill) => {
-    const matchesSearch =
-      search === "" ||
-      skill.title.toLowerCase().includes(search.toLowerCase()) ||
-      skill.description.toLowerCase().includes(search.toLowerCase()) ||
-      skill.tags.some((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-
-    const matchesTag = selectedTag === null || skill.tags.includes(selectedTag);
-
-    return matchesSearch && matchesTag;
-  });
-
   return (
     <div className="container py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Skills</h1>
-        <p className="text-muted-foreground">
-          Custom slash commands and workflows for Claude Code
+      <div className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Skills</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Reusable slash commands that turn multi-step processes into a single action.
+          Add a skill file to .claude/commands/ and get instant access to custom workflows
+          for code reviews, commits, refactoring, test generation, and more. Each skill
+          below includes the prompt content ready to copy into your project or personal
+          commands folder.
         </p>
       </div>
 
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="w-full sm:max-w-xs">
-            <Search
-              placeholder="Search skills..."
-              value={search}
-              onChange={setSearch}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Badge
-            variant={selectedTag === null ? "default" : "secondary"}
-            className={cn(
-              "cursor-pointer hover:bg-primary/80",
-              selectedTag === null && "bg-primary"
-            )}
-            onClick={() => setSelectedTag(null)}
-          >
-            All
-          </Badge>
-          {allTags.map((tag) => (
-            <Badge
-              key={tag}
-              variant={selectedTag === tag ? "default" : "secondary"}
-              className={cn(
-                "cursor-pointer",
-                selectedTag === tag
-                  ? "bg-primary hover:bg-primary/80"
-                  : "hover:bg-accent"
-              )}
-              onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
-            >
-              {tag}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredSkills.map((skill) => (
-            <SkillCard key={skill.slug} skill={skill} />
-          ))}
-        </div>
-
-        {filteredSkills.length === 0 && (
-          <div className="text-center py-12 text-muted-foreground">
-            No skills found matching your criteria
-          </div>
-        )}
-      </div>
+      <SkillsListing />
     </div>
   );
 }

--- a/src/app/skills/topic/[tag]/page.tsx
+++ b/src/app/skills/topic/[tag]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { SkillCard } from "@/components/cards/skill-card";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { getAllSkillTags, getSkillsByTag } from "@/data/skills";
+import { formatTagName } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+const BASE_URL = "https://claudedirectory.org";
+
+interface Props {
+  params: Promise<{ tag: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllSkillTags().map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getSkillsByTag(tag);
+  if (tagItems.length === 0) return { title: "Topic Not Found" };
+
+  const displayName = formatTagName(tag);
+  const url = `${BASE_URL}/skills/topic/${tag}`;
+  const title = `${displayName} Skills for Claude Code`;
+  const description = `Browse ${tagItems.length} Claude Code skills tagged with "${tag}". Custom slash commands and workflows for ${displayName}.`;
+
+  return {
+    title,
+    description,
+    keywords: [tag, `${tag} claude code skills`, `${tag} slash commands`, "claude code", "skills"],
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+    },
+    twitter: {
+      card: "summary" as const,
+      title,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+  };
+}
+
+export default async function SkillTopicPage(props: Props) {
+  const { tag } = await props.params;
+  const tagItems = getSkillsByTag(tag);
+
+  if (tagItems.length === 0) {
+    notFound();
+  }
+
+  const allTags = getAllSkillTags();
+  const displayName = formatTagName(tag);
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Skills", url: `${BASE_URL}/skills` },
+          { name: displayName, url: `${BASE_URL}/skills/topic/${tag}` },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/skills">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to All Skills
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">
+          {displayName} Skills for Claude Code
+        </h1>
+        <p className="text-muted-foreground">
+          {tagItems.length} {tagItems.length === 1 ? "skill" : "skills"} tagged
+          with &ldquo;{tag}&rdquo;
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {tagItems.map((skill) => (
+          <SkillCard key={skill.slug} skill={skill} />
+        ))}
+      </div>
+
+      <div className="border-t pt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Browse more topics
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {allTags.map((t) => (
+            <Link key={t} href={`/skills/topic/${t}`}>
+              <Badge
+                variant={t === tag ? "default" : "secondary"}
+                className={t === tag ? "bg-primary" : "cursor-pointer hover:bg-accent"}
+              >
+                {t}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatTagName(tag: string): string {
+  return tag
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
Convert all 8 category listing pages from client-only components to server components with generateMetadata() for SEO. Extract interactive search/filter into separate client components. Turn tag badges into Link elements pointing to new /topic/[tag] routes, making every tag a crawlable, statically-generated page with its own metadata, breadcrumbs, and filtered item grid.