### PR TITLE
Add prominent top-of-post related links module on blog

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -137,6 +137,7 @@ export default async function BlogPostPage(props: Props) {
 
   const readingTime = getReadingTime(post.content);
   const headings = extractHeadings(post.content);
+  const hasTopRelatedModule = (post.relatedItems?.length ?? 0) >= 3;
 
   return (
     <div className="container py-8 max-w-4xl">
@@ -214,6 +215,12 @@ export default async function BlogPostPage(props: Props) {
         </div>
 
         <Separator />
+
+        {hasTopRelatedModule && post.relatedItems && (
+          <div className="rounded-lg border-2 border-primary/20 bg-primary/5 p-5">
+            <RelatedItems items={post.relatedItems} title="Keep exploring" />
+          </div>
+        )}
 
         {headings.length > 2 && (
           <nav className="rounded-lg border bg-card p-4">
@@ -363,7 +370,7 @@ export default async function BlogPostPage(props: Props) {
           </div>
         )}
 
-        {post.relatedItems && post.relatedItems.length > 0 && (
+        {!hasTopRelatedModule && post.relatedItems && post.relatedItems.length > 0 && (
           <>
             <Separator />
             <RelatedItems items={post.relatedItems} />

--- a/src/data/blog/anthropic-claude-certification-program.ts
+++ b/src/data/blog/anthropic-claude-certification-program.ts
@@ -21,7 +21,17 @@ export const anthropicClaudeCertificationProgram: BlogPost = {
   relatedItems: [
     {
       type: "blog",
+      slug: "claude-code-subagents-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
       slug: "mcp-servers-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-md-guide",
       relationship: "recommends",
     },
     {
@@ -31,7 +41,7 @@ export const anthropicClaudeCertificationProgram: BlogPost = {
     },
     {
       type: "blog",
-      slug: "claude-md-guide",
+      slug: "context-engineering-claude-code",
       relationship: "recommends",
     },
   ],

--- a/src/data/blog/claude-md-guide.ts
+++ b/src/data/blog/claude-md-guide.ts
@@ -24,6 +24,26 @@ export const claudeMdGuide: BlogPost = {
       slug: "nextjs",
       relationship: "works-with",
     },
+    {
+      type: "prompt",
+      slug: "python",
+      relationship: "works-with",
+    },
+    {
+      type: "skill",
+      slug: "context-engineering",
+      relationship: "works-with",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-hooks-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "best-claude-code-plugins",
+      relationship: "recommends",
+    },
   ],
   content: `# The Complete Guide to CLAUDE.md: How to Configure Claude Code for Any Project
 


### PR DESCRIPTION
## Summary

Surface curated internal links above the fold on long-form blog posts to cut bounce rate. On posts with 3+ `relatedItems`, render them in a tinted "Keep exploring" callout between the author block and the Table of Contents, and suppress the now-redundant bottom render. Posts with fewer items keep the existing bottom placement, so this is opt-in per post via the `relatedItems` array.

Targets the two highest-traffic posts first:
- **The Complete Guide to CLAUDE.md** (~984 views/mo, 54.9% bounce) — adds Python CLAUDE.md template, `context-engineering` skill, hooks guide, and best-plugins roundup (was 1 related item → 5)
- **Anthropic Claude Certification Program** (~1,313 views/mo, 50.5% bounce) — adds `claude-code-subagents-guide` and `context-engineering-claude-code` to mirror the exam's largest competency domains (was 3 → 5)

If we move bounce from ~52% to ~35% on these two, that's roughly 400 additional page views per month.

## Changes

- [src/app/blog/[slug]/page.tsx](src/app/blog/[slug]/page.tsx) — gate bottom `RelatedItems` behind `!hasTopRelatedModule`; render a prominent top module with `border-primary/20 bg-primary/5` styling when `relatedItems.length >= 3`
- [src/data/blog/claude-md-guide.ts](src/data/blog/claude-md-guide.ts) — expand `relatedItems` from 1 to 5 curated links
- [src/data/blog/anthropic-claude-certification-program.ts](src/data/blog/anthropic-claude-certification-program.ts) — expand `relatedItems` from 3 to 5 curated links

No new components, no new data types — reuses existing `RelatedItems` component with a custom title.

## Test plan

- [ ] `npm run dev` — visit `/blog/claude-md-guide` and `/blog/anthropic-claude-certification-program`, confirm the "Keep exploring" callout renders after the author block and before the TOC
- [ ] Click each of the 5 cards on both pages — confirm all links resolve (no 404s)
- [ ] Visit a blog post with <3 `relatedItems` (e.g., any non-updated post) — confirm the old bottom-of-post `RelatedItems` still renders as before
- [ ] Visit a blog post with no `relatedItems` — confirm only the auto "You might also like" block renders at the bottom
- [ ] Check responsive layout at mobile widths — the tinted callout and grid should collapse cleanly