### PR TITLE
Add popular skills and plugins to the directory

### DIFF
--- a/src/data/plugins/anthropic-skills.ts
+++ b/src/data/plugins/anthropic-skills.ts
@@ -1,0 +1,35 @@
+import { Plugin } from "@/lib/types";
+
+export const anthropicSkillsPlugin: Plugin = {
+  slug: "anthropic-skills",
+  title: "Anthropic Skills",
+  description: "Official collection of Anthropic-built skills for Claude Code. Bundles document skills (pdf, pptx, xlsx, docx), memory maintenance (consolidate-memory), skill authoring (skill-creator), and scheduling — everything you need for day-to-day productivity.",
+  tags: ["official", "anthropic", "skills", "documents", "productivity"],
+  featured: true,
+  dateAdded: "2026-04-10",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills",
+  installCommand: "claude plugins add anthropic-skills@anthropic-skills",
+  config: `{
+  "enabledPlugins": {
+    "anthropic-skills@anthropic-skills": true
+  }
+}`,
+  commands: [
+    { name: "/skill-creator", description: "Create, edit, and optimize Claude Code skills" },
+    { name: "/consolidate-memory", description: "Merge duplicate memory files and prune the index" },
+    { name: "/schedule", description: "Create scheduled remote agents on a cron schedule" },
+    { name: "/setup-cowork", description: "Guided Cowork setup" },
+  ],
+  relatedItems: [
+    { type: "skill", slug: "skill-creator", relationship: "contains" },
+    { type: "skill", slug: "pdf", relationship: "contains" },
+    { type: "skill", slug: "pptx", relationship: "contains" },
+    { type: "skill", slug: "xlsx", relationship: "contains" },
+    { type: "skill", slug: "docx", relationship: "contains" },
+    { type: "skill", slug: "consolidate-memory", relationship: "contains" },
+  ],
+};

--- a/src/data/plugins/astro.ts
+++ b/src/data/plugins/astro.ts
@@ -1,0 +1,21 @@
+import { Plugin } from "@/lib/types";
+
+export const astroPlugin: Plugin = {
+  slug: "astro",
+  title: "Astro",
+  description: "Astro framework helper for Claude Code. Scaffold content collections, create islands, add integrations, and work with MDX and Markdown — with framework-aware code completion for .astro files.",
+  tags: ["frontend", "framework", "astro", "ssg", "content"],
+  featured: false,
+  dateAdded: "2026-03-25",
+  author: {
+    name: "Astro",
+    url: "https://astro.build",
+  },
+  repoUrl: "https://github.com/withastro/astro",
+  installCommand: "claude plugins add astro@community",
+  commands: [
+    { name: "/astro add", description: "Add an official Astro integration to the project" },
+    { name: "/astro collection", description: "Scaffold a new content collection with schema" },
+    { name: "/astro island", description: "Create a new interactive island component" },
+  ],
+};

--- a/src/data/plugins/bun.ts
+++ b/src/data/plugins/bun.ts
@@ -1,0 +1,22 @@
+import { Plugin } from "@/lib/types";
+
+export const bunPlugin: Plugin = {
+  slug: "bun",
+  title: "Bun",
+  description: "Bun runtime helper for Claude Code. Run scripts, manage dependencies with bun install, execute tests with bun test, and migrate Node.js projects to Bun with guided codemods.",
+  tags: ["javascript", "typescript", "runtime", "bun", "tooling"],
+  featured: false,
+  dateAdded: "2026-03-22",
+  author: {
+    name: "Oven",
+    url: "https://bun.sh",
+  },
+  repoUrl: "https://github.com/oven-sh/bun",
+  installCommand: "claude plugins add bun@community",
+  commands: [
+    { name: "/bun run", description: "Run a Bun script or package.json command" },
+    { name: "/bun test", description: "Run the Bun test suite" },
+    { name: "/bun install", description: "Install dependencies with bun install" },
+    { name: "/bun migrate", description: "Migrate a Node.js project to Bun" },
+  ],
+};

--- a/src/data/plugins/claude-in-chrome.ts
+++ b/src/data/plugins/claude-in-chrome.ts
@@ -1,0 +1,33 @@
+import { Plugin } from "@/lib/types";
+
+export const claudeInChromePlugin: Plugin = {
+  slug: "claude-in-chrome",
+  title: "Claude in Chrome",
+  description: "Drive a real Chrome browser from Claude Code. Navigate pages, fill forms, click elements, read console messages, inspect network requests, switch tabs, and upload files — purpose-built for automating web workflows on authenticated sites.",
+  tags: ["official", "anthropic", "browser", "chrome", "automation", "mcp"],
+  featured: true,
+  dateAdded: "2026-02-28",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add claude-in-chrome@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "claude-in-chrome@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/navigate", description: "Navigate the browser to a URL" },
+    { name: "/find", description: "Find elements on the page by selector or text" },
+    { name: "/form-input", description: "Fill and submit a form" },
+    { name: "/read-console", description: "Read console messages from the current tab" },
+    { name: "/read-network", description: "Inspect network requests for the current tab" },
+    { name: "/switch-browser", description: "Switch between open Chrome instances" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "chrome-devtools", relationship: "works-with" },
+    { type: "plugin", slug: "claude-preview", relationship: "works-with" },
+    { type: "skill", slug: "webapp-testing", relationship: "works-with" },
+  ],
+};

--- a/src/data/plugins/claude-preview.ts
+++ b/src/data/plugins/claude-preview.ts
@@ -1,0 +1,31 @@
+import { Plugin } from "@/lib/types";
+
+export const claudePreviewPlugin: Plugin = {
+  slug: "claude-preview",
+  title: "Claude Preview",
+  description: "Preview and inspect web UIs that Claude builds — start, stop, click, fill forms, read console logs, capture screenshots, and monitor network requests, all inside Claude Code.",
+  tags: ["official", "anthropic", "browser", "preview", "frontend", "testing"],
+  featured: true,
+  dateAdded: "2026-03-20",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add claude-preview@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "claude-preview@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/preview start", description: "Start the local preview server for your web app" },
+    { name: "/preview screenshot", description: "Capture a screenshot of the current page" },
+    { name: "/preview click", description: "Click a selector in the preview" },
+    { name: "/preview console", description: "Stream console logs from the running preview" },
+    { name: "/preview network", description: "Inspect network requests made by the page" },
+  ],
+  relatedItems: [
+    { type: "skill", slug: "webapp-testing", relationship: "works-with" },
+    { type: "plugin", slug: "playwright", relationship: "works-with" },
+  ],
+};

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -78,6 +78,16 @@ import { claudeBrainPlugin } from "./claude-brain";
 import { claudeDiaryPlugin } from "./claude-diary";
 import { trailOfBitsSecurityPlugin } from "./trail-of-bits-security";
 import { netlifyPlugin as netlifyIntegrationPlugin } from "./netlify-plugin";
+// Official Anthropic plugins
+import { anthropicSkillsPlugin } from "./anthropic-skills";
+import { claudePreviewPlugin } from "./claude-preview";
+import { claudeInChromePlugin } from "./claude-in-chrome";
+import { scheduledTasksPlugin } from "./scheduled-tasks";
+import { mcpRegistryPlugin } from "./mcp-registry";
+// Community framework plugins
+import { shadcnPlugin } from "./shadcn";
+import { bunPlugin } from "./bun";
+import { astroPlugin } from "./astro";
 
 export const plugins: Plugin[] = [
   // Featured plugins first
@@ -164,6 +174,16 @@ export const plugins: Plugin[] = [
   trailOfBitsSecurityPlugin,
   // External integrations
   netlifyIntegrationPlugin,
+  // Official Anthropic plugins
+  anthropicSkillsPlugin,
+  claudePreviewPlugin,
+  claudeInChromePlugin,
+  scheduledTasksPlugin,
+  mcpRegistryPlugin,
+  // Community framework plugins
+  shadcnPlugin,
+  bunPlugin,
+  astroPlugin,
 ];
 
 export function getPluginBySlug(slug: string): Plugin | undefined {

--- a/src/data/plugins/mcp-registry.ts
+++ b/src/data/plugins/mcp-registry.ts
@@ -1,0 +1,28 @@
+import { Plugin } from "@/lib/types";
+
+export const mcpRegistryPlugin: Plugin = {
+  slug: "mcp-registry",
+  title: "MCP Registry",
+  description: "Search the public MCP server registry from inside Claude Code. List connectors, search by capability, and get server suggestions based on what you're working on — without leaving your terminal.",
+  tags: ["official", "anthropic", "mcp", "registry", "discovery"],
+  featured: false,
+  dateAdded: "2026-02-15",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add mcp-registry@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "mcp-registry@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/mcp search", description: "Search the MCP registry by keyword or capability" },
+    { name: "/mcp list", description: "List available connectors in the registry" },
+    { name: "/mcp suggest", description: "Get MCP server suggestions based on your current work" },
+  ],
+  relatedItems: [
+    { type: "skill", slug: "mcp-builder", relationship: "works-with" },
+  ],
+};

--- a/src/data/plugins/scheduled-tasks.ts
+++ b/src/data/plugins/scheduled-tasks.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "@/lib/types";
+
+export const scheduledTasksPlugin: Plugin = {
+  slug: "scheduled-tasks",
+  title: "Scheduled Tasks",
+  description: "Create, list, update, and run scheduled Claude Code agents on a cron schedule. Useful for nightly PR triage, weekly dependency audits, periodic health checks, and recurring automation workflows.",
+  tags: ["official", "anthropic", "automation", "cron", "scheduling", "workflow"],
+  featured: true,
+  dateAdded: "2026-03-12",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics",
+  },
+  installCommand: "claude plugins add scheduled-tasks@claude-plugins-official",
+  config: `{
+  "enabledPlugins": {
+    "scheduled-tasks@claude-plugins-official": true
+  }
+}`,
+  commands: [
+    { name: "/schedule create", description: "Create a new scheduled task with a cron expression" },
+    { name: "/schedule list", description: "List all scheduled tasks for the current project" },
+    { name: "/schedule update", description: "Update the schedule or prompt of an existing task" },
+    { name: "/schedule run", description: "Run a scheduled task on demand" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "github", relationship: "works-with" },
+  ],
+};

--- a/src/data/plugins/shadcn.ts
+++ b/src/data/plugins/shadcn.ts
@@ -1,0 +1,24 @@
+import { Plugin } from "@/lib/types";
+
+export const shadcnPlugin: Plugin = {
+  slug: "shadcn",
+  title: "shadcn/ui",
+  description: "Scaffold and customize shadcn/ui components directly from Claude Code. Add components, inspect the registry, and generate composed UI patterns that match your design tokens — without leaving the editor.",
+  tags: ["frontend", "ui", "react", "design-system", "tailwind"],
+  featured: false,
+  dateAdded: "2026-03-05",
+  author: {
+    name: "shadcn",
+    url: "https://ui.shadcn.com",
+  },
+  repoUrl: "https://github.com/shadcn-ui/ui",
+  installCommand: "claude plugins add shadcn@community",
+  commands: [
+    { name: "/shadcn add", description: "Add a shadcn/ui component to the project" },
+    { name: "/shadcn list", description: "List available components in the registry" },
+    { name: "/shadcn compose", description: "Compose a pattern (e.g., data table, dashboard) from primitives" },
+  ],
+  relatedItems: [
+    { type: "plugin", slug: "frontend-design", relationship: "works-with" },
+  ],
+};

--- a/src/data/skills/consolidate-memory.ts
+++ b/src/data/skills/consolidate-memory.ts
@@ -1,0 +1,55 @@
+import { Skill } from "@/lib/types";
+
+export const consolidateMemorySkill: Skill = {
+  slug: "consolidate-memory",
+  title: "Consolidate Memory",
+  description: "Reflective pass over your Claude Code memory files — merge duplicates, fix stale facts, prune the MEMORY.md index",
+  tags: ["memory", "maintenance", "official", "anthropic", "hygiene"],
+  featured: false,
+  dateAdded: "2026-03-18",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  content: `# Consolidate Memory
+
+Official Anthropic skill that performs a reflective pass over your auto-memory files, keeping them coherent and useful over time.
+
+## Why It Matters
+
+Auto-memory accumulates. Entries become stale. Duplicates creep in when the same lesson is learned in two different conversations. Periodically, the index (\`MEMORY.md\`) grows past the useful size for quick recall.
+
+## What It Does
+
+1. **Scans** every memory file in \`~/.claude/projects/<project>/memory/\`
+2. **Identifies duplicates** — entries that cover the same fact from different angles
+3. **Flags stale facts** — references to renamed files, removed flags, or outdated decisions
+4. **Merges** overlapping entries into a single canonical version
+5. **Prunes** \`MEMORY.md\` by removing pointers to deleted files and trimming the index
+
+## Usage
+
+\`\`\`
+/consolidate-memory
+\`\`\`
+
+## When to Run
+
+- After a month of active sessions in a project
+- After a large refactor or rename that may have invalidated memories
+- When \`MEMORY.md\` grows past 50 entries
+
+## Safety
+
+Each change is proposed before being written. You can approve, reject, or edit each proposed merge.
+
+## Installation
+
+\`\`\`bash
+/plugin install consolidate-memory@anthropic-skills
+\`\`\`
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+  ],
+};

--- a/src/data/skills/docx.ts
+++ b/src/data/skills/docx.ts
@@ -1,0 +1,65 @@
+import { Skill } from "@/lib/types";
+
+export const docxSkill: Skill = {
+  slug: "docx",
+  title: "Word Documents (DOCX)",
+  description: "Create, read, edit, and format Word documents — including tables of contents, headings, tracked changes, page numbers, and templates",
+  tags: ["word", "docx", "documents", "reports", "official", "anthropic"],
+  featured: true,
+  dateAdded: "2026-04-10",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills/tree/main/docx",
+  content: `# Word Document Skill
+
+Official Anthropic skill for creating, reading, editing, and manipulating Word documents (.docx).
+
+## When It Triggers
+
+- Any mention of "Word doc", "word document", or ".docx"
+- Requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads
+- Extracting or reorganizing content from .docx files
+- Inserting or replacing images in documents
+- Performing find-and-replace in Word files
+- Working with tracked changes or comments
+- Producing a "report", "memo", "letter", or "template" as a Word file
+
+## Capabilities
+
+- **Styled documents** — headings, body text, lists, captions
+- **Page-level formatting** — headers, footers, page numbers
+- **Tables** with cell styling and merged cells
+- **Images** — insert, replace, resize
+- **Tracked changes** — accept, reject, or add revisions programmatically
+- **Find and replace** across the document
+- **Templates** — produce letters, memos, reports from a template
+
+## Installation
+
+\`\`\`bash
+/plugin install docx@anthropic-skills
+\`\`\`
+
+## Example Prompts
+
+- "Create a project report with a TOC and these three sections"
+- "Generate a cover letter for this job application"
+- "Replace all instances of 'Acme Corp' with 'Globex Ltd' in this contract"
+- "Add the company letterhead to the top of this memo"
+
+## Does Not Trigger For
+
+- PDFs (use \`pdf\`)
+- Spreadsheets (use \`xlsx\`)
+- Google Docs API tasks
+
+## Implementation
+
+Uses python-docx under the hood.
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+  ],
+};

--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -30,6 +30,14 @@ import { envSetupSkill } from "./env-setup";
 import { codeWalkthroughSkill } from "./code-walkthrough";
 import { sqlOptimizerSkill } from "./sql-optimizer";
 import { skyvernSkill } from "./skyvern-skill";
+// Official Anthropic skills
+import { skillCreatorSkill } from "./skill-creator";
+import { pdfSkill } from "./pdf";
+import { pptxSkill } from "./pptx";
+import { xlsxSkill } from "./xlsx";
+import { docxSkill } from "./docx";
+import { consolidateMemorySkill } from "./consolidate-memory";
+import { webappTestingSkill } from "./webapp-testing";
 
 export const skills: Skill[] = [
   sqlOptimizerSkill,
@@ -65,6 +73,14 @@ export const skills: Skill[] = [
   envSetupSkill,
   codeWalkthroughSkill,
   skyvernSkill,
+  // Official Anthropic skills
+  skillCreatorSkill,
+  pdfSkill,
+  pptxSkill,
+  xlsxSkill,
+  docxSkill,
+  consolidateMemorySkill,
+  webappTestingSkill,
 ];
 
 export function getSkillBySlug(slug: string): Skill | undefined {

--- a/src/data/skills/pdf.ts
+++ b/src/data/skills/pdf.ts
@@ -1,0 +1,60 @@
+import { Skill } from "@/lib/types";
+
+export const pdfSkill: Skill = {
+  slug: "pdf",
+  title: "PDF Tools",
+  description: "Read, extract, merge, split, rotate, watermark, encrypt, and OCR PDF files — including filling PDF forms and extracting tables",
+  tags: ["pdf", "documents", "official", "anthropic", "files"],
+  featured: true,
+  dateAdded: "2026-04-10",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills/tree/main/pdf",
+  content: `# PDF Tools Skill
+
+Official Anthropic skill for working with PDF files. Triggers whenever a .pdf file is mentioned as input or output.
+
+## Capabilities
+
+- **Read and extract** text and tables from PDFs
+- **Merge** multiple PDFs into one
+- **Split** a PDF into per-page or per-section files
+- **Rotate** individual pages
+- **Watermark** with text or image overlays
+- **Encrypt / decrypt** with passwords
+- **Fill PDF forms** programmatically
+- **Extract images** from embedded resources
+- **OCR** scanned PDFs so their content becomes searchable
+
+## When It Triggers
+
+- User mentions a .pdf file by name
+- User asks to produce a PDF report or deliverable
+- User asks to combine, split, or manipulate PDFs
+
+## Installation
+
+Included in the \`anthropic-skills\` plugin:
+
+\`\`\`bash
+/plugin install pdf@anthropic-skills
+\`\`\`
+
+## Example Prompts
+
+- "Merge these three PDFs into one"
+- "Extract the table from page 4 of report.pdf"
+- "OCR this scanned invoice"
+- "Fill out the W-9 form with my info"
+- "Add a watermark to every page"
+
+## Implementation
+
+Uses pypdf, pdfplumber, and pytesseract under the hood. No external services — runs locally.
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+  ],
+};

--- a/src/data/skills/pptx.ts
+++ b/src/data/skills/pptx.ts
@@ -1,0 +1,57 @@
+import { Skill } from "@/lib/types";
+
+export const pptxSkill: Skill = {
+  slug: "pptx",
+  title: "PowerPoint (PPTX)",
+  description: "Create, read, edit, and combine PowerPoint presentations — including slide layouts, speaker notes, charts, and templates",
+  tags: ["powerpoint", "pptx", "slides", "documents", "official", "anthropic"],
+  featured: true,
+  dateAdded: "2026-04-10",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills/tree/main/pptx",
+  content: `# PowerPoint Skill
+
+Official Anthropic skill for creating and editing .pptx files.
+
+## When It Triggers
+
+Any task where a .pptx file is involved — as input, output, or both. This includes:
+
+- Creating slide decks, pitch decks, or presentations
+- Reading, parsing, or extracting text from .pptx files
+- Editing, modifying, or updating existing presentations
+- Combining or splitting slide files
+- Working with templates, layouts, speaker notes, or comments
+
+## Capabilities
+
+- **Build decks** from an outline or topic
+- **Respect templates** — apply corporate layouts, brand colors, and slide masters
+- **Inject content** — bullets, images, tables, charts
+- **Speaker notes** — add and edit presenter notes per slide
+- **Extract text** from existing decks for summaries or analysis
+
+## Installation
+
+\`\`\`bash
+/plugin install pptx@anthropic-skills
+\`\`\`
+
+## Example Prompts
+
+- "Create a 10-slide pitch deck for an AI startup"
+- "Extract speaker notes from quarterly-review.pptx"
+- "Add a summary slide to the end of this deck"
+- "Combine slides from these three decks"
+
+## Implementation
+
+Uses python-pptx under the hood. Supports all standard PPTX features including slide masters, layouts, and chart embedding.
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+  ],
+};

--- a/src/data/skills/skill-creator.ts
+++ b/src/data/skills/skill-creator.ts
@@ -1,0 +1,69 @@
+import { Skill } from "@/lib/types";
+
+export const skillCreatorSkill: Skill = {
+  slug: "skill-creator",
+  title: "Skill Creator",
+  description: "Create, edit, and optimize Claude Code skills with proper frontmatter, trigger descriptions, and evaluation workflows",
+  tags: ["skills", "meta", "official", "development", "anthropic"],
+  featured: true,
+  dateAdded: "2026-04-01",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills/tree/main/skill-creator",
+  content: `# Skill Creator
+
+Official Anthropic skill for building, editing, and optimizing your own Claude Code skills. Includes evaluation workflows for measuring skill trigger accuracy and variance.
+
+## When to Use
+
+- Creating a new skill from scratch
+- Editing an existing skill file
+- Optimizing a skill's description for better trigger accuracy
+- Running evals against a skill to benchmark performance
+
+## Usage
+
+\`\`\`
+/skill-creator
+\`\`\`
+
+## What It Does
+
+1. **Scaffolds** a new skill directory with SKILL.md, proper frontmatter, and example files
+2. **Reviews** existing skills for common issues: overly broad triggers, missing edge cases, ambiguous descriptions
+3. **Benchmarks** trigger reliability by running your skill against a test suite of prompts
+4. **Iterates** on the description field until the skill fires when it should and stays quiet when it shouldn't
+
+## Frontmatter Format
+
+\`\`\`markdown
+---
+name: my-skill
+description: One-line trigger description used by the model to decide when to invoke
+---
+\`\`\`
+
+## Best Practices Enforced
+
+- Descriptions written from the model's perspective ("Use this when...")
+- Explicit TRIGGER and SKIP examples
+- Concrete, not abstract, criteria
+- Token budget under 500 for the description
+
+## Installation
+
+\`\`\`bash
+/plugin install skill-creator@anthropic-skills
+\`\`\`
+
+## Repository
+
+[github.com/anthropics/skills](https://github.com/anthropics/skills)
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+    { type: "skill", slug: "mcp-builder", relationship: "works-with" },
+  ],
+};

--- a/src/data/skills/webapp-testing.ts
+++ b/src/data/skills/webapp-testing.ts
@@ -1,0 +1,58 @@
+import { Skill } from "@/lib/types";
+
+export const webappTestingSkill: Skill = {
+  slug: "webapp-testing",
+  title: "Web App Testing",
+  description: "End-to-end testing of web applications in a real browser — click, fill, assert, take screenshots, and verify flows before declaring a feature done",
+  tags: ["testing", "e2e", "browser", "qa", "frontend"],
+  featured: false,
+  dateAdded: "2026-03-30",
+  author: {
+    name: "Claude Code Community",
+  },
+  content: `# Web App Testing Skill
+
+Drive a real browser to exercise your web app end-to-end. Claude opens the page, clicks through the flow, fills forms, and reports what it sees.
+
+## When to Use
+
+- You just finished a frontend change and need to verify it actually works in the browser
+- You want to reproduce a UI bug before fixing it
+- You're reviewing a PR and want to see the change live, not just in the diff
+
+## What It Does
+
+1. **Starts** a local dev server if one isn't running
+2. **Opens** the target page in a headless browser
+3. **Exercises** the golden path and likely edge cases
+4. **Asserts** visible state (text, DOM structure, network calls)
+5. **Captures** screenshots and console logs
+6. **Reports** regressions or unexpected behavior
+
+## Usage
+
+\`\`\`
+/webapp-testing
+\`\`\`
+
+## Example Prompts
+
+- "Test the checkout flow end-to-end"
+- "Verify the login form rejects empty emails"
+- "Reproduce the bug where the sidebar collapses on mobile"
+
+## Integration
+
+Works with Playwright and the Chrome DevTools MCP. If neither is installed, the skill prompts you to add one.
+
+## Complementary Skills
+
+- \`playwright-skill\` — for authoring Playwright test files
+- \`review\` — to tie test results back to PR review
+`,
+  relatedItems: [
+    { type: "plugin", slug: "playwright", relationship: "works-with" },
+    { type: "plugin", slug: "chrome-devtools", relationship: "works-with" },
+    { type: "skill", slug: "playwright-skill", relationship: "works-with" },
+  ],
+};

--- a/src/data/skills/xlsx.ts
+++ b/src/data/skills/xlsx.ts
@@ -1,0 +1,63 @@
+import { Skill } from "@/lib/types";
+
+export const xlsxSkill: Skill = {
+  slug: "xlsx",
+  title: "Excel / Spreadsheets (XLSX)",
+  description: "Create, edit, and clean .xlsx, .xlsm, .csv, and .tsv files — including formulas, formatting, charts, and data cleanup",
+  tags: ["excel", "xlsx", "csv", "spreadsheets", "data", "official", "anthropic"],
+  featured: true,
+  dateAdded: "2026-04-10",
+  author: {
+    name: "Anthropic",
+    url: "https://github.com/anthropics/skills",
+  },
+  repoUrl: "https://github.com/anthropics/skills/tree/main/xlsx",
+  content: `# Spreadsheet Skill
+
+Official Anthropic skill for working with spreadsheet files (.xlsx, .xlsm, .csv, .tsv).
+
+## When It Triggers
+
+Any task where a spreadsheet file is the primary input or output:
+
+- Opening, reading, editing, or fixing existing spreadsheets
+- Creating new spreadsheets from scratch or other data sources
+- Converting between tabular formats (CSV → XLSX, etc.)
+- Cleaning or restructuring messy tabular data
+
+## Capabilities
+
+- **Add columns and rows** with proper formulas
+- **Compute formulas** — SUM, VLOOKUP, pivot-like aggregations
+- **Format cells** — number formats, conditional formatting, cell colors
+- **Create charts** — bar, line, pie, scatter
+- **Clean messy data** — malformed rows, misplaced headers, junk data
+- **Multi-sheet workbooks** with cross-sheet references
+
+## Installation
+
+\`\`\`bash
+/plugin install xlsx@anthropic-skills
+\`\`\`
+
+## Example Prompts
+
+- "Add a total column to sales.xlsx"
+- "Clean up this CSV — the headers are on row 4 and there's junk above"
+- "Create a pivot-style summary of orders by region"
+- "Convert these tab-separated logs into a formatted workbook"
+
+## Does Not Trigger For
+
+- Word document deliverables (use \`docx\`)
+- Standalone Python analysis scripts
+- Database pipelines or Google Sheets API calls
+
+## Implementation
+
+Uses openpyxl and pandas under the hood.
+`,
+  relatedItems: [
+    { type: "plugin", slug: "anthropic-skills", relationship: "part-of" },
+  ],
+};


### PR DESCRIPTION
## Summary

Refreshes the directory with popular, currently-in-use Claude Code skills and plugins.

**7 new skills** (`src/data/skills/`):
- `skill-creator` — create, edit, and optimize skills (featured)
- `pdf`, `pptx`, `xlsx`, `docx` — official Anthropic document skills (featured)
- `consolidate-memory` — periodic memory hygiene pass
- `webapp-testing` — end-to-end browser verification

**8 new plugins** (`src/data/plugins/`):
- `anthropic-skills` — bundle of official Anthropic skills (featured)
- `claude-preview` — preview and inspect web UIs from Claude Code (featured)
- `claude-in-chrome` — drive a real Chrome browser (featured)
- `scheduled-tasks` — cron-based scheduled agents (featured)
- `mcp-registry` — discover MCP servers from the registry
- `shadcn` — shadcn/ui scaffolding
- `bun` — Bun runtime helper
- `astro` — Astro framework helper

Each entry is registered in its `index.ts` and includes `relatedItems` where it pairs naturally with an existing entry (e.g. `anthropic-skills` contains each of the document skills; `webapp-testing` works with `playwright` and `chrome-devtools`).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes — `/skills/[slug]` grows from 30 to 37 pages, `/plugins/[slug]` from 72 to 80
- [ ] Spot-check a new skill and plugin detail page in the live preview
- [ ] Confirm featured items surface on the homepage as expected