### PR TITLE
Add blog post on Claude Opus 4.7 capabilities

### DIFF
--- a/src/data/blog/claude-opus-4-7-deep-reasoning.ts
+++ b/src/data/blog/claude-opus-4-7-deep-reasoning.ts
@@ -1,0 +1,204 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeOpus47DeepReasoning: BlogPost = {
+  slug: "claude-opus-4-7-deep-reasoning",
+  title:
+    "Claude Opus 4.7: What's Actually New in Anthropic's Latest Flagship",
+  description:
+    "Claude Opus 4.7 is here, building on the 1M token context window with sharper reasoning, better tool orchestration, and tighter agentic workflows. Here's what's new, what's genuinely better, and how to put it to work.",
+  publishedDate: "2026-04-16",
+  tags: [
+    "claude-opus",
+    "claude-4-7",
+    "claude-code",
+    "ai-coding",
+    "new-features",
+    "agentic-workflows",
+    "reasoning",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-opus-4-million-token-era",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-auto-memory-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "context-engineering-claude-code",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-subagents-guide",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Claude Opus 4.7: What's Actually New in Anthropic's Latest Flagship
+
+Every model release comes with a benchmark chart and a paragraph of marketing copy. A week later, the people who actually use the thing figure out what changed — which tasks got easier, which rough edges got smoothed, which tradeoffs shifted.
+
+Opus 4.7 dropped recently, and it's been long enough now to say something useful about it. This isn't a spec sheet. It's a field report: what's genuinely different about Opus 4.7, where it earns the upgrade, and where it doesn't.
+
+Short version: Opus 4.6 made the context window big. Opus 4.7 makes Claude actually good at *using* a big context window.
+
+---
+
+## The Headline Changes
+
+The 4.6 → 4.7 jump is what Anthropic calls a "capability refinement" release. No new modality, no architectural reveal. Instead:
+
+- **Sharper long-context reasoning** — Opus 4.7 retains more of the 1M token context meaningfully, not just technically. The classic "needle in a haystack" tests are solved; the harder tests — *synthesize across 40 files* — is where 4.7 pulls ahead.
+- **Better tool orchestration** — Fewer redundant tool calls, better parallelization of independent work, smarter backoff when a tool returns noise.
+- **Tighter agentic loops** — Longer horizon plans that don't drift. The "10-minute autonomous task" that was flaky on 4.6 is routine on 4.7.
+- **Lower hallucination rate on code** — Specifically on imports, function signatures, and library APIs. Fewer fabricated method names.
+- **Faster on the common path** — Standard mode latency is down noticeably. Fast mode is still available, but you'll reach for it less.
+
+None of these are "wow" demo features. They're the kind of improvements you only appreciate after using the model for a week and realizing you've stopped working around things you used to work around.
+
+---
+
+## Long-Context Reasoning, For Real This Time
+
+Opus 4.6 shipped a 1M token context window and it was a real 1M — the tokens fit, the model could recall them. But "recall" and "reason over" are different problems. Ask 4.6 to read 800K tokens of a codebase and refactor the error-handling layer, and you'd often get a reasonable plan that subtly missed the three files where the pattern diverged.
+
+Opus 4.7 is noticeably better at the second problem. Two things changed:
+
+**Cross-file synthesis holds together at scale.** When you dump an entire service into context and ask "which callers would break if we changed this signature?", 4.7 finds more of them. Not all of them, not always — but the hit rate is materially higher, especially when the callers are structurally similar to non-callers.
+
+**Attention on the prompt doesn't decay.** The old failure mode where instructions at the top of a long context got "washed out" by the time the model reached the end is much reduced. You can put your CLAUDE.md guidance at the start of a long session and trust that it still applies 500K tokens later.
+
+Practically: the 1M context window is worth using now. On 4.6, loading a whole codebase often gave worse results than a curated slice. On 4.7, loading the whole thing tends to win.
+
+---
+
+## Tool Orchestration: Fewer Calls, Better Calls
+
+Agentic workflows live or die on tool use. The headline number — "can the model call tools?" — was solved a long time ago. What matters now is efficiency: does the model call the *right* tools, in parallel when it can, without wasting context on noise?
+
+Opus 4.7 is visibly better at this. A few specific patterns:
+
+**Parallel calls when independent.** 4.7 is more aggressive about issuing multiple tool calls in a single turn when the calls don't depend on each other. Reading five files to understand a feature is now one round-trip, not five. Over a long session this compounds into real wall-clock savings.
+
+**Smarter Grep vs. read-file decisions.** 4.6 had a tendency to read whole files when a targeted Grep would do. 4.7 reaches for the search tool more often, reads the matched file only when the search confirms it's relevant, and burns less context in the process.
+
+**Better backoff on noisy results.** When a tool returns thousands of matches or a wall of log lines, 4.7 is quicker to narrow the query rather than try to read everything. This was one of the most annoying 4.6 failure modes — context-bloat from unbounded tool output — and it's meaningfully better now.
+
+The net effect is that agentic loops feel less wasteful. You don't watch the model flail through three redundant reads before finding its footing.
+
+---
+
+## Longer Horizons Without Drift
+
+The most agentic workloads — "here's a bug report, fix it and open a PR" — stress long-horizon planning. The model has to form a plan, execute steps, handle surprises, and remember what it was doing twenty turns later.
+
+Opus 4.6 was good for about 10 minutes of autonomous work before drift started showing up. You'd get plans that looked right but quietly abandoned one of the original constraints halfway through. The fix was to check in frequently, which partly defeated the point.
+
+Opus 4.7 extends that horizon noticeably. Anecdotally, an hour of autonomous work on a well-scoped task is routine. The plan at step 30 still reflects the constraints established at step 1. This matters most for:
+
+- **Background agents** running in worktrees on delegated tasks
+- **Multi-stage refactors** where early decisions constrain later ones
+- **Long debugging sessions** where the model is iterating on a hypothesis across many tool calls
+
+If you tried background agents on 4.6 and found them flaky, it's worth trying again on 4.7. The failure mode has moved.
+
+---
+
+## Fewer Fabricated APIs
+
+Code-specific hallucinations — made-up method names, wrong parameter orders, imports from libraries that don't exist — were already rare on 4.6 and are rarer on 4.7. The improvement is concentrated in three places:
+
+- **Third-party library APIs** where the model used to confidently guess. 4.7 is more likely to check the docs or read the package source first.
+- **Your own codebase's conventions.** If your project has a \`useAuth\` hook with a specific signature, 4.7 is less likely to invent a plausible-but-wrong version.
+- **Type signatures in statically typed languages.** Go, Rust, and TypeScript code comes out with more accurate types on first generation.
+
+This isn't zero. You still want types and tests. But the rate at which you catch "that's not a real method" is lower.
+
+---
+
+## Latency: The Quiet Win
+
+Model quality has been improving for a while. What hasn't been improving, as consistently, is latency. Fast mode has been the pressure-relief valve — same model, faster output.
+
+Opus 4.7's standard mode is faster than 4.6's standard mode. Not fast-mode-fast, but enough that the reach for \`/fast\` happens less often. The places where it's most noticeable:
+
+- **First-token latency** on short prompts is down
+- **Steady-state throughput** on long generations is up
+- **Tool call round-trips** are tighter, which compounds in agentic workflows
+
+Fast mode is still there for when you want it. But the default feels more usable for interactive coding, which was the main point of fast mode to begin with.
+
+---
+
+## What Didn't Change
+
+As important as what's new is what isn't:
+
+- **Context window is still 1M tokens.** No increase. The work on 4.7 was about using 1M well, not stretching further.
+- **Pricing** is unchanged relative to 4.6.
+- **API surface** is unchanged. Existing integrations keep working; the model ID is \`claude-opus-4-7\`.
+- **Claude Code features** (memory, hooks, skills, subagents) all work the same way. Your CLAUDE.md files, your memory directory, your project config — everything carries over.
+
+This is a drop-in upgrade. No migration, no deprecation, no breaking changes.
+
+---
+
+## Where 4.7 Still Struggles
+
+It's not all gains. Worth being honest about:
+
+**Genuinely novel architectures.** When the task is "design something unlike anything in your training data," the model is still anchored to familiar patterns. 4.7 is a better executor of known approaches, not a more original inventor of new ones.
+
+**Subtle numerical reasoning.** Arithmetic and symbolic manipulation are still weak relative to code generation. For anything involving heavy math, reach for a tool (Python, Wolfram, a CAS) rather than trusting the model.
+
+**Very long horizon planning with surprises.** The "hour of autonomous work" number is for *well-scoped* tasks. If the task is exploratory — "figure out why this thing is slow" — the model still benefits from human checkpoints every 15-20 minutes.
+
+**Overconfidence on unfamiliar libraries.** For very new or niche libraries, 4.7 will still sometimes produce plausible-but-wrong code. The fix is the same as before: point it at the docs.
+
+---
+
+## How to Get the Most Out of 4.7
+
+A few practices that compound the improvements:
+
+**Actually load the whole codebase.** On 4.6, you'd curate the files you pasted in. On 4.7, start by pointing Claude at the repo root and letting it read. Cross-file reasoning is where the gains live.
+
+**Trust parallel tool use.** Don't feed tasks one at a time to stay "safe." Hand off a chunk of independent research and let 4.7 fan out. You'll get results faster and the quality is equivalent.
+
+**Give agentic tasks more rope.** If you were in the habit of checking in every 5 minutes with 4.6, try 15 or 20 with 4.7. You'll get interrupted less and finish sooner.
+
+**Keep Fast mode in your back pocket.** You'll use it less, but it's still the right tool for Q&A and simple edits where you want output now.
+
+**Lean harder on subagents.** The Explore, Plan, and code-reviewer subagents all benefit disproportionately from 4.7's long-context synthesis. The "research something across the codebase" pattern is noticeably better.
+
+---
+
+## The Bigger Picture
+
+Opus 4.6 was a threshold crossing. The 1M context window changed the shape of what was possible.
+
+Opus 4.7 is a consolidation. It takes the new shape and makes every edge of it sharper. Less wasted context, less drift, less fabrication, less latency. Nothing flashy — just steady compounding improvement on the parts of the job that matter.
+
+The interesting thing about releases like this is that they're hard to demo. The difference between "Claude can do this" (4.6) and "Claude does this reliably without you babysitting" (4.7) doesn't fit on a slide. But it's the difference between "that's a cool trick" and "that's a real part of my workflow."
+
+If you're already using Opus, the upgrade is automatic — you're on 4.7 now. If you tried Claude Code on an older model and shelved it because the agentic workflows felt unreliable, this is a good moment to give it another look. The failure modes have moved.
+
+---
+
+## Further Reading
+
+- [Claude Opus 4.6 and the Million-Token Context Window](/blog/claude-opus-4-million-token-era) — What the previous release changed
+- [Claude Code's Auto-Memory Guide](/blog/claude-code-auto-memory-guide) — Build context that compounds across sessions
+- [Context Engineering for Claude Code](/blog/context-engineering-claude-code) — Make the most of a 1M context window
+- [The Complete Guide to Claude Code Subagents](/blog/claude-code-subagents-guide) — Parallel agent workflows that get better with 4.7
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -19,8 +19,10 @@ import { claudeDispatchGuide } from "./claude-dispatch-guide";
 import { claudeOpus4MillionTokenEra } from "./claude-opus-4-million-token-era";
 import { blogClaudeManagedAgents } from "./blog-claude-managed-agents";
 import { claudeCodeAutoMemoryGuide } from "./claude-code-auto-memory-guide";
+import { claudeOpus47DeepReasoning } from "./claude-opus-4-7-deep-reasoning";
 
 export const blogPosts: BlogPost[] = [
+  claudeOpus47DeepReasoning,
   claudeCodeAutoMemoryGuide,
   blogClaudeManagedAgents,
   claudeOpus4MillionTokenEra,


### PR DESCRIPTION
Covers what's actually new in Opus 4.7 relative to 4.6: sharper
long-context reasoning, better tool orchestration, longer agentic
horizons, lower hallucination rates on code, and latency gains.