### PR TITLE
Fix 33 dead links and add 16 new content items

### DIFF
--- a/src/data/blog/best-claude-code-plugins.ts
+++ b/src/data/blog/best-claude-code-plugins.ts
@@ -437,5 +437,5 @@ The Claude Code plugin ecosystem is growing fast. A year ago there were a handfu
 
 The best way to stay current is to browse the [plugins directory](/plugins) and experiment. Install something, use it for a week, and keep what sticks. The plugins that save you time on day one will save you hundreds of hours over a year.
 
-If you're building your own plugin, check out the [Plugin Dev plugin](https://claudedirectory.com/plugins/plugin-dev) — yes, there's a plugin for building plugins. That's the ecosystem we're in now, and honestly, it's great.`,
+If you're building your own plugin, check out the [Plugin Dev plugin](https://www.claudedirectory.org/plugins/plugin-dev) — yes, there's a plugin for building plugins. That's the ecosystem we're in now, and honestly, it's great.`,
 };

--- a/src/data/mcp-servers/amplitude.ts
+++ b/src/data/mcp-servers/amplitude.ts
@@ -11,7 +11,7 @@ export const amplitudeServer: MCPServer = {
     name: "Amplitude",
     url: "https://amplitude.com",
   },
-  repoUrl: "https://github.com/amplitude/amplitude-mcp",
+  repoUrl: "https://amplitude.com/docs/apis",
   installCommand: "npm install -g @amplitude/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/apify.ts
+++ b/src/data/mcp-servers/apify.ts
@@ -1,0 +1,31 @@
+import { MCPServer } from "@/lib/types";
+
+export const apifyServer: MCPServer = {
+  slug: "apify",
+  title: "Apify",
+  description:
+    "Extract data from websites, social media, search engines, maps, and e-commerce using thousands of ready-made scrapers and actors",
+  tags: ["scraping", "apify", "automation", "data-extraction", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Apify",
+    url: "https://github.com/apify",
+  },
+  repoUrl: "https://github.com/apify/apify-mcp-server",
+  installCommand: "npx @apify/mcp-server",
+  config: `{
+  "mcpServers": {
+    "apify": {
+      "command": "npx",
+      "args": ["-y", "@apify/mcp-server"],
+      "env": {
+        "APIFY_TOKEN": "your-apify-api-token"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "firecrawl", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/axiom.ts
+++ b/src/data/mcp-servers/axiom.ts
@@ -1,0 +1,33 @@
+import { MCPServer } from "@/lib/types";
+
+export const axiomServer: MCPServer = {
+  slug: "axiom",
+  title: "Axiom",
+  description:
+    "Query and analyze Axiom logs, traces, and event data using natural language with APL (Axiom Processing Language)",
+  tags: ["observability", "axiom", "logs", "monitoring", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Axiom",
+    url: "https://github.com/axiomhq",
+  },
+  repoUrl: "https://github.com/axiomhq/mcp-server-axiom",
+  installCommand: "npx @axiomhq/mcp-server",
+  config: `{
+  "mcpServers": {
+    "axiom": {
+      "command": "npx",
+      "args": ["-y", "@axiomhq/mcp-server"],
+      "env": {
+        "AXIOM_TOKEN": "your-axiom-api-token",
+        "AXIOM_ORG_ID": "your-org-id"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "datadog", relationship: "works-with" },
+    { type: "mcp-server", slug: "grafana", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/azure.ts
+++ b/src/data/mcp-servers/azure.ts
@@ -11,7 +11,7 @@ export const azureServer: MCPServer = {
     name: "Microsoft",
     url: "https://github.com/microsoft",
   },
-  repoUrl: "https://github.com/microsoft/azure-mcp",
+  repoUrl: "https://github.com/Azure/azure-mcp",
   installCommand: "npm install -g @azure/mcp-server",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/brave-search.ts
+++ b/src/data/mcp-servers/brave-search.ts
@@ -10,7 +10,7 @@ export const braveSearchServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-brave-search",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/circleci.ts
+++ b/src/data/mcp-servers/circleci.ts
@@ -1,0 +1,28 @@
+import { MCPServer } from "@/lib/types";
+
+export const circleciServer: MCPServer = {
+  slug: "circleci",
+  title: "CircleCI",
+  description:
+    "Interact with CircleCI workflows, fix build failures, manage pipelines, and analyze CI/CD performance",
+  tags: ["cicd", "circleci", "devops", "automation", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "CircleCI",
+    url: "https://github.com/CircleCI-Public",
+  },
+  repoUrl: "https://github.com/CircleCI-Public/mcp-server-circleci",
+  installCommand: "npx @circleci/mcp-server-circleci",
+  config: `{
+  "mcpServers": {
+    "circleci": {
+      "command": "npx",
+      "args": ["-y", "@circleci/mcp-server-circleci"],
+      "env": {
+        "CIRCLECI_TOKEN": "your-circleci-token"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/github.ts
+++ b/src/data/mcp-servers/github.ts
@@ -7,10 +7,10 @@ export const githubServer: MCPServer = {
   tags: ["github", "git", "vcs", "official"],
   featured: true,
   author: {
-    name: "Anthropic",
-    url: "https://github.com/anthropics",
+    name: "GitHub",
+    url: "https://github.com/github",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
+  repoUrl: "https://github.com/github/github-mcp-server",
   installCommand: "npm install -g @anthropic-ai/mcp-server-github",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/gitlab.ts
+++ b/src/data/mcp-servers/gitlab.ts
@@ -1,0 +1,33 @@
+import { MCPServer } from "@/lib/types";
+
+export const gitlabServer: MCPServer = {
+  slug: "gitlab",
+  title: "GitLab",
+  description:
+    "Access GitLab project data, manage issues, merge requests, and CI/CD pipelines",
+  tags: ["gitlab", "git", "vcs", "cicd", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "zereight",
+    url: "https://github.com/zereight",
+  },
+  repoUrl: "https://github.com/zereight/gitlab-mcp",
+  installCommand: "npx gitlab-mcp",
+  config: `{
+  "mcpServers": {
+    "gitlab": {
+      "command": "npx",
+      "args": ["-y", "gitlab-mcp"],
+      "env": {
+        "GITLAB_TOKEN": "your-gitlab-token",
+        "GITLAB_URL": "https://gitlab.com"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "github", relationship: "works-with" },
+    { type: "plugin", slug: "gitlab", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/google-colab.ts
+++ b/src/data/mcp-servers/google-colab.ts
@@ -1,0 +1,28 @@
+import { MCPServer } from "@/lib/types";
+
+export const googleColabServer: MCPServer = {
+  slug: "google-colab",
+  title: "Google Colab",
+  description:
+    "Connect AI agents to Google Colab notebooks for running code, managing notebook cells, and executing data science workflows",
+  tags: ["google", "colab", "notebooks", "data-science", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Google Colab",
+    url: "https://github.com/googlecolab",
+  },
+  repoUrl: "https://github.com/googlecolab/colab-mcp",
+  installCommand: "pip install colab-mcp",
+  config: `{
+  "mcpServers": {
+    "google-colab": {
+      "command": "uvx",
+      "args": ["colab-mcp"],
+      "env": {
+        "GOOGLE_API_KEY": "your-google-api-key"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/google-drive.ts
+++ b/src/data/mcp-servers/google-drive.ts
@@ -10,7 +10,7 @@ export const googleDriveServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-gdrive",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/google-maps.ts
+++ b/src/data/mcp-servers/google-maps.ts
@@ -10,7 +10,7 @@ export const googleMapsServer: MCPServer = {
     name: "Google",
     url: "https://github.com/googleapis",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-google-maps",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -80,6 +80,18 @@ import { netlifyServer } from "./netlify";
 import { digitaloceanServer } from "./digitalocean";
 // Analytics
 import { amplitudeServer } from "./amplitude";
+// New additions
+import { mysqlServer } from "./mysql";
+import { gitlabServer } from "./gitlab";
+import { circleciServer } from "./circleci";
+import { qdrantServer } from "./qdrant";
+import { semgrepServer } from "./semgrep";
+import { tinybirdServer } from "./tinybird";
+import { axiomServer } from "./axiom";
+import { newrelicServer } from "./newrelic";
+import { trelloServer } from "./trello";
+import { googleColabServer } from "./google-colab";
+import { apifyServer } from "./apify";
 
 export const mcpServers: MCPServer[] = [
   // Featured servers first
@@ -177,6 +189,18 @@ export const mcpServers: MCPServer[] = [
   digitaloceanServer,
   // Product Analytics
   amplitudeServer,
+  // New additions
+  mysqlServer,
+  gitlabServer,
+  circleciServer,
+  qdrantServer,
+  semgrepServer,
+  tinybirdServer,
+  axiomServer,
+  newrelicServer,
+  trelloServer,
+  googleColabServer,
+  apifyServer,
 ];
 
 export function getMCPServerBySlug(slug: string): MCPServer | undefined {

--- a/src/data/mcp-servers/mysql.ts
+++ b/src/data/mcp-servers/mysql.ts
@@ -1,0 +1,35 @@
+import { MCPServer } from "@/lib/types";
+
+export const mysqlServer: MCPServer = {
+  slug: "mysql",
+  title: "MySQL",
+  description:
+    "Secure interaction with MySQL databases for queries, schema inspection, and data management",
+  tags: ["database", "mysql", "sql", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "designcomputer",
+    url: "https://github.com/designcomputer",
+  },
+  repoUrl: "https://github.com/designcomputer/mysql_mcp_server",
+  installCommand: "pip install mysql-mcp-server",
+  config: `{
+  "mcpServers": {
+    "mysql": {
+      "command": "uvx",
+      "args": ["mysql-mcp-server"],
+      "env": {
+        "MYSQL_HOST": "localhost",
+        "MYSQL_PORT": "3306",
+        "MYSQL_USER": "your-username",
+        "MYSQL_PASSWORD": "your-password",
+        "MYSQL_DATABASE": "your-database"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "postgres", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/newrelic.ts
+++ b/src/data/mcp-servers/newrelic.ts
@@ -1,0 +1,33 @@
+import { MCPServer } from "@/lib/types";
+
+export const newrelicServer: MCPServer = {
+  slug: "newrelic",
+  title: "New Relic",
+  description:
+    "Query telemetry data, investigate alerts, analyze application performance, and manage dashboards in New Relic",
+  tags: ["monitoring", "newrelic", "apm", "observability", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "New Relic",
+    url: "https://github.com/newrelic",
+  },
+  repoUrl: "https://github.com/newrelic/mcp-server",
+  installCommand: "npx @newrelic/mcp-server",
+  config: `{
+  "mcpServers": {
+    "newrelic": {
+      "command": "npx",
+      "args": ["-y", "@newrelic/mcp-server"],
+      "env": {
+        "NEW_RELIC_API_KEY": "your-new-relic-api-key",
+        "NEW_RELIC_ACCOUNT_ID": "your-account-id"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "datadog", relationship: "works-with" },
+    { type: "mcp-server", slug: "grafana", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/postgres.ts
+++ b/src/data/mcp-servers/postgres.ts
@@ -9,7 +9,7 @@ export const postgresServer: MCPServer = {
   author: {
     name: "MCP Community",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @modelcontextprotocol/server-postgres",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/puppeteer.ts
+++ b/src/data/mcp-servers/puppeteer.ts
@@ -8,7 +8,7 @@ export const puppeteerServer: MCPServer = {
   author: {
     name: "MCP Community",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-puppeteer",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/qdrant.ts
+++ b/src/data/mcp-servers/qdrant.ts
@@ -1,0 +1,34 @@
+import { MCPServer } from "@/lib/types";
+
+export const qdrantServer: MCPServer = {
+  slug: "qdrant",
+  title: "Qdrant",
+  description:
+    "Vector search engine acting as a semantic memory layer for storing and retrieving information using natural language",
+  tags: ["vector-database", "qdrant", "embeddings", "search", "ai"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Qdrant",
+    url: "https://github.com/qdrant",
+  },
+  repoUrl: "https://github.com/qdrant/mcp-server-qdrant",
+  installCommand: "pip install mcp-server-qdrant",
+  config: `{
+  "mcpServers": {
+    "qdrant": {
+      "command": "uvx",
+      "args": ["mcp-server-qdrant"],
+      "env": {
+        "QDRANT_URL": "http://localhost:6333",
+        "QDRANT_API_KEY": "your-qdrant-api-key",
+        "COLLECTION_NAME": "claude-memory"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "pinecone", relationship: "works-with" },
+    { type: "mcp-server", slug: "chromadb", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/resend.ts
+++ b/src/data/mcp-servers/resend.ts
@@ -10,7 +10,7 @@ export const resendServer: MCPServer = {
     name: "Resend",
     url: "https://github.com/resend",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/resend",
+  repoUrl: "https://github.com/resend/resend-mcp",
   installCommand: "npm install -g @anthropic-ai/mcp-server-resend",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/semgrep.ts
+++ b/src/data/mcp-servers/semgrep.ts
@@ -1,0 +1,28 @@
+import { MCPServer } from "@/lib/types";
+
+export const semgrepServer: MCPServer = {
+  slug: "semgrep",
+  title: "Semgrep",
+  description:
+    "Scan code for security vulnerabilities, bugs, and anti-patterns using Semgrep static analysis rules",
+  tags: ["security", "semgrep", "static-analysis", "sast", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Semgrep",
+    url: "https://github.com/semgrep",
+  },
+  repoUrl: "https://github.com/semgrep/mcp",
+  installCommand: "npx @semgrep/mcp",
+  config: `{
+  "mcpServers": {
+    "semgrep": {
+      "command": "npx",
+      "args": ["-y", "@semgrep/mcp"],
+      "env": {
+        "SEMGREP_APP_TOKEN": "your-semgrep-token"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/sentry.ts
+++ b/src/data/mcp-servers/sentry.ts
@@ -7,10 +7,10 @@ export const sentryServer: MCPServer = {
   tags: ["sentry", "errors", "monitoring", "debugging", "official"],
   featured: false,
   author: {
-    name: "Anthropic",
-    url: "https://github.com/anthropics",
+    name: "Sentry",
+    url: "https://github.com/getsentry",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sentry",
+  repoUrl: "https://github.com/getsentry/sentry-mcp",
   installCommand: "npm install -g @anthropic-ai/mcp-server-sentry",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/slack.ts
+++ b/src/data/mcp-servers/slack.ts
@@ -10,7 +10,7 @@ export const slackServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-slack",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/sqlite.ts
+++ b/src/data/mcp-servers/sqlite.ts
@@ -10,7 +10,7 @@ export const sqliteServer: MCPServer = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite",
+  repoUrl: "https://github.com/modelcontextprotocol/servers",
   installCommand: "npm install -g @anthropic-ai/mcp-server-sqlite",
   config: `{
   "mcpServers": {

--- a/src/data/mcp-servers/tinybird.ts
+++ b/src/data/mcp-servers/tinybird.ts
@@ -1,0 +1,31 @@
+import { MCPServer } from "@/lib/types";
+
+export const tinybirdServer: MCPServer = {
+  slug: "tinybird",
+  title: "Tinybird",
+  description:
+    "Connect to Tinybird for real-time analytics, query data sources, create API endpoints, and manage your analytics workspace",
+  tags: ["analytics", "tinybird", "real-time", "data", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Tinybird",
+    url: "https://github.com/tinybirdco",
+  },
+  repoUrl: "https://github.com/tinybirdco/mcp-tinybird",
+  installCommand: "npx @tinybirdco/mcp-tinybird",
+  config: `{
+  "mcpServers": {
+    "tinybird": {
+      "command": "npx",
+      "args": ["-y", "@tinybirdco/mcp-tinybird"],
+      "env": {
+        "TINYBIRD_TOKEN": "your-tinybird-admin-token"
+      }
+    }
+  }
+}`,
+  relatedItems: [
+    { type: "mcp-server", slug: "bigquery", relationship: "works-with" },
+  ],
+};

--- a/src/data/mcp-servers/trello.ts
+++ b/src/data/mcp-servers/trello.ts
@@ -1,0 +1,29 @@
+import { MCPServer } from "@/lib/types";
+
+export const trelloServer: MCPServer = {
+  slug: "trello",
+  title: "Trello",
+  description:
+    "Interact with Trello boards, lists, and cards for project management and task tracking",
+  tags: ["trello", "project-management", "kanban", "community"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "delorenj",
+    url: "https://github.com/delorenj",
+  },
+  repoUrl: "https://github.com/delorenj/mcp-server-trello",
+  installCommand: "npx mcp-server-trello",
+  config: `{
+  "mcpServers": {
+    "trello": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-trello"],
+      "env": {
+        "TRELLO_API_KEY": "your-trello-api-key",
+        "TRELLO_TOKEN": "your-trello-token"
+      }
+    }
+  }
+}`,
+};

--- a/src/data/plugins/aws.ts
+++ b/src/data/plugins/aws.ts
@@ -10,7 +10,7 @@ export const awsPlugin: Plugin = {
     name: "Amazon",
     url: "https://aws.amazon.com",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/aws",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add aws@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/chrome-devtools.ts
+++ b/src/data/plugins/chrome-devtools.ts
@@ -11,7 +11,7 @@ export const chromeDevtoolsPlugin: Plugin = {
     name: "Google",
     url: "https://developer.chrome.com/docs/devtools",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/chrome-devtools",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add chrome-devtools@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/clangd-lsp.ts
+++ b/src/data/plugins/clangd-lsp.ts
@@ -10,7 +10,7 @@ export const clangdLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/clangd-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add clangd-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/csharp-lsp.ts
+++ b/src/data/plugins/csharp-lsp.ts
@@ -10,7 +10,7 @@ export const csharpLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/csharp-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add csharp-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/datadog.ts
+++ b/src/data/plugins/datadog.ts
@@ -10,7 +10,7 @@ export const datadogPlugin: Plugin = {
     name: "Datadog",
     url: "https://datadoghq.com",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/datadog",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add datadog@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/docker.ts
+++ b/src/data/plugins/docker.ts
@@ -10,7 +10,7 @@ export const dockerPlugin: Plugin = {
     name: "Docker",
     url: "https://docker.com",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/docker",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add docker@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/figma.ts
+++ b/src/data/plugins/figma.ts
@@ -10,7 +10,7 @@ export const figmaPlugin: Plugin = {
     name: "Figma",
     url: "https://figma.com",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/figma",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add figma@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/gopls-lsp.ts
+++ b/src/data/plugins/gopls-lsp.ts
@@ -10,7 +10,7 @@ export const goplsLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/gopls-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add gopls-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/jdtls-lsp.ts
+++ b/src/data/plugins/jdtls-lsp.ts
@@ -10,7 +10,7 @@ export const jdtlsLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/jdtls-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add jdtls-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/jira.ts
+++ b/src/data/plugins/jira.ts
@@ -10,7 +10,7 @@ export const jiraPlugin: Plugin = {
     name: "Atlassian",
     url: "https://www.atlassian.com/software/jira",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/jira",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add jira@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/netlify-plugin.ts
+++ b/src/data/plugins/netlify-plugin.ts
@@ -11,7 +11,7 @@ export const netlifyPlugin: Plugin = {
     name: "Netlify",
     url: "https://github.com/netlify",
   },
-  repoUrl: "https://github.com/netlify/netlify-claude-plugin",
+  repoUrl: "https://github.com/netlify/netlify-mcp",
   installCommand: "claude plugins add netlify",
   commands: [
     {

--- a/src/data/plugins/notion.ts
+++ b/src/data/plugins/notion.ts
@@ -10,7 +10,7 @@ export const notionPlugin: Plugin = {
     name: "Notion",
     url: "https://notion.so",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/notion",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add notion@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/php-lsp.ts
+++ b/src/data/plugins/php-lsp.ts
@@ -10,7 +10,7 @@ export const phpLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/php-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add php-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/prisma.ts
+++ b/src/data/plugins/prisma.ts
@@ -10,7 +10,7 @@ export const prismaPlugin: Plugin = {
     name: "Prisma",
     url: "https://prisma.io",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/prisma",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add prisma@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/pyright-lsp.ts
+++ b/src/data/plugins/pyright-lsp.ts
@@ -10,7 +10,7 @@ export const pyrightLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/pyright-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add pyright-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/rust-analyzer-lsp.ts
+++ b/src/data/plugins/rust-analyzer-lsp.ts
@@ -10,7 +10,7 @@ export const rustAnalyzerLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/rust-analyzer-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add rust-analyzer-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/sentry.ts
+++ b/src/data/plugins/sentry.ts
@@ -10,7 +10,7 @@ export const sentryPlugin: Plugin = {
     name: "Sentry",
     url: "https://sentry.io",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/sentry",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add sentry@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/stripe.ts
+++ b/src/data/plugins/stripe.ts
@@ -16,7 +16,7 @@ export const stripePlugin: Plugin = {
     "stripe@claude-plugins-official": true
   }
 }`,
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/stripe",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   commands: [
     { name: "/stripe-test", description: "Test Stripe integration with test mode" },
     { name: "/stripe-webhook", description: "Set up and verify webhook handlers" },

--- a/src/data/plugins/typescript-lsp.ts
+++ b/src/data/plugins/typescript-lsp.ts
@@ -10,7 +10,7 @@ export const typescriptLspPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/lsp_plugins/typescript-lsp",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add typescript-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/plugins/vercel.ts
+++ b/src/data/plugins/vercel.ts
@@ -10,7 +10,7 @@ export const vercelPlugin: Plugin = {
     name: "Vercel",
     url: "https://vercel.com",
   },
-  repoUrl: "https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/vercel",
+  repoUrl: "https://github.com/anthropics/claude-plugins-official",
   installCommand: "claude plugins add vercel@claude-plugins-official",
   config: `{
   "enabledPlugins": {

--- a/src/data/prompts/angular.ts
+++ b/src/data/prompts/angular.ts
@@ -1,0 +1,50 @@
+import { Prompt } from "@/lib/types";
+
+export const angularPrompt: Prompt = {
+  slug: "angular",
+  title: "Angular Development",
+  description: "CLAUDE.md for Angular enterprise applications with Signals and standalone components",
+  tags: ["angular", "typescript", "frontend", "enterprise"],
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Angular Project
+
+This is an Angular project using standalone components and Signals for reactivity.
+
+## Project Structure
+- \`src/app/\` - Application source code
+- \`src/app/components/\` - Shared/reusable components
+- \`src/app/pages/\` - Route-level page components
+- \`src/app/services/\` - Injectable services
+- \`src/app/models/\` - TypeScript interfaces and types
+- \`src/app/guards/\` - Route guards
+- \`src/app/interceptors/\` - HTTP interceptors
+- \`src/app/pipes/\` - Custom pipes
+- \`src/app/directives/\` - Custom directives
+- \`src/environments/\` - Environment configurations
+
+## Code Style
+- Use standalone components (no NgModules for new code)
+- Use Angular Signals for state management
+- Use strict TypeScript settings
+- Follow Angular style guide (angular.dev)
+- Use OnPush change detection strategy
+
+## Conventions
+- Use \`inject()\` function instead of constructor injection
+- Prefer \`signal()\`, \`computed()\`, and \`effect()\` for reactivity
+- Use \`@defer\` blocks for lazy loading
+- Use typed reactive forms (\`FormGroup<T>\`)
+- Prefix services with their domain (e.g., AuthService, UserService)
+- Use barrel exports (index.ts) for feature directories
+
+## Commands
+- \`ng serve\` - Start development server
+- \`ng build\` - Build for production
+- \`ng test\` - Run unit tests with Karma
+- \`ng lint\` - Run ESLint
+- \`ng generate component <name>\` - Generate new component
+`,
+};

--- a/src/data/prompts/astro.ts
+++ b/src/data/prompts/astro.ts
@@ -1,0 +1,48 @@
+import { Prompt } from "@/lib/types";
+
+export const astroPrompt: Prompt = {
+  slug: "astro",
+  title: "Astro Development",
+  description: "CLAUDE.md for Astro content-driven websites with island architecture",
+  tags: ["astro", "static-site", "frontend", "content", "javascript"],
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Astro Project
+
+This is an Astro project using content collections and island architecture for minimal client-side JavaScript.
+
+## Project Structure
+- \`src/pages/\` - File-based routing (.astro, .md, .mdx)
+- \`src/layouts/\` - Page layout components
+- \`src/components/\` - Reusable Astro and framework components
+- \`src/content/\` - Content collections (Markdown/MDX)
+- \`src/content/config.ts\` - Content collection schemas
+- \`src/styles/\` - Global styles
+- \`public/\` - Static assets (served as-is)
+- \`astro.config.mjs\` - Astro configuration
+
+## Code Style
+- Use .astro components for static content (zero JS by default)
+- Use framework components (React/Vue/Svelte) only for interactive islands
+- Use TypeScript for type safety
+- Use content collections for structured content
+- Keep client-side JavaScript minimal
+
+## Conventions
+- Use \`client:load\` for interactive components that need JS immediately
+- Use \`client:visible\` for components below the fold
+- Use \`client:idle\` for low-priority interactive components
+- Define content schemas with Zod in \`content/config.ts\`
+- Use \`getCollection()\` and \`getEntry()\` for content queries
+- Prefer Astro components over framework components when possible
+
+## Commands
+- \`npm run dev\` - Start development server
+- \`npm run build\` - Build for production
+- \`npm run preview\` - Preview production build
+- \`npx astro check\` - Run type checking
+- \`npx astro add <integration>\` - Add an integration
+`,
+};

--- a/src/data/prompts/django.ts
+++ b/src/data/prompts/django.ts
@@ -1,0 +1,51 @@
+import { Prompt } from "@/lib/types";
+
+export const djangoPrompt: Prompt = {
+  slug: "django",
+  title: "Django Development",
+  description: "CLAUDE.md for Django web applications with REST framework and modern Python patterns",
+  tags: ["django", "python", "backend", "rest-api", "web"],
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Django Project
+
+This is a Django project using Django REST Framework for API development.
+
+## Project Structure
+- \`manage.py\` - Django management script
+- \`config/\` - Project settings and root URL config
+- \`apps/\` - Django applications
+- \`apps/<name>/models.py\` - Database models
+- \`apps/<name>/views.py\` - Views and viewsets
+- \`apps/<name>/serializers.py\` - DRF serializers
+- \`apps/<name>/urls.py\` - URL routing
+- \`apps/<name>/tests/\` - App-level tests
+- \`templates/\` - Django templates
+- \`static/\` - Static files
+
+## Code Style
+- Follow PEP 8 and Django coding style
+- Use type hints for function signatures
+- Use class-based views for complex logic, function-based for simple endpoints
+- Keep models lean, use managers and querysets for complex queries
+- Write docstrings for models, views, and utility functions
+
+## Conventions
+- Use Django ORM for all database operations (no raw SQL unless necessary)
+- Use DRF serializers for input validation and output formatting
+- Use Django signals sparingly, prefer explicit service functions
+- Use \`select_related()\` and \`prefetch_related()\` to avoid N+1 queries
+- Use environment variables for secrets (django-environ)
+- Use Django migrations for all schema changes
+
+## Commands
+- \`python manage.py runserver\` - Start development server
+- \`python manage.py test\` - Run tests
+- \`python manage.py makemigrations\` - Create new migrations
+- \`python manage.py migrate\` - Apply migrations
+- \`python manage.py shell_plus\` - Enhanced Django shell
+- \`ruff check .\` - Run linter
+`,
+};

--- a/src/data/prompts/flutter.ts
+++ b/src/data/prompts/flutter.ts
@@ -1,0 +1,51 @@
+import { Prompt } from "@/lib/types";
+
+export const flutterPrompt: Prompt = {
+  slug: "flutter",
+  title: "Flutter & Dart Development",
+  description: "CLAUDE.md for Flutter and Dart cross-platform mobile and web apps",
+  tags: ["flutter", "dart", "mobile", "cross-platform", "android", "ios"],
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Flutter Project
+
+This is a Flutter project using Dart for cross-platform mobile and web development.
+
+## Project Structure
+- \`lib/\` - Main Dart source code
+- \`lib/main.dart\` - App entry point
+- \`lib/screens/\` - Screen/page widgets
+- \`lib/widgets/\` - Reusable widget components
+- \`lib/models/\` - Data models
+- \`lib/services/\` - API services and business logic
+- \`lib/providers/\` - State management (Riverpod/Provider)
+- \`lib/utils/\` - Helper functions and constants
+- \`test/\` - Unit and widget tests
+- \`integration_test/\` - Integration tests
+
+## Code Style
+- Follow official Dart style guide and \`dart analyze\` rules
+- Use \`const\` constructors wherever possible
+- Prefer composition over inheritance for widgets
+- Keep widgets small and single-purpose
+- Use named parameters for widget constructors
+
+## Conventions
+- Use PascalCase for classes and enums
+- Use camelCase for variables, functions, and parameters
+- Use snake_case for file names
+- Prefix private members with underscore
+- Use Riverpod or Provider for state management
+- Use \`go_router\` for navigation
+
+## Commands
+- \`flutter run\` - Run on connected device or emulator
+- \`flutter build apk\` - Build Android APK
+- \`flutter build ios\` - Build iOS app
+- \`flutter test\` - Run all tests
+- \`dart analyze\` - Run static analysis
+- \`dart format .\` - Format all Dart files
+`,
+};

--- a/src/data/prompts/index.ts
+++ b/src/data/prompts/index.ts
@@ -12,6 +12,11 @@ import { swiftPrompt } from "./swift";
 import { laravelPrompt } from "./laravel";
 import { csharpDotnetPrompt } from "./csharp-dotnet";
 import { kotlinAndroidPrompt } from "./kotlin-android";
+import { flutterPrompt } from "./flutter";
+import { angularPrompt } from "./angular";
+import { djangoPrompt } from "./django";
+import { sveltekitPrompt } from "./sveltekit";
+import { astroPrompt } from "./astro";
 
 export const prompts: Prompt[] = [
   nextjsPrompt,
@@ -27,6 +32,11 @@ export const prompts: Prompt[] = [
   laravelPrompt,
   csharpDotnetPrompt,
   kotlinAndroidPrompt,
+  flutterPrompt,
+  angularPrompt,
+  djangoPrompt,
+  sveltekitPrompt,
+  astroPrompt,
 ];
 
 export function getPromptBySlug(slug: string): Prompt | undefined {

--- a/src/data/prompts/sveltekit.ts
+++ b/src/data/prompts/sveltekit.ts
@@ -1,0 +1,49 @@
+import { Prompt } from "@/lib/types";
+
+export const sveltekitPrompt: Prompt = {
+  slug: "sveltekit",
+  title: "SvelteKit Development",
+  description: "CLAUDE.md for SvelteKit full-stack applications with Svelte 5 runes",
+  tags: ["svelte", "sveltekit", "frontend", "fullstack", "javascript"],
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# SvelteKit Project
+
+This is a SvelteKit project using Svelte 5 runes and file-based routing.
+
+## Project Structure
+- \`src/routes/\` - File-based routing (pages and API endpoints)
+- \`src/routes/+page.svelte\` - Page components
+- \`src/routes/+page.server.ts\` - Server-side load functions
+- \`src/routes/+server.ts\` - API endpoints
+- \`src/lib/\` - Shared library code (\`$lib\` alias)
+- \`src/lib/components/\` - Reusable Svelte components
+- \`src/lib/server/\` - Server-only modules
+- \`static/\` - Static assets
+- \`tests/\` - Playwright and Vitest tests
+
+## Code Style
+- Use Svelte 5 runes (\`$state\`, \`$derived\`, \`$effect\`, \`$props\`)
+- Use TypeScript for type safety
+- Keep components small and composable
+- Use \`+page.server.ts\` for data loading, not client-side fetching
+- Use form actions for mutations
+
+## Conventions
+- Use \`$state()\` for reactive state, \`$derived()\` for computed values
+- Use \`$props()\` to declare component props
+- Prefer \`+server.ts\` API routes over external API calls
+- Use \`$lib\` alias for imports from lib directory
+- Use SvelteKit's built-in form handling for progressive enhancement
+- Colocate related files in route directories
+
+## Commands
+- \`npm run dev\` - Start development server
+- \`npm run build\` - Build for production
+- \`npm run preview\` - Preview production build
+- \`npm run test\` - Run Vitest tests
+- \`npm run lint\` - Run ESLint and svelte-check
+`,
+};


### PR DESCRIPTION
Update broken repo URLs for MCP servers (github, sentry, resend, azure, amplitude, and 7 monorepo paths), 19 plugin subdirectory links, and 1 wrong domain in blog post. Add 11 new MCP servers (MySQL, GitLab, CircleCI, Qdrant, Semgrep, Tinybird, Axiom, New Relic, Trello, Google Colab, Apify) and 5 new prompt templates (Flutter, Angular, Django, SvelteKit, Astro).