### PR TITLE
Add blog post: Claude Code for non-engineers in technical codebases

### DIFF
--- a/src/data/blog/claude-code-for-non-engineers-in-engineering-codebases.ts
+++ b/src/data/blog/claude-code-for-non-engineers-in-engineering-codebases.ts
@@ -1,0 +1,313 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeCodeForNonEngineersInEngineeringCodebases: BlogPost = {
+  slug: "claude-code-for-non-engineers-in-engineering-codebases",
+  title:
+    "Claude Code for Non-Engineers in a Technical Codebase: How to Ship Without Pissing Off Engineering",
+  description:
+    "PMs, marketers, designers, and ops people are now opening Claude Code on real production repos. Here's how to actually ship useful changes — and the specific things that make engineers want to revoke your access.",
+  publishedDate: "2026-04-27",
+  tags: [
+    "claude-code",
+    "non-technical",
+    "engineering",
+    "collaboration",
+    "code-review",
+    "pull-requests",
+    "workflow",
+    "codebase",
+    "etiquette",
+    "productivity",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-cowork-for-business-users",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-md-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-cheat-sheet",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "ultrareview-claude-code-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-workflows-10x-productivity",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "vibe-coding-claude-code",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Claude Code for Non-Engineers in a Technical Codebase: How to Ship Without Pissing Off Engineering
+
+A new pattern is showing up in serious engineering orgs, and it's making a specific set of people very nervous.
+
+The pattern: a product manager opens Claude Code on the actual product repo to fix a string of marketing copy. A designer pulls down the frontend repo to tweak a color token directly instead of waiting on the design system PR. A marketer edits a pricing constant. An ops engineer adjusts a config flag that's been on the team's backlog for two months. None of these people would have touched the codebase six months ago. Now they're opening pull requests.
+
+The nervous people are the engineers who own those repos.
+
+This post is for both groups, but especially for the non-engineer side. **Claude Code can absolutely make you productive in a codebase you don't fully understand. It can also blow up the trust your engineering team has extended you in a single bad PR.** The difference is almost entirely about a handful of habits — most of which are obvious in hindsight, but only after someone has burned the trust once.
+
+If you're a PM, marketer, designer, ops lead, or analyst who has started using Claude Code on a real engineering codebase, read this before your next PR.
+
+---
+
+## Why This Is Suddenly A Real Conversation
+
+Three things happened at roughly the same time:
+
+1. **Claude Code got good enough that non-engineers can drive it.** Plan mode, [auto memory](/blog/claude-code-auto-memory-guide), [CLAUDE.md](/blog/claude-md-guide), and the recent UX work mean you don't have to know what \`git rebase\` does to make a clean change.
+2. **Engineering orgs ran out of patience for "small change, three-week ticket."** A copy fix waiting in the backlog for a sprint is embarrassing. If a PM can ship it in 20 minutes with a tagged review, that's a strict win.
+3. **Companies started shipping access more broadly.** Internal Claude Code usage policies stopped being engineering-only. Permissions got tightened, hooks got installed, but the door is now open to a lot more people.
+
+The combination is great. It's also the exact moment trust gets tested. **The engineers haven't blocked you out yet. Whether they keep you in depends on what your first ten PRs look like.**
+
+---
+
+## What Actually Pisses Engineers Off
+
+Let's be specific. The complaints we hear from engineering teams about non-engineer Claude Code users cluster into a small set, and almost all of them are avoidable.
+
+### 1. PRs that touch fifty files when they should touch one
+
+The number-one offender. You opened Claude Code to change one string. Claude — being helpful — also reformatted the file, "improved" three nearby functions, regenerated the lockfile, and moved an import. Your PR is now a 2,000-line diff and the reviewer has to read all of it to find your one-line change.
+
+Engineers don't review the change you intended. They review the diff. If the diff is enormous, the diff is what gets blamed when something breaks.
+
+### 2. Surprise refactors
+
+Closely related: "while you were in there, Claude decided the function should be split in two." You did not ask. You did not understand the implications. The reviewer is now arguing with cleanup work they didn't sign up for, on a PR that was supposed to be about a config value.
+
+### 3. New dependencies you didn't notice were added
+
+A non-engineer almost never has the context to evaluate a new dependency. License, maintenance status, supply-chain risk, bundle size, transitive deps — these are real considerations that engineering teams take seriously. If your PR adds a package and your reasoning is "Claude said it would be cleaner," you have just made the reviewer's day worse and possibly created a real security conversation.
+
+### 4. Generated tests that don't actually test anything
+
+Claude is good at producing tests that *look like* tests. A test that calls the function and asserts it doesn't throw is not a test. A test that mocks the entire module under test is not a test. Engineers can spot these in two seconds, and once they spot one, the rest of your PR is suspect.
+
+### 5. Conventions broken for no reason
+
+The codebase uses single quotes. Your changes use double quotes. The codebase uses functional components with hooks. Your changes introduce a class component because Claude defaulted to one. Existing helpers do exactly what you need; your PR adds a parallel utility.
+
+These look minor. They are not minor to the people who maintain the code. Convention drift is one of the loudest "this person doesn't know what they're doing" signals there is.
+
+### 6. Force pushes, branch chaos, and "I'll just merge it"
+
+Force-pushing a shared branch. Pushing directly to \`main\`. Self-approving a PR. Bypassing CI because "the failure is unrelated." Every one of these is a culture violation in any real engineering org. None of them are necessary, ever, for the kind of change a non-engineer should be making.
+
+### 7. Touching things you weren't supposed to touch
+
+Production configs. Database migrations. Environment files. Auth code. Anything in a directory that has CODEOWNERS. Anything labeled "do not edit." Claude will happily edit any of it if you ask. The fact that it *can* doesn't mean you *should*.
+
+### 8. PRs with no context
+
+"Update copy." Forty-seven files changed. No description. No screenshots. No before/after. The reviewer has to reverse-engineer what you were trying to accomplish from the diff. This is the single fastest way to get put on a "review last" list.
+
+### 9. Quoting Claude during code review
+
+When an engineer leaves a review comment, the worst possible response is: *"But Claude said this was the right approach."* The engineer's reaction — every time — is to wonder whether you're capable of evaluating their feedback at all. Claude is your collaborator, not your authority. Push back if you have a real reason. Don't push back with an appeal to the model.
+
+### 10. Not running the thing
+
+You changed the homepage. Did you load the homepage? You touched the build config. Did you run a build? "It compiled" and "the tests passed" are not the same as "I ran it and saw it work." Engineers can tell the difference, and it's the single biggest signal of whether your PR was actually exercised before being submitted.
+
+---
+
+## The Trust Contract
+
+Here's the thing nobody says out loud. Engineering teams letting non-engineers into the codebase is *not* a permissions decision. It's a trust decision. The permissions are the formal version. The trust is the actual version.
+
+The trust contract sounds like this:
+
+> *You can ship changes here without an engineer holding your hand, because we believe (a) you'll stay in your lane, (b) you'll catch your own mistakes before we see them, and (c) when we do raise something, you'll listen.*
+
+Every PR you submit either reinforces or erodes that. Six clean, scoped PRs and the team starts merging your work without much fuss. One PR that breaks production or pulls in 80 unrelated changes and you're back to "everything goes through engineering review for two weeks while we figure out what's safe."
+
+The good news: the work to honor that contract is small. It's habit, not skill.
+
+---
+
+## The Habits That Keep You In The Codebase
+
+### Use plan mode before you let Claude touch anything
+
+Run \`/plan\` first. Read what it's proposing. If the plan mentions files you don't recognize, directories you didn't expect, or actions like "refactor" or "extract" or "modernize," stop. Edit the plan. Ask explicitly: *"Only change \`<the specific file>\`. Do not modify anything else. Do not add dependencies. Do not reformat."*
+
+Plan mode is the single most underused feature for non-engineer users, and it's the one that prevents 80% of the problems above.
+
+### Read \`CLAUDE.md\` before you start
+
+Most serious codebases now have a \`CLAUDE.md\` (or several — root, plus per-package). Read it. It tells you the conventions the team has agreed on: naming, testing, commit style, what not to touch. If there isn't one, ask the team to add one. See [the complete CLAUDE.md guide](/blog/claude-md-guide).
+
+If you're going to work in a directory often, ask the codeowner to give you a one-paragraph rundown of the local conventions and add it to \`CLAUDE.md\`. Engineers love this — it's the conversation they wish they could have with every contributor.
+
+### Tightly scope every prompt
+
+Bad: *"Update the pricing page to use the new tier names."*
+
+Good: *"In \`src/app/pricing/page.tsx\`, replace the strings 'Starter', 'Pro', and 'Enterprise' with 'Solo', 'Team', and 'Business'. Do not modify any other file. Do not change any logic. Show me the diff before applying."*
+
+The verbosity is the point. Specificity prevents drift. The five extra seconds you spend writing a precise prompt save the reviewer five minutes — and save you the embarrassing back-and-forth.
+
+### Always ask for the diff before committing
+
+\`git diff\` is your last line of defense. If you can't read code at all, ask Claude to *summarize the diff in plain English, file by file, and flag anything outside the scope I asked for.* You're looking for two things:
+
+1. Did Claude change anything I didn't ask it to change?
+2. Did Claude touch any files I don't recognize?
+
+If yes to either, push back: *"Revert the changes to X. I only want changes to Y."*
+
+### Run the thing locally
+
+If your change is to the frontend, load the page and click through it. If your change is to copy, look at the page in the browser. If your change is to a CLI, run the CLI. If you can't run it locally, that is the problem to solve first — ask the team to help you set up a local dev loop, or have Claude walk you through it. Shipping changes you couldn't run yourself is the highest-risk move a non-engineer can make.
+
+For UI: take a screenshot of before and after and put both in the PR description. Engineers love this. It tells them you actually saw the change.
+
+### Run the tests and the linter — even if you don't know what they do
+
+Find the command. It's probably \`npm test\`, \`pytest\`, or in the README. Run it. If it fails, don't merge. If you don't understand the failure, ask Claude to explain it in plain English, and if it's anything other than "your specific change broke something obvious," tag an engineer.
+
+Same for the linter. If lint fails on your PR, fix it before asking for review. Failed lint on a non-engineer PR is a uniquely annoying way to interrupt an engineer's day.
+
+### Use a worktree or a feature branch — never \`main\`
+
+Always work in a branch. If your tooling supports [worktrees](/blog/claude-code-cheat-sheet), use them. Never push directly to \`main\` or \`master\`. Never force-push. If a tool is suggesting a force push, that's the moment to tag an engineer in Slack and ask them to take over for thirty seconds.
+
+### Open a real PR, with a real description
+
+The PR description is your one chance to set the reviewer up to say yes quickly. Include:
+
+- **What changed** in plain English. *"Updated the three pricing tier names on the marketing pricing page."*
+- **Why.** Link to the doc, ticket, or thread that prompted the change.
+- **What you tested.** *"Loaded \`/pricing\` in dev, confirmed all three names render. Ran \`npm test\`, all pass."*
+- **Screenshots if it's UI.** Always. Even for one-line changes.
+- **Anything you're unsure about.** *"I'm not sure if the same tier names are referenced elsewhere — flagged for reviewer."*
+
+This is the single highest-leverage thing you can do to make engineering happy. A well-written PR description makes you look more careful than you actually are. (Which is fine. The careful behavior comes after a couple of cycles of writing them.)
+
+### Tag the right reviewer, and only that reviewer
+
+Don't send a PR to "the team channel." Find the codeowner of the files you touched (\`CODEOWNERS\` file, or \`git log\` on the file). Tag them specifically. Don't double-tag two engineers because you're nervous — that splits responsibility and slows the review.
+
+### Don't argue review feedback by quoting the model
+
+If an engineer leaves a comment, treat it as ground truth until you have a real reason not to. Real reasons are: *"I tested this, here's what I saw."* Or: *"The doc says X — am I reading it wrong?"* Real reasons are not: *"Claude suggested this approach."*
+
+If you genuinely think Claude is right and the engineer is wrong, the move is to ask, not to argue. *"Claude is suggesting Y here — is there a reason we don't do that in this codebase? Happy to go either way, just want to learn the convention."*
+
+### Permissions and hooks: set them up before you need them
+
+This is the one piece of "engineering work" worth doing for yourself. Spend ten minutes setting up your Claude Code permissions so the tool can't do destructive things by default — no force-pushing, no \`rm -rf\`, no \`git reset --hard\` unless you explicitly approve. See the [hooks guide](/blog/claude-code-hooks-guide) and the [cheat sheet](/blog/claude-code-cheat-sheet) for the configuration. Have an engineer sanity-check it once.
+
+The point isn't paranoia. It's that the *one* time the model gets the wrong end of an instruction, the blast radius should be small.
+
+---
+
+## What To Stay Out Of (Just Skip These)
+
+There are a few areas where the right answer for a non-engineer is almost always *"don't."* Open a ticket and ask an engineer instead.
+
+- **Authentication, authorization, session, or any security-adjacent code.** Even one-line changes here can have outsized blast radius.
+- **Database migrations and schema changes.** The change you can see is rarely the whole change.
+- **Production environment configs.** Tag your SRE/platform team.
+- **CI/CD pipelines.** Breaking CI affects every engineer on the team.
+- **Anything labeled \`@deprecated\`, \`@internal\`, or wrapped in feature flags you don't understand.**
+- **Build tooling, bundler config, package manager config (\`webpack\`, \`vite\`, \`turbo\`, \`pnpm-workspace.yaml\`).**
+- **Anything under \`node_modules\`, \`vendor/\`, or generated directories.** If Claude wants to edit something in a folder named \`generated\` or \`dist\`, that's the warning sign.
+
+A useful rule of thumb: if the file's name has the word "config," "lock," "build," "ci," or "deploy" in it, ask first.
+
+---
+
+## What You Absolutely Can Do
+
+Lest this whole post sound like a list of "don'ts," let's be clear about what you *should* be using Claude Code for. These are the changes engineering teams are happy to see non-engineers ship:
+
+- **Marketing copy, microcopy, error messages, button labels, page titles.** The change you've been waiting on for two sprints.
+- **Static content updates** — pricing pages, feature pages, help docs, blog posts.
+- **Image swaps and asset updates.**
+- **Single-file design tweaks** if you understand the design system — color tokens, spacing, typography in places that don't ripple.
+- **Updating dashboards, internal tools, and admin pages** that are owned by your team.
+- **Config flag changes** that are explicitly delegated to your role (feature flags you own, content flags, region toggles).
+- **Documentation** — \`README\` updates, runbooks, internal docs, the \`CLAUDE.md\` itself.
+- **Test data, fixture data, seed data** if your team is set up for it.
+- **Translations and localization keys** if the i18n system is one you've been onboarded to.
+
+These are the boring, valuable, perpetually-stuck-in-someone's-queue changes. Picking them off without engineering hand-holding is the *whole point* of putting non-engineers into the codebase. It's also the thing engineering teams are most enthusiastic about — fewer tiny tickets in their queue.
+
+---
+
+## A Realistic First Two Weeks
+
+If you're a non-engineer about to start using Claude Code on a real repo, here's the on-ramp we recommend.
+
+**Day 1.** Have an engineer pair with you for thirty minutes. Walk through: cloning, branching, where \`CLAUDE.md\` lives, how to run tests, how to open a PR, who reviews. This conversation saves you a week of fumbling.
+
+**Day 2.** Pick a tiny, low-stakes change. A typo. A copy tweak. Run it through Claude Code end-to-end with plan mode. Open the PR, tag the engineer who paired with you, ask them to review you on form, not just substance.
+
+**Day 3.** Read your own diff before submitting. Read it out loud. Notice anything you didn't mean to change, revert it, resubmit.
+
+**Day 4–5.** Same kind of change, but now actually testing locally before pushing. If you can't run the project locally, this is where you fix that — with help, with Claude, with whatever it takes.
+
+**Week 2.** Pick a slightly bigger change — multiple files, but still in the "obviously safe" category from the section above. Submit a PR with a real description. Ask the reviewer for one piece of substantive feedback ("anything I should be doing differently?") so you keep learning.
+
+By the end of week two, you'll have a calibrated sense of what's safe for you to ship solo and what to escalate. That calibration is the actual skill. Everything else is just typing.
+
+---
+
+## A Note For Engineering Teams Reading This
+
+If you're an engineer reading this from the other side: the worst thing you can do is treat non-engineer Claude Code users as either equal contributors or as banned. The right framing is *junior contributor, with leverage.* They need:
+
+- A clear \`CLAUDE.md\` with conventions and a "do not touch" list.
+- An obvious place to ask "is this safe to do?" — Slack channel, a couple of named buddies, a triage rotation.
+- Permissions and hooks pre-configured so the easy mistakes are impossible.
+- A real first review, not a rubber stamp.
+- A culture that treats their tiny PRs as a feature, not a tax.
+
+The teams that get this right end up with engineers focused on actual engineering work, and non-engineers shipping the perpetual long tail of small changes. The teams that get it wrong end up with engineers gatekeeping every PR while a backlog of trivial fixes never gets done. Same access, very different outcomes.
+
+---
+
+## The Whole Game In One Sentence
+
+Treat Claude Code in someone else's codebase the way you'd treat working in someone else's kitchen: be useful, stay in the section you were invited into, clean up after yourself, and *never* rearrange the spice rack just because you can.
+
+The teams that are pulling this off — non-engineers shipping real changes, engineers staying in flow — aren't using a magic config. They're using the habits above. None of them are hard. All of them are the difference between getting your access expanded and getting it revoked.
+
+---
+
+## Related Reading
+
+- [Claude Cowork for Business Users](/blog/claude-cowork-for-business-users) — for the file-based, non-codebase work where Claude really shines for non-engineers.
+- [Complete \`CLAUDE.md\` Guide](/blog/claude-md-guide) — what your team's conventions file should say, and why.
+- [Claude Code Cheat Sheet](/blog/claude-code-cheat-sheet) — quick reference for the commands and flags you'll actually use.
+- [Ultrareview Guide](/blog/ultrareview-claude-code-guide) — the multi-agent review pass to run before you ask a human to look at your PR.
+- [10x Productivity Workflows](/blog/claude-code-workflows-10x-productivity) — daily patterns that scale.
+- [Vibe Coding with Claude Code](/blog/vibe-coding-claude-code) — the broader debate about non-experts shipping code, with our take.
+
+---
+
+*Last updated: April 27, 2026. The non-engineer-in-the-codebase pattern is evolving fast — what's "safe" today depends on your team, your repo, and your tooling. When in doubt, ask the engineer. If you spot something out of date here, open an issue on the [Claude Directory repo](https://github.com/tmcpa/claudedirectory).*
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -24,8 +24,10 @@ import { designingWithClaude } from "./designing-with-claude";
 import { claudeCodeCheatSheet } from "./claude-code-cheat-sheet";
 import { ultrareviewClaudeCodeGuide } from "./ultrareview-claude-code-guide";
 import { claudeCoworkForBusinessUsers } from "./claude-cowork-for-business-users";
+import { claudeCodeForNonEngineersInEngineeringCodebases } from "./claude-code-for-non-engineers-in-engineering-codebases";
 
 export const blogPosts: BlogPost[] = [
+  claudeCodeForNonEngineersInEngineeringCodebases,
   claudeCoworkForBusinessUsers,
   ultrareviewClaudeCodeGuide,
   claudeCodeCheatSheet,


### PR DESCRIPTION
## Summary

New featured blog post aimed at PMs, marketers, designers, ops, and analysts who have started opening Claude Code on real engineering repos — and at the engineering teams who are nervous about it.

The post argues that the gating factor isn't tooling or permissions but a small set of habits, and lays them out concretely.

## What's covered

- Why this is suddenly a real conversation (Claude Code is good enough, eng patience for tiny tickets is gone, access is broader)
- 10 specific things that piss engineers off — giant diffs, surprise refactors, sneaky deps, fake tests, broken conventions, force-pushes, touching forbidden areas, no PR context, quoting the model in review, not running the change
- The "trust contract" framing
- The habits that keep non-engineers in the codebase: plan mode, CLAUDE.md, scoped prompts, reading diffs, running locally, tests/lint, branches not main, real PR descriptions, tagging the right reviewer, permissions/hooks
- A "stay out of these" list (auth, migrations, prod config, CI/CD, build tooling, generated dirs)
- A "you can absolutely do these" list (copy, static content, design tokens, dashboards, docs, fixtures, i18n)
- A two-week on-ramp plan
- A short note for engineering teams on how to set this up well

## Files

- New: `src/data/blog/claude-code-for-non-engineers-in-engineering-codebases.ts`
- Updated: `src/data/blog/index.ts` (registers the post at the top of the list)

Marked `featured: true`. Cross-links to existing posts (Cowork for Business Users, CLAUDE.md guide, Cheat Sheet, Ultrareview, 10x Workflows, Vibe Coding).

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Visit `/blog/claude-code-for-non-engineers-in-engineering-codebases` in dev — content, related links, and frontmatter render correctly
- [ ] Confirm the post appears at the top of `/blog` and on the homepage featured section
- [ ] Spot-check internal links resolve (CLAUDE.md guide, cheat sheet, ultrareview, etc.)