### PR TITLE
Fix 213 Google Search Console 404s caused by URL extraction from rend…

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -235,7 +235,25 @@ export default async function BlogPostPage(props: Props) {
                   />
                 );
               },
-              pre({ children }) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              pre({ children, node }: any) {
+                const codeChild = node?.children?.find(
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (child: any) => child.type === "element" && child.tagName === "code"
+                );
+                if (codeChild) {
+                  const cls = (codeChild.properties?.className as string[] | undefined)?.[0] || "";
+                  const langMatch = /language-(\w+)/.exec(cls);
+                  if (!langMatch) {
+                    const text = codeChild.children
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      ?.filter((c: any) => c.type === "text")
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      .map((c: any) => c.value)
+                      .join("") || "";
+                    return <CodeBlock code={text.replace(/\n$/, "")} language="text" />;
+                  }
+                }
                 return <>{children}</>;
               },
               h1({ children }) {

--- a/src/app/hooks/[slug]/page.tsx
+++ b/src/app/hooks/[slug]/page.tsx
@@ -160,9 +160,9 @@ export default async function HookDetailPage(props: Props) {
         <div className="bg-accent/50 rounded-lg p-4">
           <h3 className="font-semibold mb-2">How to use</h3>
           <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
-            <li>Create a hooks directory in your project: mkdir hooks</li>
-            <li>Save the hook script as hooks/{hook.slug}.sh</li>
-            <li>Make it executable: chmod +x hooks/{hook.slug}.sh</li>
+            <li>Create a hooks directory in your project: <code className="bg-muted px-1.5 py-0.5 rounded text-xs">mkdir hooks</code></li>
+            <li>Save the hook script as <code className="bg-muted px-1.5 py-0.5 rounded text-xs">hooks/{hook.slug}.sh</code></li>
+            <li>Make it executable: <code className="bg-muted px-1.5 py-0.5 rounded text-xs">chmod +x hooks/{hook.slug}.sh</code></li>
             <li>Add the configuration to your Claude Code settings</li>
             <li>Restart Claude Code to apply changes</li>
           </ol>

--- a/src/app/how-to/[slug]/page.tsx
+++ b/src/app/how-to/[slug]/page.tsx
@@ -167,7 +167,25 @@ export default async function HowToDetailPage(props: Props) {
                   />
                 );
               },
-              pre({ children }) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              pre({ children, node }: any) {
+                const codeChild = node?.children?.find(
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (child: any) => child.type === "element" && child.tagName === "code"
+                );
+                if (codeChild) {
+                  const cls = (codeChild.properties?.className as string[] | undefined)?.[0] || "";
+                  const langMatch = /language-(\w+)/.exec(cls);
+                  if (!langMatch) {
+                    const text = codeChild.children
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      ?.filter((c: any) => c.type === "text")
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      .map((c: any) => c.value)
+                      .join("") || "";
+                    return <CodeBlock code={text.replace(/\n$/, "")} language="text" />;
+                  }
+                }
                 return <>{children}</>;
               },
               h1({ children }) {

--- a/src/app/plugins/[slug]/page.tsx
+++ b/src/app/plugins/[slug]/page.tsx
@@ -153,8 +153,8 @@ export default async function PluginDetailPage(props: Props) {
                   key={command.name}
                   className="flex items-start gap-3 p-3 bg-muted rounded-lg"
                 >
-                  <code className="font-mono text-sm font-semibold text-primary">
-                    {command.name}
+                  <code className="font-mono text-sm font-semibold text-primary whitespace-nowrap before:content-['/']">
+                    {command.name.replace(/^\//, "")}
                   </code>
                   <span className="text-sm text-muted-foreground">
                     {command.description}


### PR DESCRIPTION
…ered content

- Plugin commands: render `/` prefix via CSS ::before so DOM text doesn't start with `/`, preventing Google from extracting command names as URLs
- ReactMarkdown: fix fenced code blocks without language specifiers rendering as inline <code> instead of <pre> blocks (blog and how-to pages)
- Hook setup instructions: wrap file paths in <code> tags to prevent relative URL resolution by crawlers