### PR TITLE
Switch canonical URL from www to non-www to match Google's preferred …

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,4 +3,4 @@ User-agent: *
 Allow: /
 
 # Sitemap
-Sitemap: https://www.claudedirectory.org/sitemap.xml
+Sitemap: https://claudedirectory.org/sitemap.xml

--- a/src/data/blog/best-claude-code-plugins.ts
+++ b/src/data/blog/best-claude-code-plugins.ts
@@ -437,5 +437,5 @@ The Claude Code plugin ecosystem is growing fast. A year ago there were a handfu
 
 The best way to stay current is to browse the [plugins directory](/plugins) and experiment. Install something, use it for a week, and keep what sticks. The plugins that save you time on day one will save you hundreds of hours over a year.
 
-If you're building your own plugin, check out the [Plugin Dev plugin](https://www.claudedirectory.org/plugins/plugin-dev) — yes, there's a plugin for building plugins. That's the ecosystem we're in now, and honestly, it's great.`,
+If you're building your own plugin, check out the [Plugin Dev plugin](https://claudedirectory.org/plugins/plugin-dev) — yes, there's a plugin for building plugins. That's the ecosystem we're in now, and honestly, it's great.`,
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = "https://www.claudedirectory.org";
+export const BASE_URL = "https://claudedirectory.org";


### PR DESCRIPTION
…canonical

Google Search Console flagged "Duplicate, Google chose different canonical than user" because the site declared www.claudedirectory.org as canonical while Google preferred claudedirectory.org. Updates BASE_URL constant, robots.txt sitemap reference, and one hardcoded blog link.