### PR TITLE
Add use-case directory pages at /for/<use-case>

### DIFF
--- a/src/app/agents/topic/[tag]/page.tsx
+++ b/src/app/agents/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { AgentCard } from "@/components/cards/agent-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllAgentTags, getAgentsByTag } from "@/data/agents";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function AgentTopicPage(props: Props) {
           <AgentCard key={agent.slug} agent={agent} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/blog/topic/[tag]/page.tsx
+++ b/src/app/blog/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { BlogCard } from "@/components/cards/blog-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllBlogPostTags, getBlogPostsByTag } from "@/data/blog";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function BlogTopicPage(props: Props) {
           <BlogCard key={post.slug} post={post} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/for/[useCase]/page.tsx
+++ b/src/app/for/[useCase]/page.tsx
@@ -1,0 +1,241 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { SkillCard } from "@/components/cards/skill-card";
+import { AgentCard } from "@/components/cards/agent-card";
+import { PluginCard } from "@/components/cards/plugin-card";
+import { MCPCard } from "@/components/cards/mcp-card";
+import { PromptCard } from "@/components/cards/prompt-card";
+import { HookCard } from "@/components/cards/hook-card";
+import { HowToCard } from "@/components/cards/how-to-card";
+import { BreadcrumbJsonLd, CollectionPageJsonLd } from "@/components/json-ld";
+import {
+  getUseCaseBySlug,
+  getAllUseCaseSlugs,
+  useCases,
+} from "@/data/use-cases";
+import { getMatchesForUseCase } from "@/lib/use-cases";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { BASE_URL } from "@/lib/constants";
+
+interface Props {
+  params: Promise<{ useCase: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllUseCaseSlugs().map((useCase) => ({ useCase }));
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { useCase: slug } = await props.params;
+  const useCase = getUseCaseBySlug(slug);
+  if (!useCase) return { title: "Use Case Not Found" };
+
+  const url = `${BASE_URL}/for/${useCase.slug}`;
+  const title = `${useCase.title} - Claude Code Skills, Agents, Plugins & More`;
+  const description = useCase.description;
+
+  return {
+    title,
+    description,
+    keywords: useCase.keywords,
+    openGraph: { title, description, url, type: "website" },
+    twitter: { card: "summary", title, description },
+    alternates: { canonical: url },
+  };
+}
+
+export default async function UseCasePage(props: Props) {
+  const { useCase: slug } = await props.params;
+  const useCase = getUseCaseBySlug(slug);
+  if (!useCase) notFound();
+
+  const matches = getMatchesForUseCase(useCase);
+  if (matches.total === 0) notFound();
+
+  const otherUseCases = useCases.filter((u) => u.slug !== useCase.slug);
+  const url = `${BASE_URL}/for/${useCase.slug}`;
+
+  return (
+    <div className="container py-8">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: "Use Cases", url: `${BASE_URL}/for` },
+          { name: useCase.title, url },
+        ]}
+      />
+      <CollectionPageJsonLd
+        name={useCase.headline}
+        description={useCase.description}
+        url={url}
+        itemCount={matches.total}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href="/for">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          All Use Cases
+        </Link>
+      </Button>
+
+      <div className="mb-10 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">{useCase.headline}</h1>
+        <p className="text-muted-foreground leading-relaxed mb-4">
+          {useCase.description}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {matches.total} {matches.total === 1 ? "item" : "items"} across skills,
+          agents, plugins, MCP servers, prompts, hooks, and guides.
+        </p>
+      </div>
+
+      {matches.skills.length > 0 && (
+        <UseCaseSection
+          title="Skills"
+          count={matches.skills.length}
+          viewAllHref={`/skills/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all skills"
+        >
+          {matches.skills.map((skill) => (
+            <SkillCard key={skill.slug} skill={skill} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.agents.length > 0 && (
+        <UseCaseSection
+          title="Agents"
+          count={matches.agents.length}
+          viewAllHref={`/agents/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all agents"
+        >
+          {matches.agents.map((agent) => (
+            <AgentCard key={agent.slug} agent={agent} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.plugins.length > 0 && (
+        <UseCaseSection
+          title="Plugins"
+          count={matches.plugins.length}
+          viewAllHref={`/plugins/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all plugins"
+        >
+          {matches.plugins.map((plugin) => (
+            <PluginCard key={plugin.slug} plugin={plugin} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.mcpServers.length > 0 && (
+        <UseCaseSection
+          title="MCP Servers"
+          count={matches.mcpServers.length}
+          viewAllHref={`/mcp-servers/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all MCP servers"
+        >
+          {matches.mcpServers.map((server) => (
+            <MCPCard key={server.slug} server={server} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.prompts.length > 0 && (
+        <UseCaseSection
+          title="Prompts"
+          count={matches.prompts.length}
+          viewAllHref={`/prompts/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all prompts"
+        >
+          {matches.prompts.map((prompt) => (
+            <PromptCard key={prompt.slug} prompt={prompt} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.hooks.length > 0 && (
+        <UseCaseSection
+          title="Hooks"
+          count={matches.hooks.length}
+          viewAllHref={`/hooks/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all hooks"
+        >
+          {matches.hooks.map((hook) => (
+            <HookCard key={hook.slug} hook={hook} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      {matches.howTos.length > 0 && (
+        <UseCaseSection
+          title="How-To Guides"
+          count={matches.howTos.length}
+          viewAllHref={`/how-to/topic/${useCase.primaryTopic}`}
+          viewAllLabel="Browse all how-tos"
+        >
+          {matches.howTos.map((howTo) => (
+            <HowToCard key={howTo.slug} howTo={howTo} />
+          ))}
+        </UseCaseSection>
+      )}
+
+      <div className="border-t pt-6 mt-6">
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">
+          Other use cases
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {otherUseCases.map((u) => (
+            <Link key={u.slug} href={`/for/${u.slug}`}>
+              <Badge
+                variant="secondary"
+                className="cursor-pointer hover:bg-accent"
+              >
+                {u.title}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UseCaseSection({
+  title,
+  count,
+  viewAllHref,
+  viewAllLabel,
+  children,
+}: {
+  title: string;
+  count: number;
+  viewAllHref: string;
+  viewAllLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-10">
+      <div className="flex items-end justify-between mb-4">
+        <h2 className="text-xl font-semibold">
+          {title}{" "}
+          <span className="text-sm font-normal text-muted-foreground">
+            ({count})
+          </span>
+        </h2>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href={viewAllHref}>
+            {viewAllLabel}
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/app/for/page.tsx
+++ b/src/app/for/page.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CollectionPageJsonLd } from "@/components/json-ld";
+import { useCases } from "@/data/use-cases";
+import { getUseCaseCounts } from "@/lib/use-cases";
+import { BASE_URL } from "@/lib/constants";
+
+export const metadata: Metadata = {
+  title: "Claude Code by Use Case - Skills, Agents, Plugins, MCP Servers",
+  description:
+    "Browse Claude Code configurations by what you're trying to do: code review, testing, security, deployment, debugging, databases, APIs, and more. Curated directories of skills, agents, plugins, MCP servers, and hooks for each use case.",
+  keywords: [
+    "claude code use cases",
+    "claude code by use case",
+    "claude code workflows",
+    "claude code code review",
+    "claude code testing",
+    "claude code security",
+  ],
+  openGraph: {
+    title: "Claude Code by Use Case",
+    description:
+      "Curated directories of Claude Code skills, agents, plugins, and MCP servers for every common use case.",
+    url: `${BASE_URL}/for`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Claude Code by Use Case",
+    description:
+      "Curated directories of Claude Code skills, agents, plugins, and MCP servers for every common use case.",
+  },
+  alternates: { canonical: `${BASE_URL}/for` },
+};
+
+export default function UseCaseIndexPage() {
+  const counts = getUseCaseCounts();
+
+  return (
+    <div className="container py-8">
+      <CollectionPageJsonLd
+        name="Claude Code by Use Case"
+        description="Curated cross-type directories for common Claude Code workflows."
+        url={`${BASE_URL}/for`}
+        itemCount={useCases.length}
+      />
+
+      <div className="mb-10 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">Claude Code by Use Case</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Start with what you&apos;re trying to do. Each page pulls together
+          skills, agents, plugins, MCP servers, prompts, hooks, and how-tos for
+          a single workflow — so you can see every Claude Code configuration
+          that helps with, say, code review or deployment in one place.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {useCases.map((useCase) => (
+          <Link key={useCase.slug} href={`/for/${useCase.slug}`}>
+            <Card className="h-full hover:bg-accent/50 transition-colors cursor-pointer">
+              <CardHeader>
+                <div className="flex items-start justify-between gap-2">
+                  <CardTitle className="text-lg">{useCase.title}</CardTitle>
+                  <span className="text-xs text-muted-foreground shrink-0 pt-1">
+                    {counts[useCase.slug] ?? 0} items
+                  </span>
+                </div>
+                <CardDescription className="line-clamp-3">
+                  {useCase.description}
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/hooks/topic/[tag]/page.tsx
+++ b/src/app/hooks/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { HookCard } from "@/components/cards/hook-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllHookTags, getHooksByTag } from "@/data/hooks";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function HookTopicPage(props: Props) {
           <HookCard key={hook.slug} hook={hook} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/how-to/topic/[tag]/page.tsx
+++ b/src/app/how-to/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { HowToCard } from "@/components/cards/how-to-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllHowToTags, getHowTosByTag } from "@/data/how-to";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function HowToTopicPage(props: Props) {
           <HowToCard key={howTo.slug} howTo={howTo} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/mcp-servers/topic/[tag]/page.tsx
+++ b/src/app/mcp-servers/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MCPCard } from "@/components/cards/mcp-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllMCPServerTags, getMCPServersByTag } from "@/data/mcp-servers";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function MCPServerTopicPage(props: Props) {
           <MCPCard key={server.slug} server={server} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,9 @@ import { getFeaturedAgents } from "@/data/agents";
 import { getFeaturedBlogPosts } from "@/data/blog";
 import { getRecentlyAdded } from "@/data/recently-added";
 import { RecentItemCard } from "@/components/cards/recent-item-card";
-import { Terminal, FileText, Server, Webhook, Zap, Puzzle, BookOpen, Bot, Newspaper, ArrowRight, Github, Clock, Mail } from "lucide-react";
+import { useCases } from "@/data/use-cases";
+import { getUseCaseCounts } from "@/lib/use-cases";
+import { Terminal, FileText, Server, Webhook, Zap, Puzzle, BookOpen, Bot, Newspaper, ArrowRight, Github, Clock, Mail, Compass } from "lucide-react";
 
 const categories = [
   {
@@ -84,6 +86,7 @@ export default function Home() {
   const featuredAgents = getFeaturedAgents();
   const featuredBlogPosts = getFeaturedBlogPosts();
   const recentlyAdded = getRecentlyAdded(6);
+  const useCaseCounts = getUseCaseCounts();
 
   return (
     <div className="flex flex-col">
@@ -137,6 +140,39 @@ export default function Home() {
             </p>
             <NewsletterSignup source="home_hero" />
           </div>
+        </div>
+      </section>
+
+      {/* Browse by Use Case */}
+      <section className="container py-12 border-t">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-2">
+            <Compass className="h-5 w-5 text-muted-foreground" />
+            <h2 className="text-2xl font-bold">Browse by Use Case</h2>
+          </div>
+          <Button variant="ghost" asChild>
+            <Link href="/for">
+              View all
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+        <p className="text-muted-foreground mb-6 max-w-3xl">
+          Skills, agents, plugins, MCP servers, prompts, hooks, and guides — grouped by what you&apos;re trying to do.
+        </p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          {useCases.map((useCase) => (
+            <Link key={useCase.slug} href={`/for/${useCase.slug}`}>
+              <Card className="h-full hover:bg-accent/50 transition-colors cursor-pointer">
+                <CardHeader className="p-4">
+                  <CardTitle className="text-sm">{useCase.title}</CardTitle>
+                  <CardDescription className="text-xs">
+                    {useCaseCounts[useCase.slug] ?? 0} items
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Link>
+          ))}
         </div>
       </section>
 

--- a/src/app/plugins/topic/[tag]/page.tsx
+++ b/src/app/plugins/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PluginCard } from "@/components/cards/plugin-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllPluginTags, getPluginsByTag } from "@/data/plugins";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function PluginTopicPage(props: Props) {
           <PluginCard key={plugin.slug} plugin={plugin} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/prompts/topic/[tag]/page.tsx
+++ b/src/app/prompts/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PromptCard } from "@/components/cards/prompt-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { prompts, getAllPromptTags, getPromptsByTag } from "@/data/prompts";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function PromptTopicPage(props: Props) {
           <PromptCard key={prompt.slug} prompt={prompt} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import { plugins, getAllPluginTags } from "@/data/plugins";
 import { howTos, getAllHowToTags } from "@/data/how-to";
 import { agents, getAllAgentTags } from "@/data/agents";
 import { blogPosts, getAllBlogPostTags } from "@/data/blog";
+import { useCases } from "@/data/use-cases";
 import { BASE_URL } from "@/lib/constants";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -74,7 +75,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily",
       priority: 0.8,
     },
+    {
+      url: `${BASE_URL}/for`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
   ];
+
+  // Use-case directory pages
+  const useCasePages: MetadataRoute.Sitemap = useCases.map((u) => ({
+    url: `${BASE_URL}/for/${u.slug}`,
+    lastModified: now,
+    changeFrequency: "weekly" as const,
+    priority: 0.85,
+  }));
 
   // Dynamic pages - Prompts
   const promptPages: MetadataRoute.Sitemap = prompts.map((item) => ({
@@ -163,5 +178,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...agentPages,
     ...blogPages,
     ...topicPages,
+    ...useCasePages,
   ];
 }

--- a/src/app/skills/topic/[tag]/page.tsx
+++ b/src/app/skills/topic/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SkillCard } from "@/components/cards/skill-card";
 import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { RelatedUseCases } from "@/components/related-use-cases";
 import { getAllSkillTags, getSkillsByTag } from "@/data/skills";
 import { formatTagName } from "@/lib/utils";
 import { ArrowLeft } from "lucide-react";
@@ -91,6 +92,8 @@ export default async function SkillTopicPage(props: Props) {
           <SkillCard key={skill.slug} skill={skill} />
         ))}
       </div>
+
+      <RelatedUseCases tag={tag} />
 
       <div className="border-t pt-6">
         <h2 className="text-sm font-medium text-muted-foreground mb-3">

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Terminal, Rss } from "lucide-react";
 import { NewsletterSignup } from "@/components/newsletter-signup";
+import { useCases } from "@/data/use-cases";
 
 export function Footer() {
   return (
@@ -18,6 +19,28 @@ export function Footer() {
             className="md:w-[420px]"
             buttonLabel="Subscribe"
           />
+        </div>
+        <div className="mb-8 rounded-lg border bg-card/40 p-5">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="font-semibold text-sm">Browse by Use Case</h3>
+            <Link
+              href="/for"
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              See all
+            </Link>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
+            {useCases.map((u) => (
+              <Link
+                key={u.slug}
+                href={`/for/${u.slug}`}
+                className="hover:text-foreground transition-colors"
+              >
+                {u.title}
+              </Link>
+            ))}
+          </div>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
           <div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { useState } from "react";
 
 const navigation = [
+  { name: "Use Cases", href: "/for" },
   { name: "Prompts", href: "/prompts" },
   { name: "MCP Servers", href: "/mcp-servers" },
   { name: "Hooks", href: "/hooks" },

--- a/src/components/related-use-cases.tsx
+++ b/src/components/related-use-cases.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { getUseCasesForTag } from "@/lib/use-cases";
+
+export function RelatedUseCases({ tag }: { tag: string }) {
+  const matches = getUseCasesForTag(tag);
+  if (matches.length === 0) return null;
+
+  return (
+    <div className="border-t pt-6 mb-6">
+      <h2 className="text-sm font-medium text-muted-foreground mb-3">
+        Use cases that include {tag}
+      </h2>
+      <div className="flex flex-wrap gap-2">
+        {matches.map((u) => (
+          <Link key={u.slug} href={`/for/${u.slug}`}>
+            <Badge className="cursor-pointer hover:bg-accent" variant="default">
+              {u.title} →
+            </Badge>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/use-cases.ts
+++ b/src/data/use-cases.ts
@@ -1,0 +1,193 @@
+export interface UseCase {
+  slug: string;
+  title: string;
+  headline: string;
+  description: string;
+  keywords: string[];
+  tags: string[];
+  primaryTopic: string;
+}
+
+export const useCases: UseCase[] = [
+  {
+    slug: "code-review",
+    title: "Code Review",
+    headline: "Claude Code setups for code review",
+    description:
+      "Automate pull request reviews, catch bugs before they ship, and enforce quality standards. Curated skills, agents, plugins, and hooks that plug Claude Code into your review workflow.",
+    keywords: [
+      "claude code code review",
+      "automated pr review",
+      "pull request review ai",
+      "code quality claude code",
+    ],
+    tags: ["code-review", "review", "quality", "audit", "pr"],
+    primaryTopic: "code-review",
+  },
+  {
+    slug: "testing",
+    title: "Testing",
+    headline: "Claude Code setups for testing",
+    description:
+      "Generate tests, run them on save, and keep coverage honest. Skills, agents, MCP servers, and hooks that help Claude Code write, run, and monitor tests across your stack.",
+    keywords: [
+      "claude code testing",
+      "test generation ai",
+      "tdd claude code",
+      "e2e testing claude",
+    ],
+    tags: ["testing", "tdd", "e2e", "coverage", "qa"],
+    primaryTopic: "testing",
+  },
+  {
+    slug: "security",
+    title: "Security",
+    headline: "Claude Code setups for security",
+    description:
+      "Scan for vulnerabilities, block leaked secrets, guard against prompt injection, and audit dependencies. Defensive configurations for Claude Code across skills, hooks, and agents.",
+    keywords: [
+      "claude code security",
+      "security audit ai",
+      "secret scanning claude",
+      "prompt injection defense",
+    ],
+    tags: [
+      "security",
+      "audit",
+      "owasp",
+      "vulnerability",
+      "secrets",
+      "prompt-injection",
+      "scanning",
+    ],
+    primaryTopic: "security",
+  },
+  {
+    slug: "git-workflows",
+    title: "Git Workflows",
+    headline: "Claude Code setups for Git and GitHub",
+    description:
+      "Commit messages, branch hygiene, PR authoring, and GitHub automation. Skills, agents, hooks, and MCP servers that make Claude Code a first-class citizen in your Git workflow.",
+    keywords: [
+      "claude code git",
+      "git automation claude",
+      "commit message ai",
+      "github claude code",
+    ],
+    tags: ["git", "github", "commit", "branch", "conventional-commits"],
+    primaryTopic: "git",
+  },
+  {
+    slug: "documentation",
+    title: "Documentation",
+    headline: "Claude Code setups for documentation",
+    description:
+      "Write and maintain docs without the drag. Generate API references, changelogs, walkthroughs, and READMEs with skills, agents, and plugins that keep documentation in sync with code.",
+    keywords: [
+      "claude code documentation",
+      "api docs ai",
+      "changelog generator claude",
+      "readme claude code",
+    ],
+    tags: ["documentation", "changelog", "api-docs"],
+    primaryTopic: "documentation",
+  },
+  {
+    slug: "debugging",
+    title: "Debugging",
+    headline: "Claude Code setups for debugging",
+    description:
+      "Bisect, trace, and triage faster. Skills, agents, MCP servers, and how-tos that help Claude Code find the root cause instead of patching symptoms.",
+    keywords: [
+      "claude code debugging",
+      "debug with claude",
+      "git bisect claude",
+      "error triage ai",
+    ],
+    tags: ["debugging", "troubleshooting", "errors"],
+    primaryTopic: "debugging",
+  },
+  {
+    slug: "performance",
+    title: "Performance",
+    headline: "Claude Code setups for performance",
+    description:
+      "Profile, benchmark, and optimize with Claude Code. Skills, agents, and plugins that surface bottlenecks and guide real improvements — not guesswork.",
+    keywords: [
+      "claude code performance",
+      "performance optimization ai",
+      "benchmarking claude code",
+      "profiling ai",
+    ],
+    tags: ["performance", "optimization", "benchmarking", "profiling"],
+    primaryTopic: "performance",
+  },
+  {
+    slug: "deployment",
+    title: "Deployment & CI/CD",
+    headline: "Claude Code setups for deployment and CI/CD",
+    description:
+      "Ship safely. Docker, Kubernetes, release automation, and pipeline integrations — skills, agents, plugins, and MCP servers that make Claude Code part of your deployment loop.",
+    keywords: [
+      "claude code deployment",
+      "ci/cd claude code",
+      "docker claude code",
+      "kubernetes ai",
+    ],
+    tags: [
+      "deployment",
+      "ci-cd",
+      "docker",
+      "kubernetes",
+      "release",
+      "containers",
+    ],
+    primaryTopic: "deployment",
+  },
+  {
+    slug: "databases",
+    title: "Databases",
+    headline: "Claude Code setups for databases",
+    description:
+      "Query, migrate, and optimize across SQL and NoSQL. MCP servers, skills, and agents for Postgres, MySQL, Redis, and more — wired into Claude Code.",
+    keywords: [
+      "claude code database",
+      "sql claude code",
+      "postgres claude",
+      "database migration ai",
+    ],
+    tags: [
+      "database",
+      "postgres",
+      "sql",
+      "migrations",
+      "mysql",
+      "redis",
+      "nosql",
+    ],
+    primaryTopic: "database",
+  },
+  {
+    slug: "api-development",
+    title: "API Development",
+    headline: "Claude Code setups for API development",
+    description:
+      "REST, GraphQL, OpenAPI, SDK generation. Skills, agents, plugins, and MCP servers that help Claude Code design, document, and implement APIs end-to-end.",
+    keywords: [
+      "claude code api",
+      "rest api claude code",
+      "graphql ai",
+      "openapi claude code",
+    ],
+    tags: ["api", "rest", "graphql", "openapi", "swagger", "sdk"],
+    primaryTopic: "api",
+  },
+];
+
+export function getUseCaseBySlug(slug: string): UseCase | undefined {
+  return useCases.find((u) => u.slug === slug);
+}
+
+export function getAllUseCaseSlugs(): string[] {
+  return useCases.map((u) => u.slug);
+}

--- a/src/lib/use-cases.ts
+++ b/src/lib/use-cases.ts
@@ -1,0 +1,73 @@
+import { skills } from "@/data/skills";
+import { agents } from "@/data/agents";
+import { plugins } from "@/data/plugins";
+import { mcpServers } from "@/data/mcp-servers";
+import { prompts } from "@/data/prompts";
+import { hooks } from "@/data/hooks";
+import { howTos } from "@/data/how-to";
+import type {
+  Skill,
+  Agent,
+  Plugin,
+  MCPServer,
+  Prompt,
+  Hook,
+  HowTo,
+} from "@/lib/types";
+import { useCases, type UseCase } from "@/data/use-cases";
+
+export interface UseCaseMatches {
+  skills: Skill[];
+  agents: Agent[];
+  plugins: Plugin[];
+  mcpServers: MCPServer[];
+  prompts: Prompt[];
+  hooks: Hook[];
+  howTos: HowTo[];
+  total: number;
+}
+
+function matches(itemTags: string[], useCaseTags: string[]): boolean {
+  const set = new Set(itemTags);
+  return useCaseTags.some((t) => set.has(t));
+}
+
+export function getMatchesForUseCase(useCase: UseCase): UseCaseMatches {
+  const matchedSkills = skills.filter((s) => matches(s.tags, useCase.tags));
+  const matchedAgents = agents.filter((a) => matches(a.tags, useCase.tags));
+  const matchedPlugins = plugins.filter((p) => matches(p.tags, useCase.tags));
+  const matchedMcp = mcpServers.filter((m) => matches(m.tags, useCase.tags));
+  const matchedPrompts = prompts.filter((p) => matches(p.tags, useCase.tags));
+  const matchedHooks = hooks.filter((h) => matches(h.tags, useCase.tags));
+  const matchedHowTos = howTos.filter((h) => matches(h.tags, useCase.tags));
+
+  return {
+    skills: matchedSkills,
+    agents: matchedAgents,
+    plugins: matchedPlugins,
+    mcpServers: matchedMcp,
+    prompts: matchedPrompts,
+    hooks: matchedHooks,
+    howTos: matchedHowTos,
+    total:
+      matchedSkills.length +
+      matchedAgents.length +
+      matchedPlugins.length +
+      matchedMcp.length +
+      matchedPrompts.length +
+      matchedHooks.length +
+      matchedHowTos.length,
+  };
+}
+
+export function getUseCasesForTag(tag: string): UseCase[] {
+  return useCases.filter((u) => u.tags.includes(tag));
+}
+
+export function getUseCaseCounts(): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const uc of useCases) {
+    counts[uc.slug] = getMatchesForUseCase(uc).total;
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary
- Scale the directory format that's working (/skills has 14.5% bounce, 2.13 views/user) by adding 10 cross-type **use-case** pages at `/for/<use-case>` that pull matching items from all 7 content types (skills, agents, plugins, MCP servers, prompts, hooks, how-tos).
- Curated taxonomy: `code-review`, `testing`, `security`, `git-workflows`, `documentation`, `debugging`, `performance`, `deployment`, `databases`, `api-development`.
- Aggressive cross-linking so pages compound: Use Cases entry in the header nav, a "Browse by Use Case" panel on the homepage (above categories) and in the footer (visible on every page), and related-use-case chips on every `/<type>/topic/[tag]` page whose tag maps to a use case.
- Sitemap entries for `/for` and all 10 subpages.

## Why
Directory pages compound: each one ranks for long-tail queries and multiplies internal page views per session. Cross-type pages pull from 7 content pools per URL (vs. 1 for the existing per-type topic pages), and the `/<type>/topic/[tag]` → `/for/<use-case>` links turn single-type landings into multi-section browsing sessions.

## What's in the diff
- `src/data/use-cases.ts` — curated taxonomy with SEO metadata and tag mappings into the existing tag vocabulary.
- `src/lib/use-cases.ts` — helpers that pull matching items from all content types and compute per-use-case counts.
- `src/app/for/[useCase]/page.tsx` + `src/app/for/page.tsx` — index + detail pages with JSON-LD, canonical URLs, and "view all" links back into per-type topic pages.
- `src/components/related-use-cases.tsx` — shared component inserted into all 8 topic pages.
- `src/components/layout/header.tsx` + `footer.tsx` + `src/app/page.tsx` — navigation surfaces.

## Test plan
- [ ] `npm run build` — confirm 10 `/for/<use-case>` pages and `/for` index prerender as static
- [ ] Visit `/for` — index lists all 10 use cases with item counts
- [ ] Visit `/for/testing` — sections render for each content type that has matches, with "Browse all X" links
- [ ] Visit `/skills/topic/testing` — "Use cases that include testing" chip appears above "Browse more topics"
- [ ] Header nav shows "Use Cases" as first item (desktop + mobile)
- [ ] Footer shows "Browse by Use Case" panel on every page
- [ ] Homepage: "Browse by Use Case" section renders above "Browse by Category"