### PR TITLE
Newsletter signup + blog TOC fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "resend": "^6.12.2",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -1775,6 +1776,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -4248,6 +4255,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -7069,6 +7082,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -7393,6 +7412,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -7774,6 +7814,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -8003,6 +8053,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -8531,6 +8591,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "resend": "^6.12.2",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+
+export const runtime = "nodejs";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(request: Request) {
+  let body: { email?: unknown; source?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  const source = typeof body.source === "string" ? body.source.slice(0, 64) : undefined;
+
+  if (!email || !EMAIL_REGEX.test(email) || email.length > 254) {
+    return NextResponse.json({ error: "Please enter a valid email address." }, { status: 400 });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+  if (!apiKey || !audienceId) {
+    console.error("Newsletter signup: missing RESEND_API_KEY or RESEND_AUDIENCE_ID");
+    return NextResponse.json(
+      { error: "Newsletter is temporarily unavailable. Please try again later." },
+      { status: 503 },
+    );
+  }
+
+  const resend = new Resend(apiKey);
+
+  const { error } = await resend.contacts.create({
+    email,
+    audienceId,
+    unsubscribed: false,
+  });
+
+  if (error) {
+    const message = (error as { message?: string }).message ?? "";
+    if (/already exists/i.test(message)) {
+      return NextResponse.json({ ok: true, alreadySubscribed: true });
+    }
+    console.error("Newsletter signup failed:", error);
+    return NextResponse.json(
+      { error: "Could not subscribe. Please try again later." },
+      { status: 502 },
+    );
+  }
+
+  if (source) {
+    console.log(`Newsletter signup from "${source}": ${email}`);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -27,11 +27,35 @@ function slugify(text: string): string {
 }
 
 function extractHeadings(content: string): { text: string; slug: string }[] {
-  const headingRegex = /^## (.+)$/gm;
   const headings: { text: string; slug: string }[] = [];
-  let match;
-  while ((match = headingRegex.exec(content)) !== null) {
-    headings.push({ text: match[1], slug: slugify(match[1]) });
+  const seen = new Set<string>();
+  let inFence = false;
+  let fenceMarker = "";
+  for (const line of content.split("\n")) {
+    const fenceMatch = /^(\s*)(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[2];
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = marker[0];
+      } else if (marker[0] === fenceMarker) {
+        inFence = false;
+        fenceMarker = "";
+      }
+      continue;
+    }
+    if (inFence) continue;
+    const headingMatch = /^## (.+)$/.exec(line);
+    if (!headingMatch) continue;
+    const text = headingMatch[1];
+    let slug = slugify(text);
+    if (seen.has(slug)) {
+      let n = 2;
+      while (seen.has(`${slug}-${n}`)) n++;
+      slug = `${slug}-${n}`;
+    }
+    seen.add(slug);
+    headings.push({ text, slug });
   }
   return headings;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { HowToCard } from "@/components/cards/how-to-card";
 import { AgentCard } from "@/components/cards/agent-card";
 import { BlogCard } from "@/components/cards/blog-card";
 import { UniversalSearch } from "@/components/universal-search";
+import { NewsletterSignup } from "@/components/newsletter-signup";
 import { getFeaturedPrompts } from "@/data/prompts";
 import { getFeaturedMCPServers } from "@/data/mcp-servers";
 import { getFeaturedHooks } from "@/data/hooks";
@@ -20,7 +21,7 @@ import { getFeaturedAgents } from "@/data/agents";
 import { getFeaturedBlogPosts } from "@/data/blog";
 import { getRecentlyAdded } from "@/data/recently-added";
 import { RecentItemCard } from "@/components/cards/recent-item-card";
-import { Terminal, FileText, Server, Webhook, Zap, Puzzle, BookOpen, Bot, Newspaper, ArrowRight, Github, Clock } from "lucide-react";
+import { Terminal, FileText, Server, Webhook, Zap, Puzzle, BookOpen, Bot, Newspaper, ArrowRight, Github, Clock, Mail } from "lucide-react";
 
 const categories = [
   {
@@ -124,6 +125,17 @@ export default function Home() {
                 Contribute
               </a>
             </Button>
+          </div>
+
+          <div className="mt-10 w-full max-w-xl rounded-lg border bg-card/40 p-4 text-left">
+            <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+              <Mail className="h-4 w-4 text-muted-foreground" />
+              <span>The Claude Code weekly</span>
+            </div>
+            <p className="mb-3 text-sm text-muted-foreground">
+              New prompts, MCP servers, and skills — one short email each week. No spam, unsubscribe anytime.
+            </p>
+            <NewsletterSignup source="home_hero" />
           </div>
         </div>
       </section>
@@ -335,6 +347,20 @@ export default function Home() {
           </div>
         </section>
       )}
+
+      {/* Newsletter CTA */}
+      <section className="container py-16 border-t">
+        <div className="mx-auto flex max-w-2xl flex-col items-center gap-4 rounded-xl border bg-card/50 p-8 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full border bg-background">
+            <Mail className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <h2 className="text-2xl font-bold tracking-tight">Stay ahead on Claude Code</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            Get the best new prompts, MCP servers, hooks, and skills delivered every week. Free, short, no spam.
+          </p>
+          <NewsletterSignup source="home_footer_cta" className="max-w-md" />
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,10 +1,24 @@
 import Link from "next/link";
 import { Terminal, Rss } from "lucide-react";
+import { NewsletterSignup } from "@/components/newsletter-signup";
 
 export function Footer() {
   return (
     <footer className="border-t border-border/40 py-8">
       <div className="container">
+        <div className="mb-10 flex flex-col gap-3 rounded-lg border bg-card/40 p-5 md:flex-row md:items-center md:justify-between">
+          <div className="md:max-w-sm">
+            <h3 className="text-sm font-semibold">Get the weekly digest</h3>
+            <p className="text-xs text-muted-foreground">
+              The best new Claude Code prompts, MCP servers, and skills — every week.
+            </p>
+          </div>
+          <NewsletterSignup
+            source="footer"
+            className="md:w-[420px]"
+            buttonLabel="Subscribe"
+          />
+        </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
           <div>
             <h3 className="font-semibold text-sm mb-3">Browse</h3>

--- a/src/components/newsletter-signup.tsx
+++ b/src/components/newsletter-signup.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { Loader2, Mail, CheckCircle2 } from "lucide-react";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+interface NewsletterSignupProps {
+  source?: string;
+  className?: string;
+  variant?: "inline" | "stacked";
+  buttonLabel?: string;
+  placeholder?: string;
+  successMessage?: string;
+}
+
+export function NewsletterSignup({
+  source = "unknown",
+  className,
+  variant = "inline",
+  buttonLabel = "Subscribe",
+  placeholder = "you@example.com",
+  successMessage = "You're in. Check your inbox to confirm.",
+}: NewsletterSignupProps) {
+  const [email, setEmail] = React.useState("");
+  const [status, setStatus] = React.useState<Status>("idle");
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (status === "loading") return;
+
+    setStatus("loading");
+    setMessage(null);
+
+    try {
+      const res = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, source }),
+      });
+
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+        alreadySubscribed?: boolean;
+      };
+
+      if (!res.ok || !data.ok) {
+        setStatus("error");
+        setMessage(data.error ?? "Something went wrong. Please try again.");
+        return;
+      }
+
+      setStatus("success");
+      setMessage(
+        data.alreadySubscribed
+          ? "You're already subscribed — thanks for sticking with us."
+          : successMessage,
+      );
+      setEmail("");
+
+      if (typeof window !== "undefined") {
+        const w = window as unknown as { gtag?: (...args: unknown[]) => void };
+        w.gtag?.("event", "newsletter_signup", { source });
+      }
+    } catch {
+      setStatus("error");
+      setMessage("Network error. Please try again.");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300",
+          className,
+        )}
+        role="status"
+      >
+        <CheckCircle2 className="h-4 w-4 shrink-0" />
+        <span>{message}</span>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn(
+        variant === "inline"
+          ? "flex w-full flex-col gap-2 sm:flex-row"
+          : "flex w-full flex-col gap-2",
+        className,
+      )}
+      noValidate
+    >
+      <label htmlFor={`newsletter-email-${source}`} className="sr-only">
+        Email address
+      </label>
+      <Input
+        id={`newsletter-email-${source}`}
+        type="email"
+        name="email"
+        autoComplete="email"
+        inputMode="email"
+        required
+        placeholder={placeholder}
+        value={email}
+        onChange={(e) => {
+          setEmail(e.target.value);
+          if (status === "error") {
+            setStatus("idle");
+            setMessage(null);
+          }
+        }}
+        disabled={status === "loading"}
+        aria-invalid={status === "error" || undefined}
+        className="flex-1"
+      />
+      <Button
+        type="submit"
+        disabled={status === "loading" || email.length === 0}
+        className={variant === "inline" ? "sm:w-auto" : "w-full"}
+      >
+        {status === "loading" ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Subscribing
+          </>
+        ) : (
+          <>
+            <Mail className="h-4 w-4" />
+            {buttonLabel}
+          </>
+        )}
+      </Button>
+      {status === "error" && message && (
+        <p
+          className="basis-full text-xs text-destructive sm:order-3"
+          role="alert"
+        >
+          {message}
+        </p>
+      )}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a Resend-backed newsletter: reusable `NewsletterSignup` component, `/api/subscribe` route, and three placements (home hero, home footer CTA, sitewide footer) tagged with a `source` for analytics.
- Fixes blog post tables of contents that were leaking `## headings` from inside fenced code blocks (e.g. example `CLAUDE.md` snippets), producing dead anchor links and React duplicate-key warnings.

## Test plan
- [ ] Set `RESEND_API_KEY` and `RESEND_AUDIENCE_ID` in Vercel env vars before deploy
- [ ] Submit an email from each of the three placements and confirm the contact lands in the Resend audience
- [ ] Submit the same email twice and confirm the "already subscribed" message renders
- [ ] Submit an invalid email and confirm the inline error renders
- [ ] Open `/blog/claude-code-cheat-sheet` and confirm the TOC has no duplicates and every link scrolls to a real heading
- [ ] Spot-check a couple of other blog posts with markdown code samples (e.g. `claude-md-guide`, `claude-code-hooks-guide`) for the same