### PR TITLE
Add blog post: Claude Cowork for business users

### DIFF
--- a/src/data/blog/claude-cowork-for-business-users.ts
+++ b/src/data/blog/claude-cowork-for-business-users.ts
@@ -1,0 +1,301 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeCoworkForBusinessUsers: BlogPost = {
+  slug: "claude-cowork-for-business-users",
+  title:
+    "Claude Cowork for Business Users: Stop Using Claude Like Google, Start Handing It Your Files",
+  description:
+    "Ops leads, sales managers, marketers, and PMs are pouring into Claude — but most are using it like a smarter search box. Here's the Claude Cowork workflow that actually moves work: hand over your .pptx, .xlsx, and .docx files and get a finished file back.",
+  publishedDate: "2026-04-23",
+  tags: [
+    "claude-cowork",
+    "business",
+    "productivity",
+    "non-technical",
+    "skills",
+    "pptx",
+    "xlsx",
+    "docx",
+    "operations",
+    "sales",
+    "marketing",
+    "project-management",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-skills-non-coding-use-cases",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-dispatch-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "how-to-create-claude-skills",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-workflows-10x-productivity",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-md-guide",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Claude Cowork for Business Users: Stop Using Claude Like Google, Start Handing It Your Files
+
+Something has shifted in the last few months. The wave of people showing up to Claude isn't just engineers anymore. It's ops leads trying to automate their weekly board pack. Sales managers rebuilding the pipeline review deck for the fifth time this quarter. Marketers drafting campaign briefs. Project managers translating a 60-message Slack thread into a real status update their execs will actually read.
+
+We've been heavy Claude users ourselves, we talk to a lot of customers, and we keep seeing the same pattern with business users who are new to it:
+
+**They're using Claude like a smarter Google.**
+
+They type a question, read an answer. They ask it to "write a better email" and paste the result back into Outlook. That's real value — better than Google, faster than a colleague — but it's a rounding error compared to what Claude is actually for if you're doing knowledge work.
+
+The part they're missing is the part that matters most: **you can hand Claude your actual \`.pptx\`, \`.xlsx\`, and \`.docx\` files, and it will hand you back a finished file.** Not a summary. Not a suggestion. The file itself. Updated. Formatted. Ready to send.
+
+That's Claude Cowork. And if you're a business user, this is the one post you should read before you do anything else with it.
+
+---
+
+## What Claude Cowork Actually Is (For Non-Engineers)
+
+Before we go further: a quick reset, because the product surface has gotten crowded.
+
+- **Claude.ai** is the chat interface most people start with. Type a question, get an answer.
+- **Claude Code** is the terminal/CLI tool developers use. Not relevant for this post.
+- **Claude Cowork** is the one you want. It's the desktop-native experience designed for real knowledge work — the one that reads your files, edits them, and gives them back to you.
+
+Cowork lives inside Claude Desktop (the Mac/Windows app). When you drag a PowerPoint into the conversation, it doesn't just read the slides and describe them. It *opens* the file, *understands* its structure (layouts, masters, speaker notes, embedded charts), and can produce a new \`.pptx\` with your edits applied. Same for Excel — real formulas, real formatting, real sheets — and Word, including styles, tables of contents, tracked changes, and page numbers.
+
+If you've only used Claude by pasting text into a chat box, this will feel like a different product. It is.
+
+---
+
+## The Pattern Business Users Keep Missing
+
+Here's the specific gap we see over and over again.
+
+**What most business users do:**
+
+1. Open Claude.
+2. Type: *"Write me a good summary of last quarter's revenue for a board update."*
+3. Copy the answer.
+4. Paste into PowerPoint or Word.
+5. Spend 20 minutes reformatting, reflowing, fixing fonts, redoing tables.
+
+**What Claude Cowork is actually designed for:**
+
+1. Open Cowork.
+2. Drag the existing board deck into the conversation.
+3. Attach the Q1 financials spreadsheet.
+4. Type: *"Update the revenue slides using Q1 actuals from the attached sheet. Keep the same layout and speaker notes. Flag anything that looks off."*
+5. Get back an updated \`.pptx\` with the new numbers, formatting intact, and a short note at the bottom of the chat: *"Gross margin compressed 3 points vs. plan — wanted to flag in case that's worth calling out on slide 7."*
+
+Step 5 is the thing. That's the entire point. You didn't get a paragraph of advice — you got the file, and you got a coworker's take on what to look at next.
+
+The reason this matters is simple: **formatting is where knowledge work dies.** Anyone who has rebuilt a slide deck into a brand template, or reconciled a spreadsheet someone emailed them into the master tracker, knows that the "thinking" part of the work is maybe 20% of the time. The other 80% is moving bits around. Claude Cowork eats the 80%.
+
+---
+
+## The Files Worth Handing Over
+
+If you take one thing from this post, it's the list of things to drag into Cowork instead of asking Claude to regenerate from scratch.
+
+### PowerPoint (\`.pptx\`)
+
+- **Quarterly board decks** — update numbers, refresh charts, regenerate the narrative slides from raw notes.
+- **Sales pipeline reviews** — drop in the CRM export, get the deck rebuilt with current stages and deal sizes.
+- **Customer business reviews (QBRs)** — hand it the prior QBR plus the last 90 days of account activity and get a personalized draft for each customer.
+- **Internal all-hands** — last quarter's template plus this quarter's highlights → finished deck.
+- **Partner/investor updates** — reuse your existing layout, feed in the new data, keep the visual identity.
+
+**The prompt that unlocks it:** *"Use the attached deck as the template. Keep layouts, fonts, and masters. Update content using the attached [data source]."*
+
+### Excel (\`.xlsx\`)
+
+- **Monthly/quarterly finance roll-ups** — consolidate exports from multiple sources into your master sheet, preserving your formulas.
+- **Pipeline tracking** — normalize messy CRM exports into your standard format with your column order, your labels, your formulas.
+- **Campaign performance trackers** — pull ad platform CSVs into your master attribution model.
+- **OKR trackers** — update progress, calculate variance, highlight at-risk items.
+- **Pricing and discount analysis** — model scenarios against your real pipeline data.
+
+Claude Cowork handles real formulas. It can add new sheets, pivot the data, apply conditional formatting, and keep your existing named ranges intact. This is not a text-to-spreadsheet toy.
+
+### Word (\`.docx\`)
+
+- **Proposals and SOWs** — start from your standard template, plug in the customer details, keep the styles.
+- **Policy documents** — refresh an outdated HR or compliance doc with your TOC, page numbers, and headers intact.
+- **Meeting notes → status reports** — hand it the raw notes, get a polished stakeholder-ready doc back.
+- **Long-form research** — existing draft plus new sources → next revision, with tracked changes so your editor can see what moved.
+- **Letterhead-correct external letters** — template in, custom letter out, with your logo and formatting preserved.
+
+### PDFs
+
+Cowork reads PDFs natively. Contracts, research reports, scanned forms, financial statements — drag them in and ask for extraction, comparison, or summarization. The output goes wherever you want: a Word memo, a spreadsheet of line items, a slide with the key takeaways.
+
+---
+
+## What This Looks Like Role By Role
+
+We've watched this pattern click for business users across a few specific roles. Here are the use cases we keep hearing about — the ones where people go *"oh — this is different."*
+
+### Operations Leads
+
+The weekly ops review. You have:
+- A metrics dashboard export (CSV or sheet).
+- Last week's review deck.
+- Three Slack threads about incidents or escalations.
+
+**Old workflow:** You spend Friday afternoon rebuilding the deck and writing the narrative. 90 minutes, sometimes two hours, every week.
+
+**Cowork workflow:** Drop all three inputs into a conversation. *"Update last week's ops deck. Pull the metrics from the CSV. Summarize incidents from the Slack threads into the risks slide. Keep the same format."* You read the output, tweak two things, send it. 15 minutes.
+
+### Sales Managers
+
+Pipeline reviews, QBRs, and forecast calls are the obvious wins. The less-obvious one: **deal-specific prep.**
+
+Drop in the account's last three call transcripts, the MSA, and the proposal deck. *"Give me a one-pager on where we stand going into Tuesday's expansion conversation — risks, open questions, and three specific things to lead with based on what they've told us."* You get a doc back. You read it on the train. You walk in prepared.
+
+### Marketers
+
+Campaign recaps live and die on formatting. You have three ad platform exports, a creative asset folder, and a campaign brief.
+
+*"Build the wrap-up deck using the attached brief as the template. Pull spend and conversion from the platform exports. For each creative, add a slide with the top-line metrics. Flag the two worst performers so I can speak to them."* The deck is done before the first coffee.
+
+For content work: hand Cowork a brand voice doc plus last month's five blog posts, and it now writes *in your voice* for the next brief. That's a skill-adjacent pattern — see the section below.
+
+### Project Managers
+
+The weekly status report is the killer use case. You have:
+- Jira/Linear export (or a CSV dump of tickets).
+- Meeting notes from standups.
+- Last week's status doc.
+
+*"Update the status doc. Pull ticket status from the CSV. Flag anything that moved from green to yellow or yellow to red. Use the same template as last week."*
+
+The compounding value: Claude Cowork has persistent memory of your format preferences. Over a few weeks, it learns your template and the narrative style your leadership expects. Weekly status drops from an hour to ten minutes, and the ten minutes are the high-leverage part — your actual judgment calls on what to escalate.
+
+---
+
+## The Mental Model: What To Send vs. What To Ask
+
+Most business users get more out of Cowork in a week after they internalize this distinction.
+
+| If you want... | You should... |
+|---|---|
+| A quick answer, a definition, an explanation | Just ask — this is the "smarter Google" mode |
+| A paragraph or email draft | Ask, then paste |
+| **A finished deliverable in the right format** | **Attach the template and the data, then ask for the file back** |
+| Repeated work done the same way every time | Build a [skill](/blog/how-to-create-claude-skills) |
+
+The third row is the one people miss. It looks like more work upfront — you have to find the template, find the data, attach both — but it saves you the reformatting step, which is where the actual hour goes.
+
+The fourth row is how you go from "this is useful" to "this has changed how I work." Which brings us to —
+
+---
+
+## Skills: The Business-User Multiplier
+
+Skills are a Claude feature that lets you save a workflow once and reuse it as a simple command. Most coverage of skills has been developer-focused, but they are *at least* as valuable for business users, maybe more, because business work is more repetitive than most engineers realize.
+
+A skill is just a short file that tells Claude: *"When I ask you to run this, here's exactly what to do."* You don't have to write code. You write instructions in plain English.
+
+**Examples of business-user skills that pay for themselves in a week:**
+
+- \`/weekly-status\` — "Read the latest standup notes and Jira export. Update the standard status template. Flag movers. Email me when ready."
+- \`/qbr [customer]\` — "Pull the last 90 days of activity for this customer. Generate the QBR deck using our template."
+- \`/board-pack\` — "Update the monthly board deck using the finance sheet, the ops metrics sheet, and the product roadmap doc."
+- \`/campaign-recap\` — "For the named campaign, pull platform exports, build the recap deck, flag underperformers."
+- \`/deal-prep [account]\` — "Generate a one-page brief using the last three calls and the open proposal."
+
+You build the skill once. After that, you type the command. The deliverable shows up. No more rediscovering which files go in, no more reminding Claude what your template looks like, no more reformatting.
+
+We've written a dedicated guide on this: [How to Create Claude Skills](/blog/how-to-create-claude-skills), and [15 Non-Coding Use Cases](/blog/claude-skills-non-coding-use-cases) with templates you can steal.
+
+For a business user, the TL;DR is: **if you do it more than twice a month, turn it into a skill.** The upfront investment is 15 minutes. The payback is every Monday for the rest of the year.
+
+---
+
+## The Five Mistakes Business Users Make Early On
+
+From watching this adoption curve up close, the same handful of mistakes keep showing up. Avoid these and you'll be ahead of 90% of your peers.
+
+### 1. Treating Claude like a search engine
+
+The "smarter Google" use case is real, but it's the shallowest thing Cowork does. If every conversation you have is a single question and a single answer, you are leaving most of the value on the table. Ask yourself at the end of the day: *"How many files did I hand Claude today?"* If the answer is zero, you're not using the product.
+
+### 2. Copy-pasting text instead of attaching files
+
+If the data lives in a spreadsheet, attach the spreadsheet. If the template is a PowerPoint, attach the PowerPoint. Pasting text into the chat loses structure — formulas, formatting, speaker notes, styles, relationships between sheets. Cowork is specifically designed to preserve all of that. Use it.
+
+### 3. Not telling Claude what "good" looks like
+
+The single biggest quality lever is giving Cowork an example. "Here's last quarter's version — match this tone, structure, and length" produces night-and-day better output than a generic prompt. The example is more instructive than any amount of adjectives.
+
+### 4. Skipping skills because they "sound technical"
+
+Skills feel like a developer concept. They're not. A skill is a saved instruction you can trigger by name. If you can write an email describing what you want, you can write a skill. Pretending you'll remember to structure your Monday report the same way next week is how work ends up inconsistent and slow.
+
+### 5. Giving up after one bad output
+
+If the first draft is off, don't start over. Tell Cowork what's wrong: *"Slides 3 and 4 should be combined. The chart on slide 6 is the wrong scale. The tone on the executive summary is too casual — match slide 2."* Claude holds the file in context. The second draft is almost always the one that ships.
+
+---
+
+## A Realistic First Week
+
+If you're a business user reading this and wondering where to start, here's the one-week plan we give people.
+
+**Day 1.** Open Claude Desktop. Install Cowork if you haven't. Drop your most recent finished deliverable — a deck, a report, a spreadsheet — into a conversation and ask: *"What would you do differently with this next time?"* Read the response. You're calibrating.
+
+**Day 2.** Pick one recurring file you own. The weekly status, the monthly report, the quarterly review. Do it with Cowork for real. Attach the previous version plus the new data. Ask for the next version.
+
+**Day 3.** Do the same task again, but this time pay attention to what you had to correct. That's the instruction set for your first skill.
+
+**Day 4.** Write the skill. It's a plain-English file. See our [skill creation guide](/blog/how-to-create-claude-skills).
+
+**Day 5.** Use the skill. Tune it. This is also the day to set up [Claude Dispatch](/blog/claude-dispatch-guide) if you want to hand off tasks from your phone — great for "kick off the Monday report from my commute."
+
+**Day 6–7.** Pick one more workflow. Repeat.
+
+By the end of week two, you'll have three or four skills that collectively save you 3–5 hours a week. By the end of month one, that number is usually 8–10.
+
+---
+
+## Where This Fits In The Bigger Picture
+
+Most of the press around Claude has been about agents, coding, and frontier benchmarks. Those are real, but they are not where the bulk of real-world value is being unlocked right now. The bulk of it is sitting inside the \`.pptx\`, \`.xlsx\`, and \`.docx\` files that run every business on earth.
+
+Claude Cowork is the product that takes those files seriously. Not as text to paraphrase — as structured artifacts to edit and ship back.
+
+If you're an ops lead, a sales manager, a marketer, or a PM, and you've been using Claude as a faster search box, you're not wrong, you're just early. The next step is the one that actually changes how your Monday mornings work. Drag in the file. Ask for the file back. Build the skill. Do it again next week.
+
+That's the whole game.
+
+---
+
+## Related Reading
+
+- [15 Non-Coding Use Cases for Claude Skills](/blog/claude-skills-non-coding-use-cases) — ready-to-steal skill templates for writing, research, and project management.
+- [How to Create Claude Skills](/blog/how-to-create-claude-skills) — the complete guide, written for non-developers.
+- [Claude Dispatch Guide](/blog/claude-dispatch-guide) — run Cowork from your phone.
+- [10x Productivity Workflows with Claude](/blog/claude-code-workflows-10x-productivity) — daily workflow patterns that scale.
+- [Complete \`CLAUDE.md\` Guide](/blog/claude-md-guide) — how to teach Claude your team's conventions so every output lands closer to "done."
+
+---
+
+*Last updated: April 23, 2026. Claude Cowork is evolving fast; features and file-format support expand regularly. If something here is out of date, open an issue on the [Claude Directory repo](https://github.com/tmcpa/claudedirectory).*
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -23,8 +23,10 @@ import { claudeOpus47DeepReasoning } from "./claude-opus-4-7-deep-reasoning";
 import { designingWithClaude } from "./designing-with-claude";
 import { claudeCodeCheatSheet } from "./claude-code-cheat-sheet";
 import { ultrareviewClaudeCodeGuide } from "./ultrareview-claude-code-guide";
+import { claudeCoworkForBusinessUsers } from "./claude-cowork-for-business-users";
 
 export const blogPosts: BlogPost[] = [
+  claudeCoworkForBusinessUsers,
   ultrareviewClaudeCodeGuide,
   claudeCodeCheatSheet,
   designingWithClaude,


### PR DESCRIPTION
## Summary

New featured blog post targeting the growing wave of non-engineer Claude users — ops leads, sales managers, marketers, PMs — who've been adopting Claude but using it like a smarter Google.

**Core thesis:** business users are missing the highest-value workflow — hand Claude your actual `.pptx`, `.xlsx`, `.docx` files and get a finished file back.

## What's in the post

- The "smarter Google" pattern we keep seeing with business users and what they're missing
- What Claude Cowork actually is (for readers who haven't used it)
- The file handoff workflow with concrete prompts
- Role-by-role use cases: operations, sales, marketing, project management
- Send-vs-ask mental model
- Skills as the multiplier for repeat work (with examples like `/weekly-status`, `/qbr`, `/board-pack`)
- Five common early-adoption mistakes
- A realistic one-week getting-started plan

## SEO / engagement

- Title leads with the brand term ("Claude Cowork for Business Users")
- Featured on the blog index (first position)
- Tags cover `claude-cowork`, `business`, `non-technical`, `pptx`, `xlsx`, `docx`, and each role keyword
- Internal links to the skills guide, dispatch guide, workflows post, and CLAUDE.md guide

## Files changed

- New: `src/data/blog/claude-cowork-for-business-users.ts`
- Modified: `src/data/blog/index.ts` (registered at top of post list)

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Verify post renders at `/blog/claude-cowork-for-business-users`
- [ ] Verify it appears first on the `/blog` index
- [ ] Spot-check internal links resolve
- [ ] Confirm sitemap picks up the new slug