### PR TITLE
SEO: action-led titles + metas for underperforming Google queries

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -88,13 +88,16 @@ export async function generateMetadata(props: Props) {
 
   const url = `${BASE_URL}/blog/${post.slug}`;
 
+  const title = post.seoTitle ?? `${post.title} - Claude Directory Blog`;
+  const description = post.seoDescription ?? post.description;
+
   return {
-    title: `${post.title} - Claude Directory Blog`,
-    description: post.description,
+    title,
+    description,
     keywords: [...post.tags, "claude code", "blog", "ai development"],
     openGraph: {
-      title: `${post.title} - Claude Directory Blog`,
-      description: post.description,
+      title,
+      description,
       url,
       type: "article",
       publishedTime: new Date(post.publishedDate).toISOString(),
@@ -109,8 +112,8 @@ export async function generateMetadata(props: Props) {
     },
     twitter: {
       card: "summary_large_image",
-      title: `${post.title} - Claude Directory Blog`,
-      description: post.description,
+      title,
+      description,
       images: [`${BASE_URL}/og/blog/${post.slug}.png`],
     },
     alternates: {

--- a/src/app/how-to/[slug]/page.tsx
+++ b/src/app/how-to/[slug]/page.tsx
@@ -30,20 +30,23 @@ export async function generateMetadata(props: Props) {
 
   const url = `${BASE_URL}/how-to/${howTo.slug}`;
 
+  const title = howTo.seoTitle ?? `${howTo.title} - Claude Code Guide`;
+  const description = howTo.seoDescription ?? howTo.description;
+
   return {
-    title: `${howTo.title} - Claude Code Guide`,
-    description: howTo.description,
+    title,
+    description,
     keywords: [...howTo.tags, "claude code", "guide", "tutorial", "how to"],
     openGraph: {
-      title: `${howTo.title} - Claude Code Guide`,
-      description: howTo.description,
+      title,
+      description,
       url,
       type: "article",
     },
     twitter: {
       card: "summary",
-      title: `${howTo.title} - Claude Code Guide`,
-      description: howTo.description,
+      title,
+      description,
     },
     alternates: {
       canonical: url,

--- a/src/app/mcp-servers/[slug]/page.tsx
+++ b/src/app/mcp-servers/[slug]/page.tsx
@@ -28,20 +28,27 @@ export async function generateMetadata(props: Props) {
 
   const url = `${BASE_URL}/mcp-servers/${server.slug}`;
 
+  const title =
+    server.seoTitle ??
+    `Add ${server.title} to Claude Code – MCP Setup Guide (2026)`;
+  const description =
+    server.seoDescription ??
+    `${server.description} Copy-paste the JSON config into your Claude Code settings.`;
+
   return {
-    title: `${server.title} MCP Server for Claude Code | Config & Setup`,
-    description: `${server.description} Copy-paste the JSON config into your Claude Code settings.`,
+    title,
+    description,
     keywords: [...server.tags, "claude code", "mcp server", "model context protocol", server.title.toLowerCase()],
     openGraph: {
-      title: `${server.title} MCP Server for Claude Code | Config & Setup`,
-      description: `${server.description} Copy-paste the JSON config into your Claude Code settings.`,
+      title,
+      description,
       url,
       type: "article",
     },
     twitter: {
       card: "summary",
-      title: `${server.title} MCP Server for Claude Code | Config & Setup`,
-      description: `${server.description} Copy-paste the JSON config into your Claude Code settings.`,
+      title,
+      description,
     },
     alternates: {
       canonical: url,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,6 +23,24 @@ import { getFeaturedBlogPosts } from "@/data/blog";
 import { getRecentlyAdded } from "@/data/recently-added";
 import { RecentItemCard } from "@/components/cards/recent-item-card";
 import { Terminal, FileText, Server, Webhook, Zap, Puzzle, BookOpen, Bot, Newspaper, ArrowRight, Github, Clock, Mail } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: {
+    absolute: "Claude Directory – Community Alternative to claude.ai/directory",
+  },
+  description:
+    "The community-curated Claude AI directory. Browse 100+ prompts, MCP servers, hooks, skills, plugins, and agents for Claude Code. Copy-paste setup in seconds.",
+  openGraph: {
+    title: "Claude Directory – Community Alternative to claude.ai/directory",
+    description:
+      "The community-curated Claude AI directory. Browse 100+ prompts, MCP servers, hooks, skills, plugins, and agents for Claude Code. Copy-paste setup in seconds.",
+  },
+  twitter: {
+    title: "Claude Directory – Community Alternative to claude.ai/directory",
+    description:
+      "The community-curated Claude AI directory. Browse 100+ prompts, MCP servers, hooks, skills, plugins, and agents for Claude Code. Copy-paste setup in seconds.",
+  },
+};
 
 const categories = [
   {

--- a/src/app/plugins/[slug]/page.tsx
+++ b/src/app/plugins/[slug]/page.tsx
@@ -28,20 +28,27 @@ export async function generateMetadata(props: Props) {
 
   const url = `${BASE_URL}/plugins/${plugin.slug}`;
 
+  const title =
+    plugin.seoTitle ??
+    `Install ${plugin.title} – Claude Code Plugin Setup Guide (2026)`;
+  const description =
+    plugin.seoDescription ??
+    `Install with \`${plugin.installCommand}\`. ${plugin.description}`;
+
   return {
-    title: `${plugin.title} - Claude Code Plugin | Install & Setup Guide`,
-    description: `${plugin.description} One-command install for Claude Code.`,
+    title,
+    description,
     keywords: [...plugin.tags, "claude code", "plugin", "extension", plugin.title.toLowerCase()],
     openGraph: {
-      title: `${plugin.title} - Claude Code Plugin | Install & Setup Guide`,
-      description: `${plugin.description} One-command install for Claude Code.`,
+      title,
+      description,
       url,
       type: "article",
     },
     twitter: {
       card: "summary",
-      title: `${plugin.title} - Claude Code Plugin | Install & Setup Guide`,
-      description: `${plugin.description} One-command install for Claude Code.`,
+      title,
+      description,
     },
     alternates: {
       canonical: url,

--- a/src/app/skills/[slug]/page.tsx
+++ b/src/app/skills/[slug]/page.tsx
@@ -28,20 +28,27 @@ export async function generateMetadata(props: Props) {
 
   const url = `${BASE_URL}/skills/${skill.slug}`;
 
+  const title =
+    skill.seoTitle ??
+    `${skill.title} – Claude Code Skill & Slash Command (2026)`;
+  const description =
+    skill.seoDescription ??
+    `${skill.description} Copy this skill into .claude/commands/ and use it instantly.`;
+
   return {
-    title: `${skill.title} - Claude Code Skill | Ready-to-Use Slash Command`,
-    description: `${skill.description} Copy this skill into .claude/commands/ and use it instantly.`,
+    title,
+    description,
     keywords: [...skill.tags, "claude code", "skill", "slash command", skill.title.toLowerCase()],
     openGraph: {
-      title: `${skill.title} - Claude Code Skill | Ready-to-Use Slash Command`,
-      description: `${skill.description} Copy this skill into .claude/commands/ and use it instantly.`,
+      title,
+      description,
       url,
       type: "article",
     },
     twitter: {
       card: "summary",
-      title: `${skill.title} - Claude Code Skill | Ready-to-Use Slash Command`,
-      description: `${skill.description} Copy this skill into .claude/commands/ and use it instantly.`,
+      title,
+      description,
     },
     alternates: {
       canonical: url,

--- a/src/data/blog/anthropic-claude-certification-program.ts
+++ b/src/data/blog/anthropic-claude-certification-program.ts
@@ -6,6 +6,10 @@ export const anthropicClaudeCertificationProgram: BlogPost = {
     "The Anthropic Claude Certification Program: Everything You Need to Know",
   description:
     "Anthropic just launched its first official certification — the Claude Certified Architect. Here's what it covers, who it's for, and how to prepare.",
+  seoTitle:
+    "Claude Certified Architect (CCA) Exam – Anthropic's Proctored Skilljar Certification Guide",
+  seoDescription:
+    "Complete guide to Anthropic's Claude Certification Program and the Claude Certified Architect (CCA) exam. Skilljar-proctored, 60 questions — topics, format, cost, and how to prepare.",
   publishedDate: "2026-03-16",
   tags: [
     "claude-code",

--- a/src/data/blog/claude-code-cheat-sheet.ts
+++ b/src/data/blog/claude-code-cheat-sheet.ts
@@ -459,6 +459,7 @@ Short description of what this codebase does.
 - [MCP Servers Guide](/blog/mcp-servers-guide)
 - [10x Productivity Workflows with Claude Code](/blog/claude-code-workflows-10x-productivity)
 - [Best Claude Code Plugins](/blog/best-claude-code-plugins)
+- [anthropic certification](/blog/anthropic-claude-certification-program) — the Claude Certified Architect (CCA) exam and how to prepare
 
 ---
 

--- a/src/data/blog/claude-code-workflows-10x-productivity.ts
+++ b/src/data/blog/claude-code-workflows-10x-productivity.ts
@@ -372,7 +372,7 @@ If you're new to Claude Code workflows, start with these three:
 2. **Lint Fixer** (#5) — Immediate quality-of-life improvement
 3. **PR Machine** (#2) — The biggest time savings for most developers
 
-Then explore the rest as your workflow matures. Browse our full collection of [hooks](/hooks), [MCP servers](/mcp-servers), [agents](/agents), and [skills](/skills) to build your own custom workflows.
+Then explore the rest as your workflow matures. Browse our full collection of [hooks](/hooks), [MCP servers](/mcp-servers), [agents](/agents), and [skills](/skills) to build your own custom workflows. If you want to formalize what you've learned, Anthropic now offers an official [anthropic certification](/blog/anthropic-claude-certification-program) — the Claude Certified Architect exam covers workflow design, tool integration, and enterprise rollout.
 
 ---
 

--- a/src/data/blog/designing-with-claude.ts
+++ b/src/data/blog/designing-with-claude.ts
@@ -221,5 +221,6 @@ If you're building with Claude Code: this expands what "designing with Claude" m
 - [Vibe Coding with Claude Code](/blog/vibe-coding-claude-code) — Natural-language development, now extended to visual artifacts
 - [Context Engineering for Claude Code](/blog/context-engineering-claude-code) — Why design-system context matters for quality output
 - [10x Productivity Workflows with Claude Code](/blog/claude-code-workflows-10x-productivity) — Day-to-day patterns that now extend into design work
+- [anthropic certification](/blog/anthropic-claude-certification-program) — The Claude Certified Architect exam, for teams formalizing design + engineering workflows
 `,
 };

--- a/src/data/how-to/claude-folder.ts
+++ b/src/data/how-to/claude-folder.ts
@@ -1,0 +1,169 @@
+import { HowTo } from "@/lib/types";
+
+export const claudeFolderHowTo: HowTo = {
+  slug: "claude-folder",
+  title: "What is the .claude folder? Structure, purpose, and examples",
+  description:
+    "The .claude folder is where Claude Code stores settings, agents, commands, hooks, and skills. Learn its structure, what goes in each subdirectory, and see real examples.",
+  seoTitle: "The .claude Directory Explained – Structure of the Claude Code Config Folder (2026)",
+  seoDescription: "What the .claude directory is, what goes in each subfolder (agents, commands, hooks, skills, settings.json, CLAUDE.md), and how global vs project .claude folders layer. With examples.",
+  difficulty: "beginner",
+  timeToComplete: "8 min",
+  tags: ["claude-folder", "configuration", "getting-started", "claude-code"],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    { type: "how-to", slug: "memory", relationship: "recommends" },
+    { type: "how-to", slug: "hooks", relationship: "recommends" },
+    { type: "how-to", slug: "skills", relationship: "recommends" },
+    { type: "how-to", slug: "slash-commands", relationship: "recommends" },
+  ],
+  content: `# What is the .claude folder?
+
+The \`.claude\` folder is the central configuration directory for Claude Code. It holds your settings, custom agents, slash commands, hooks, skills, and CLAUDE.md memory files. Claude Code reads it automatically at startup — no flags or environment variables required.
+
+There are two scopes:
+
+- **Global**: \`~/.claude/\` — applies to every project on your machine
+- **Project**: \`.claude/\` in your repo root — applies only to that project
+
+Project settings take precedence over global settings, and both layer on top of Claude Code's defaults.
+
+## Structure
+
+A fully-configured \`.claude\` folder looks like this:
+
+\`\`\`text
+.claude/
+├── CLAUDE.md            # Persistent project/user memory
+├── settings.json        # Shared settings (commit this to git)
+├── settings.local.json  # Local-only overrides (gitignored)
+├── agents/              # Custom subagent definitions
+│   └── code-reviewer.md
+├── commands/            # Custom slash commands
+│   └── review.md
+├── hooks/               # PreToolUse / PostToolUse / Stop scripts
+│   └── block-secrets.sh
+├── skills/              # Skills (reusable workflows)
+│   └── security-review/
+│       └── SKILL.md
+├── plugins/             # Installed plugin manifests
+└── projects/            # Session transcripts and state
+\`\`\`
+
+Not every folder needs to exist — Claude Code creates them on demand.
+
+## What each piece does
+
+### \`CLAUDE.md\`
+Plain-text memory loaded into every session. Put project conventions, tech stack, commands, and anything Claude should know without being told. See the [memory guide](/how-to/memory) for format tips.
+
+### \`settings.json\`
+Shared configuration: permissions, model selection, environment variables, hook registrations, MCP servers. Safe to commit.
+
+### \`settings.local.json\`
+Personal overrides — API keys, machine-specific paths, experiments. Add it to \`.gitignore\`.
+
+### \`agents/\`
+Each file is a Markdown document with YAML frontmatter defining a specialized subagent (name, description, tools, model). Claude Code delegates to them via the Agent tool.
+
+### \`commands/\`
+Each file is a slash command. Filename becomes the command: \`commands/review.md\` → \`/review\`. The body is the prompt that runs when invoked.
+
+### \`hooks/\`
+Scripts executed on tool events — block dangerous commands, auto-format on write, send a notification when Claude stops. Wire them up in \`settings.json\` under the \`hooks\` key.
+
+### \`skills/\`
+Reusable multi-step workflows. Each skill is a folder containing a \`SKILL.md\` with metadata and instructions. Claude loads the index on startup and invokes skills when the user's request matches.
+
+### \`plugins/\`
+Manifests for plugins installed via \`claude plugins add …\`. Usually not edited by hand.
+
+### \`projects/\`
+Per-session history and state. Safe to delete if you want a clean slate; Claude Code will rebuild it.
+
+## Quick-start example
+
+Minimal project \`.claude/\` for a TypeScript repo:
+
+\`\`\`text
+.claude/
+├── CLAUDE.md
+└── settings.json
+\`\`\`
+
+\`\`\`markdown
+# CLAUDE.md
+
+## Stack
+- Next.js 15 App Router
+- TypeScript strict mode
+- Tailwind v4
+
+## Commands
+- \`pnpm dev\` — dev server
+- \`pnpm test\` — Vitest
+- \`pnpm lint\` — ESLint
+
+## Conventions
+- Named exports only
+- Zod for runtime validation
+\`\`\`
+
+\`\`\`json
+{
+  "permissions": {
+    "allow": ["Bash(pnpm *)", "Bash(git status)", "Bash(git diff *)"]
+  }
+}
+\`\`\`
+
+That's enough to give Claude Code durable context and let it run your build commands without prompting.
+
+## Global vs project: what goes where
+
+| Location | Good for |
+|----------|----------|
+| \`~/.claude/CLAUDE.md\` | Your personal coding style, preferred languages, universal rules |
+| \`~/.claude/commands/\` | Commands you want in every project (e.g. \`/commit\`) |
+| \`~/.claude/settings.json\` | Global permissions, default model, your API keys |
+| \`.claude/CLAUDE.md\` | Project tech stack, conventions, current focus |
+| \`.claude/settings.json\` | Project-specific permissions, hooks, MCP servers |
+| \`.claude/agents/\` | Subagents that understand this codebase specifically |
+
+## Should I commit \`.claude/\` to git?
+
+Yes — commit the shared files so your team inherits the same setup:
+
+- \`.claude/CLAUDE.md\`
+- \`.claude/settings.json\`
+- \`.claude/agents/\`
+- \`.claude/commands/\`
+- \`.claude/skills/\`
+- \`.claude/hooks/\`
+
+Gitignore the personal/ephemeral pieces:
+
+\`\`\`gitignore
+.claude/settings.local.json
+.claude/projects/
+\`\`\`
+
+## Common gotchas
+
+- **Files don't load:** check filename case — \`CLAUDE.md\` must be uppercase, \`settings.json\` must be lowercase.
+- **Hook not firing:** make sure it's registered in \`settings.json\` *and* the script is executable (\`chmod +x\`).
+- **Command not found:** slash commands use the filename (without \`.md\`) — \`commands/my-review.md\` → \`/my-review\`.
+- **Settings ignored:** project \`settings.json\` overrides global; check both if something seems wrong.
+
+## Where to go next
+
+- [Using CLAUDE.md for project memory](/how-to/memory)
+- [Writing custom slash commands](/how-to/slash-commands)
+- [Claude Code hooks](/how-to/hooks)
+- [Building skills](/how-to/skills)
+`,
+};

--- a/src/data/how-to/index.ts
+++ b/src/data/how-to/index.ts
@@ -14,9 +14,11 @@ import { debuggingHowTo } from "./debugging";
 import { cicdIntegrationHowTo } from "./cicd-integration";
 import { multiPlatformSetupHowTo } from "./multi-platform-setup";
 import { backgroundAgentsWorktreesHowTo } from "./background-agents-worktrees";
+import { claudeFolderHowTo } from "./claude-folder";
 
 export const howTos: HowTo[] = [
   backgroundAgentsWorktreesHowTo,
+  claudeFolderHowTo,
   gettingStartedHowTo,
   memoryHowTo,
   slashCommandsHowTo,

--- a/src/data/mcp-servers/elasticsearch.ts
+++ b/src/data/mcp-servers/elasticsearch.ts
@@ -4,6 +4,8 @@ export const elasticsearchServer: MCPServer = {
   slug: "elasticsearch",
   title: "Elasticsearch Server",
   description: "Search, index, and analyze data in Elasticsearch clusters with natural language queries",
+  seoTitle: "Elastic (Elasticsearch) MCP Server for Claude Code – Setup Guide (2026)",
+  seoDescription: "Connect Elastic / Elasticsearch to Claude Code via MCP. Query indexes, analyze logs, and run searches from the terminal — copy-paste JSON config and API key setup included.",
   tags: ["search", "elasticsearch", "analytics", "logging", "community"],
   featured: false,
   author: {

--- a/src/data/mcp-servers/grafana.ts
+++ b/src/data/mcp-servers/grafana.ts
@@ -4,6 +4,8 @@ export const grafanaServer: MCPServer = {
   slug: "grafana",
   title: "Grafana Server",
   description: "Query Grafana dashboards, alerts, and datasources for observability and monitoring workflows",
+  seoTitle: "Add Grafana MCP to Claude Code – Dashboards, Alerts & Datasources (2026)",
+  seoDescription: "Step-by-step guide to add the Grafana MCP server to Claude Code. Query dashboards, alerts, and datasources from the terminal — copy-paste JSON config included.",
   tags: ["monitoring", "grafana", "observability", "dashboards", "community"],
   featured: false,
   author: {

--- a/src/data/plugins/feature-dev.ts
+++ b/src/data/plugins/feature-dev.ts
@@ -4,6 +4,8 @@ export const featureDevPlugin: Plugin = {
   slug: "feature-dev",
   title: "Feature Development",
   description: "Guided feature development with codebase understanding and architecture focus. A comprehensive 7-phase workflow for building features systematically with specialized agents for exploration, architecture, and review.",
+  seoTitle: "Install feature-dev@claude-plugins-official – Claude Code Plugin Setup (2026)",
+  seoDescription: "Complete 2026 guide to installing feature-dev. Run `claude plugins add feature-dev@claude-plugins-official` for a 7-phase guided workflow: discovery, exploration, architecture, implementation, and review.",
   tags: ["feature", "development", "architecture", "official", "workflow"],
   featured: true,
   author: {

--- a/src/data/plugins/figma.ts
+++ b/src/data/plugins/figma.ts
@@ -4,6 +4,8 @@ export const figmaPlugin: Plugin = {
   slug: "figma",
   title: "Figma",
   description: "Figma design tool integration. Extract design specs, generate code from designs, access component libraries, and bridge the gap between design and development.",
+  seoTitle: "Install figma@claude-plugins-official – Claude Code Figma Plugin Setup (2026)",
+  seoDescription: "Install with `claude plugins add figma@claude-plugins-official`. Extract design specs, generate code from Figma components, and export design tokens — complete setup guide.",
   tags: ["design", "ui", "collaboration", "official"],
   featured: false,
   author: {

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -4,6 +4,8 @@ export const frontendDesignPlugin: Plugin = {
   slug: "frontend-design",
   title: "Frontend Design",
   description: "Create distinctive, production-grade frontend interfaces with high design quality. UI/UX specialist plugin that generates polished, creative code avoiding generic AI aesthetics. Supports React, Vue, Svelte, and vanilla HTML/CSS with modern design patterns.",
+  seoTitle: "Install Frontend Design Plugin for Claude Code – frontend-design@claude-plugins-official (2026)",
+  seoDescription: "Step-by-step install guide for the frontend-design plugin. Run `claude plugins add frontend-design@claude-code-plugins` in Claude Code to generate production-grade React, Vue, and Svelte UIs — setup in under a minute.",
   tags: ["frontend", "design", "ui", "ux", "react", "official"],
   featured: true,
   author: {

--- a/src/data/skills/pr.ts
+++ b/src/data/skills/pr.ts
@@ -4,6 +4,8 @@ export const prSkill: Skill = {
   slug: "pr",
   title: "Create Pull Request",
   description: "Generate comprehensive pull request descriptions and create PRs via GitHub CLI",
+  seoTitle: "Claude Create PR – /pr Slash Command to Open GitHub Pull Requests (2026)",
+  seoDescription: "Use Claude Code to create a pull request automatically. The /pr skill analyzes your branch, writes a descriptive PR title and body, and opens it via `gh pr create` — copy-paste setup.",
   tags: ["git", "github", "pr", "workflow"],
   featured: true,
   author: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,8 @@ export interface MCPServer {
   dateAdded?: string;
   relatedItems?: RelatedItem[];
   repoUrl?: string;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 export interface Hook {
@@ -73,6 +75,8 @@ export interface Skill {
   dateAdded?: string;
   relatedItems?: RelatedItem[];
   repoUrl?: string;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 export interface Plugin {
@@ -88,6 +92,8 @@ export interface Plugin {
   relatedItems?: RelatedItem[];
   commands?: { name: string; description: string }[];
   repoUrl?: string;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 export interface HowTo {
@@ -103,6 +109,8 @@ export interface HowTo {
   dateAdded?: string;
   relatedItems?: RelatedItem[];
   repoUrl?: string;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 export interface Agent {
@@ -131,6 +139,8 @@ export interface BlogPost {
   dateAdded?: string;
   relatedItems?: RelatedItem[];
   repoUrl?: string;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 export type ContentItem = Prompt | MCPServer | Hook | Skill | Plugin | HowTo | Agent | BlogPost;


### PR DESCRIPTION
## Summary

Lifts Google CTR on queries we already rank for (positions 3–12) by rewriting title tags and meta descriptions with action-oriented language, and by adding one new page plus a handful of internal anchor links.

Targets ~18 queries across three priority tiers with combined potential of ~100 extra clicks/month at constant impressions.

## What changed

**Infrastructure**
- Added optional `seoTitle` / `seoDescription` to `Plugin`, `MCPServer`, `BlogPost`, `Skill`, and `HowTo` in `src/lib/types.ts`.
- Every `[slug]/page.tsx` for those content types now prefers the per-item SEO fields and falls back to a tightened default. New defaults lead with action verbs (`Install …`, `Add …`).
- Home page (`src/app/page.tsx`) gets an explicit `metadata` export with `title.absolute` to bypass the `| Claude Directory` template from the root layout.

**Per-item rewrites**
| Query | Target page | New title |
|---|---|---|
| `claude.ai/directory` / `claude ai directory` | `/` | `Claude Directory – Community Alternative to claude.ai/directory` |
| `claude plugin install figma@claude-plugins-official` | `/plugins/figma` | `Install figma@claude-plugins-official – Claude Code Figma Plugin Setup (2026)` |
| `/plugin install frontend-design@claude-plugins-official`, `claude install frontend design plugin`, `install frontend-design@claude-code-plugins` | `/plugins/frontend-design` | `Install Frontend Design Plugin for Claude Code – frontend-design@claude-plugins-official (2026)` |
| `feature-dev` | `/plugins/feature-dev` | `Install feature-dev@claude-plugins-official – Claude Code Plugin Setup (2026)` |
| `add grafana mcp to claude code`, `grafana mcp claude code` | `/mcp-servers/grafana` | `Add Grafana MCP to Claude Code – Dashboards, Alerts & Datasources (2026)` |
| `elastic` + `claude code` | `/mcp-servers/elasticsearch` | `Elastic (Elasticsearch) MCP Server for Claude Code – Setup Guide (2026)` |
| `anthropic claude certification program`, `claude certified architect`, `cca`, `skilljar`, `proctored` | `/blog/anthropic-claude-certification-program` | `Claude Certified Architect (CCA) Exam – Anthropic's Proctored Skilljar Certification Guide` |
| `claude create pr` | `/skills/pr` | `Claude Create PR – /pr Slash Command to Open GitHub Pull Requests (2026)` |

**New page**
- `src/data/how-to/claude-folder.ts` — `/how-to/claude-folder`, titled `The .claude Directory Explained – Structure of the Claude Code Config Folder (2026)`. Targets `.claude folder` and `claude .claude directory` queries; registered in `src/data/how-to/index.ts` so it appears in the sitemap automatically.

**Internal anchor links**
Three mentions of `anthropic certification` (exact anchor text) pointing to `/blog/anthropic-claude-certification-program` to push it from position 12 into the top 10:
- `src/data/blog/claude-code-cheat-sheet.ts` (Related reading)
- `src/data/blog/claude-code-workflows-10x-productivity.ts` (closing paragraph)
- `src/data/blog/designing-with-claude.ts` (Further Reading)

## Why

CTR at 3.48% across 14,426 monthly Google impressions is well below where it should be — the pages are visible but the snippets aren't earning the click. Lifting average CTR to 6% on existing impressions would roughly double Google clicks (~360 extra visits/month) with no new content needed.

## Reviewer notes

- No install commands were changed. The `frontend-design` plugin has a mismatch between the user-facing install command (`@claude-code-plugins`) and what users search for (`@claude-plugins-official`, matching the repo name). The new metadata covers both strings but leaves the actual command untouched — worth a separate look.
- The `/skills/pr` slug was kept as-is rather than renamed to `create-pr`. The existing URL already ranks at position 5.2 and a rename would trade a known ranking for new URL churn. Metadata was retuned in-place instead.
- All metadata verified live in rendered HTML via `next dev` before committing.
- Typecheck and `next build` pass clean.

## Test plan

- [ ] Pull the branch, run `npm run dev`, confirm titles/descriptions render on: `/`, `/plugins/figma`, `/plugins/frontend-design`, `/plugins/feature-dev`, `/mcp-servers/grafana`, `/mcp-servers/elasticsearch`, `/blog/anthropic-claude-certification-program`, `/skills/pr`, `/how-to/claude-folder`.
- [ ] Confirm the three internal anchor links use `anthropic certification` as the link text and point to the cert post.
- [ ] Spot-check that non-target plugin/MCP/skill/how-to pages still get reasonable default titles (action verbs kicked in).
- [ ] After merge, request re-crawl of the target URLs in Google Search Console and watch CTR / position shifts over 2–4 weeks.