### PR TITLE
Add blog post: Claude Code Plan Mode guide

### DIFF
--- a/src/data/blog/claude-code-plan-mode-guide.ts
+++ b/src/data/blog/claude-code-plan-mode-guide.ts
@@ -1,0 +1,298 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeCodePlanModeGuide: BlogPost = {
+  slug: "claude-code-plan-mode-guide",
+  title:
+    "Claude Code Plan Mode: The Underrated Feature Behind the Best PRs in 2026",
+  description:
+    "Plan Mode is the difference between agents that ship the right thing and agents that confidently ship the wrong thing. Here's how it works, when to use it, and the habits that turn it into your biggest reliability lever.",
+  publishedDate: "2026-05-03",
+  tags: [
+    "claude-code",
+    "plan-mode",
+    "workflow",
+    "productivity",
+    "advanced",
+    "context-engineering",
+    "code-review",
+    "subagents",
+    "2026",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-code-cheat-sheet",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "context-engineering-claude-code",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-subagents-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-worktrees-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-workflows-10x-productivity",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-md-guide",
+      relationship: "recommends",
+    },
+  ],
+  seoTitle:
+    "Claude Code Plan Mode (2026): When to Use It and How to Get Real Value",
+  seoDescription:
+    "A practical guide to Plan Mode in Claude Code: what it actually does, when it pays off, the failure modes that make people give up on it, and the habits power users build around it.",
+  content: `# Claude Code Plan Mode: The Underrated Feature Behind the Best PRs in 2026
+
+Most Claude Code users discover Plan Mode the same way: they hit a key combination by accident, get a strange "I'll plan first, no edits" prompt back, escape out of it, and never think about it again. A year later they're still wondering why their colleague's PRs always look surgical while their own come back from review with "did you actually read the existing code?" comments.
+
+Plan Mode is the difference. It is the single biggest reliability lever in Claude Code, and it is the most consistently underused feature in the harness. Power users live in it. Most users never enter it. The gap between those two groups, in shipped-code quality, is enormous.
+
+This guide is what I wish someone had handed me a year ago: what Plan Mode actually does, when it earns its keep, when it is wasted ceremony, and the daily habits that turn it from "weird optional thing" into "the reason your agents stop hallucinating fixes."
+
+If you are still building muscle memory for Claude Code basics, the [cheat sheet](/blog/claude-code-cheat-sheet) is a good place to start. This post assumes you have shipped real code with the tool and want to be measurably better at it.
+
+---
+
+## What Plan Mode Actually Is
+
+Plan Mode is a state of the Claude Code session in which the agent is allowed to read, search, and reason about the code, but is not allowed to write to disk, run side-effecting commands, or otherwise change the world. The agent uses that read-only window to produce a concrete plan — usually a structured proposal of what files to change, in what order, and why — and then waits for you to approve it before any of those changes happen.
+
+Three things distinguish it from "just chatting before you let the agent code":
+
+1. **It is enforced by the harness, not by prompting.** The model literally cannot Edit, Write, or run destructive Bash while Plan Mode is on. You are not relying on the agent's good intentions; the tools are gated.
+2. **It produces an artifact.** The plan is a discrete object you can read, critique, modify, and re-issue. It is not a chat message buried in scrollback.
+3. **Exiting Plan Mode is an explicit gate.** The agent does not silently start writing. You approve, or you keep iterating on the plan, or you abandon it.
+
+That third property is the whole point. Plan Mode turns "the agent will start editing in a moment" into a hard checkpoint. It is the difference between watching a contractor draw on the wall and watching them lay out blueprints.
+
+---
+
+## Why Most People Skip It (And Why That's Expensive)
+
+If Plan Mode is so good, why does almost no one use it?
+
+**It feels slow.** A single prompt becomes two: plan, then execute. For a one-line typo fix, it is genuine overhead. People try it once on a trivial task, decide it is theater, and never enable it again.
+
+**The failure mode is invisible.** When an agent skips planning and writes the wrong code, the failure is loud — broken tests, ugly diffs, review comments. When an agent skips planning and writes the *right* code, you feel like you got away with it. You did not. You got lucky on a small task and built a habit that will hurt you on a large one.
+
+**The harness does not nag.** Plan Mode is opt-in. Nothing in the default loop prompts you to enter it. If you do not deliberately reach for it, you will not use it.
+
+**It exposes vagueness.** A good plan requires a clear ask. Many users only realize their request was ambiguous when the plan comes back assuming the wrong thing. That feels like the tool's fault. It is not.
+
+The cost of skipping it shows up in the second-order metrics: rework rate, PRs that grow during review, debugging sessions on code the agent confidently wrote without checking the existing patterns. None of these get blamed on "I should have planned first." All of them are.
+
+---
+
+## The Five Tasks Where Plan Mode Pays for Itself Immediately
+
+You do not need Plan Mode for every prompt. You need it for the ones below. If you adopted no other discipline beyond "use Plan Mode for these five categories," your shipping quality would jump within a week.
+
+### 1. Anything that touches more than one file
+
+The single biggest predictor of "the agent is about to make a mess" is multi-file scope. A change that spans a service, a client, and a test file has at least three places where the agent has to make a judgment call. Each of those is a coin flip without a plan. Plan Mode forces the agent to lay all three out *before* committing to any of them, so you catch a wrong call when it costs nothing.
+
+### 2. Anything that requires understanding existing patterns
+
+"Add a new endpoint that follows our standard pattern" is a great prompt for Plan Mode and a terrible one for the default loop. Without planning, the agent guesses what your standard pattern is and codes against the guess. With planning, it reads three existing endpoints, infers the convention, and shows you its inference before writing. You correct the inference if it is wrong. The actual implementation is then mechanical.
+
+### 3. Refactors
+
+Refactors are the most expensive thing to get partially wrong, because half-applied changes break in subtle, branchy ways. A plan that says "I will rename X in these eight call sites, update the type in these two files, and migrate the test fixture in this third file" is something you can verify is *complete* before any code moves. The default loop tends to refactor confidently, miss two call sites, and force you to clean up.
+
+### 4. Anything where you are not 100% sure what you want
+
+When you are still discovering the requirements, Plan Mode is a thinking tool. You ask for a plan; the plan reveals an ambiguity ("should this also handle the legacy format?"); you make a decision; the next plan is sharper. You are using the agent's read-only loop as a cheap simulator of "what would shipping this actually look like." This is most of where senior engineers get value, and it is invisible to anyone watching diff counts.
+
+### 5. Production-impacting changes
+
+Migrations, config changes, infra edits, anything touching auth or data. You want the explicit checkpoint. You want to read the plan, sleep on it if it is risky, and approve only when you are certain. The harness's enforcement of "no writes until approved" is the cheap insurance policy that prevents the 2 a.m. rollback. See the [feature dev](/blog/claude-code-subagents-guide) and [code review](/blog/ultrareview-claude-code-guide) workflows for how teams chain Plan Mode into safer release patterns.
+
+---
+
+## When Plan Mode Is Theatre
+
+Equally important: when not to use it.
+
+- **Truly trivial fixes.** A typo, a constant rename, a one-line config tweak. Plan Mode here is ceremony. Just do it.
+- **Pure exploration.** "Where does the auth middleware live?" Plan Mode adds nothing — the agent is already read-only by virtue of the question.
+- **You already wrote the plan.** If your prompt is "edit file X to do Y in this exact way," you have already done the planning. Asking the agent to plan is asking it to summarize your prompt back to you.
+- **You are paired with another reviewer.** Some teams use a [code-reviewer](/blog/claude-code-subagents-guide) subagent on every diff. If review is mechanized post-hoc, the planning gate is partially redundant — though "partially" is not "fully," and Plan Mode still earns its keep on the high-risk categories above.
+
+The general rule: **Plan Mode is for tasks where the cost of doing the wrong thing exceeds the cost of one extra round-trip.** Anything ambiguous, multi-file, or production-touching qualifies. Anything mechanical and obvious does not.
+
+---
+
+## How To Actually Use It (The Mechanics)
+
+The basics:
+
+- **Enter Plan Mode** with the keybinding shown in your harness, or by issuing the explicit Plan command. The session UI changes to indicate you are in plan-only mode.
+- **Issue your task** as you normally would. The agent will read, search, and reason. It will not edit.
+- **Review the plan.** It will be structured: files to touch, changes per file, order of operations, sometimes test plan. Read it like a reviewer reads a PR description, not like a user reads a chat.
+- **Iterate or approve.** If the plan is wrong, push back: "no, you missed the legacy adapter" or "do not touch X, it is owned by another team." The agent revises. When the plan is right, you exit Plan Mode and the agent begins executing exactly that plan.
+
+A few sharper habits the best users have:
+
+### Treat the plan as a contract
+
+When the agent exits Plan Mode and begins editing, the plan is the spec. If during execution it discovers something new that requires deviating, the right behavior is to stop and surface it, not to silently improvise. Train yourself (and your project [\`CLAUDE.md\`](/blog/claude-md-guide)) to expect this: "if reality doesn't match the plan, return to Plan Mode rather than ad-libbing."
+
+### Push back on the plan, not the code
+
+The cheapest place to fix a bug is in the plan. A plan that says "I will modify the cache key format" can be rejected in five seconds with "no, that breaks existing keys, use a versioned key prefix." The same fix after the code is written is a real diff to review and possibly a revert.
+
+### Use Plan Mode as a teaching loop
+
+When the agent's plan exposes a wrong assumption ("I will reuse the existing \`User\` type" when actually you have a separate \`AuthUser\`), do not just correct it for this task — capture the correction in [\`CLAUDE.md\`](/blog/claude-md-guide) so the next agent does not make the same mistake. Plan Mode is where these teaching moments are visible. In the default loop they are buried in code that already shipped.
+
+### Combine it with worktrees
+
+Plan Mode plus [worktrees](/blog/claude-code-worktrees-guide) is the combination that lets you run multi-agent feature development without anyone stepping on anyone. Each subagent gets its own worktree and produces its own plan. You approve plans in parallel. The agents execute in isolation. Bugs are caught at plan-review time when they are nearly free to fix.
+
+---
+
+## The Plan Mode → Subagent Pattern
+
+The single most powerful workflow built on Plan Mode looks like this:
+
+1. **Top-level Plan Mode.** You enter Plan Mode in the main session. The agent produces a high-level plan: "This feature has four components — A, B, C, D. Here's how they fit together."
+2. **Approve and decompose.** You exit Plan Mode and ask the main agent to dispatch four subagents, one per component, each with \`isolation: "worktree"\` and instructions to plan their slice before executing.
+3. **Per-subagent Plan Mode.** Each subagent plans its slice. The plans come back to the main session as messages. You review them in parallel.
+4. **Approve and execute.** As you approve each plan, the corresponding subagent begins execution in its own worktree. You can have four agents writing code simultaneously, each working off a plan you reviewed.
+5. **Merge in dependency order.** As subagents finish, you merge their branches. The system that comes out the other end is built from four small, plan-reviewed PRs instead of one giant blob.
+
+This is the pattern behind the "ten engineers in your terminal" claims people make about Claude Code in 2026. The key ingredient is not the parallelism. It is the planning gate at every layer. Without it, parallelism just lets you ship the wrong thing four times faster. The [subagents guide](/blog/claude-code-subagents-guide) covers the dispatching mechanics; this post covers why Plan Mode is what makes the dispatching trustworthy.
+
+---
+
+## Common Failure Modes (And How To Avoid Them)
+
+### "The plan is too vague to act on"
+
+You asked for a plan and got a paragraph. The agent said "I will refactor the auth flow" without naming files or operations. The fix: ask for specifics in your prompt. "Plan this change with the list of files to be edited, the specific functions to be modified in each, and the order of operations." Once you set the bar, the agent meets it.
+
+### "The plan looked right but the execution drifted"
+
+You approved a plan; the agent started executing; halfway through, the diff stopped looking like the plan. This usually means the agent encountered an unexpected complication and improvised. Add to your project [\`CLAUDE.md\`](/blog/claude-md-guide): "if execution diverges from the approved plan, stop and re-enter Plan Mode." This is one of the highest-leverage rules you can write.
+
+### "Plan Mode is making me slower on small tasks"
+
+You are using it on tasks that do not need it. Re-read the "five tasks" section above. Plan Mode is not a replacement for thinking; it is a tool for making thinking explicit when stakes are high. For a typo fix, just type the fix.
+
+### "The plan keeps proposing the wrong architecture"
+
+This is a [\`CLAUDE.md\`](/blog/claude-md-guide) gap. The agent is making decisions because nothing in the project tells it which way to go. Capture the rule once, in the right file, and stop fighting the same battle in every plan.
+
+### "I feel like I'm just rubber-stamping the plans"
+
+If you are approving plans without reading them, you are getting no value from Plan Mode and paying its cost. Either read the plans (the discipline is the point) or stop using Plan Mode for this category of task. Rubber-stamping is the worst of both worlds.
+
+---
+
+## Plan Mode And Context Engineering
+
+Plan Mode interacts in interesting ways with how you manage the agent's context. Two specific patterns are worth knowing:
+
+**Plan Mode keeps your main context clean.** When you ask for a plan, the agent often reads many files into its context window. If you then approve and execute, that context is already loaded — the execution phase is fast and well-grounded. If you reject the plan and start over with a different approach, you can drop the context cheaply because no edits depend on it. This is why Plan Mode often *speeds up* the second prompt even though it adds a step to the first.
+
+**Plan Mode is where context-engineering gaps surface.** A plan that ignores half your codebase is a plan written without enough context. The fix is upstream: better [\`CLAUDE.md\`](/blog/claude-md-guide), tighter project conventions, more explicit prompt scoping. The [context engineering post](/blog/context-engineering-claude-code) goes deeper. The takeaway: if your plans are consistently weak, the answer is rarely "stop using Plan Mode." It is "fix what the agent can see when it plans."
+
+---
+
+## A Concrete Walkthrough
+
+Suppose your task is: *Add rate limiting to the public API.*
+
+In the default loop, the agent might immediately install a middleware library, add a configuration block, wire it into the main app, and write a test. The diff looks plausible. Review catches that it ignored your existing rate-limit pattern in the admin API, used a different storage backend, and broke an integration test you didn't think about.
+
+In Plan Mode:
+
+> **Agent:** Plan to add rate limiting to the public API.
+>
+> 1. Read existing pattern in \`api/admin/middleware/rate-limit.ts\` — uses Redis-backed sliding window, 100 req/min default, configurable per-route.
+> 2. Apply the same pattern to public routes by extracting the middleware into \`api/shared/rate-limit.ts\`, parameterized for both routers.
+> 3. Wire into \`api/public/server.ts\` after auth middleware (so unauthenticated requests are still rate-limited but by IP).
+> 4. Add per-route overrides for \`/auth/login\` (stricter: 10/min/IP) and \`/health\` (excluded).
+> 5. Update integration tests in \`tests/integration/rate-limit.test.ts\` to cover the public routes.
+> 6. Note: this change requires the \`REDIS_URL\` env var to be set in public-api production. Confirm with infra before deploy.
+
+You read the plan. You catch one thing: "actually, item 4 — \`/health\` should still be rate-limited at a high threshold so we get DDoS protection, just not strictly." You push back. The plan revises. You approve. The agent executes exactly that plan. The PR is clean.
+
+This is what Plan Mode looks like in practice. Not magic — just an explicit gate where your judgment can intervene before any code exists.
+
+---
+
+## Frequently Asked Questions
+
+### Is Plan Mode the same as just asking "what would you do?"
+
+No. Asking the agent to describe its approach in chat is a chat message. Plan Mode is a harness state with enforced read-only tooling and an explicit approval gate. The model cannot accidentally start editing. It produces a structured artifact. The two are correlated but not equivalent.
+
+### Does Plan Mode work with subagents?
+
+Yes — and this is the killer combination. Each subagent can plan its slice in its own session. See the Plan Mode → Subagent Pattern section above and the [subagents guide](/blog/claude-code-subagents-guide).
+
+### Should every prompt start in Plan Mode?
+
+No. For trivial or read-only tasks, it is overhead. Use it where the cost of being wrong is meaningful — the five categories above. For the rest, the default loop is fine.
+
+### Can I customize what a plan looks like?
+
+You can shape it through your prompt and through [\`CLAUDE.md\`](/blog/claude-md-guide). A project that says "all plans must include test impact and rollout risk" will get plans that include those sections. The harness does not constrain the plan format; you do.
+
+### Does Plan Mode prevent the agent from reading sensitive files?
+
+No. Plan Mode prevents writes, not reads. If you want to scope what the agent can read, that is a permissions question, not a Plan Mode question. The [worktrees guide](/blog/claude-code-worktrees-guide) covers per-worktree permission scoping.
+
+### Will Plan Mode slow down my CI?
+
+Plan Mode is an interactive feature. CI typically runs the agent in non-interactive mode where you have already specified the task tightly. CI agents usually do not need a planning gate because the prompt itself is the plan, vetted by the human who wrote the workflow.
+
+---
+
+## The TL;DR
+
+If you remember three things:
+
+1. **Use Plan Mode for anything multi-file, refactor-shaped, ambiguous, or production-touching.** The five categories above. Skip it for trivial mechanical edits.
+2. **Treat the plan as a contract, not a chat message.** Read it, push back on it, and expect the agent to return to Plan Mode if reality diverges from it.
+3. **Combine Plan Mode with [worktrees](/blog/claude-code-worktrees-guide) and [subagents](/blog/claude-code-subagents-guide).** That trio is the entire foundation of high-throughput, high-quality Claude Code work in 2026.
+
+Plan Mode is the unsexy, mechanical feature that makes everything else in the harness more reliable. It is a gate, not magic. The teams shipping the cleanest PRs in 2026 are not the ones with the cleverest prompts; they are the ones who treat planning as a first-class step instead of an optional one.
+
+The upgrade takes about a week of habit-building. Once it sticks, you will not go back.
+
+---
+
+## Related Reading
+
+- [Claude Code Cheat Sheet](/blog/claude-code-cheat-sheet) — keybindings, including how to enter and exit Plan Mode quickly.
+- [Context Engineering for Claude Code](/blog/context-engineering-claude-code) — what the agent sees when it plans, and how to shape that.
+- [Claude Code Subagents Guide](/blog/claude-code-subagents-guide) — combining planning with delegated execution.
+- [Claude Code Worktrees Guide](/blog/claude-code-worktrees-guide) — the isolation layer that makes parallel planned execution safe.
+- [10x Productivity Workflows](/blog/claude-code-workflows-10x-productivity) — daily patterns that depend on planning as a habit.
+- [Complete \`CLAUDE.md\` Guide](/blog/claude-md-guide) — where you encode the rules that make every future plan sharper.
+
+---
+
+*Last updated: May 3, 2026. Plan Mode behavior continues to evolve alongside the rest of the harness; check the [Claude Directory repo](https://github.com/tmcpa/claudedirectory) for updates if anything here drifts from the latest release.*
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -26,8 +26,10 @@ import { ultrareviewClaudeCodeGuide } from "./ultrareview-claude-code-guide";
 import { claudeCoworkForBusinessUsers } from "./claude-cowork-for-business-users";
 import { claudeCodeForNonEngineersInEngineeringCodebases } from "./claude-code-for-non-engineers-in-engineering-codebases";
 import { claudeCodeWorktreesGuide } from "./claude-code-worktrees-guide";
+import { claudeCodePlanModeGuide } from "./claude-code-plan-mode-guide";
 
 export const blogPosts: BlogPost[] = [
+  claudeCodePlanModeGuide,
   claudeCodeWorktreesGuide,
   claudeCodeForNonEngineersInEngineeringCodebases,
   claudeCoworkForBusinessUsers,


### PR DESCRIPTION
## Summary
- New featured blog post **Claude Code Plan Mode: The Underrated Feature Behind the Best PRs in 2026** at `src/data/blog/claude-code-plan-mode-guide.ts`.
- Wired into `src/data/blog/index.ts` as the newest entry (top of the list).

## Why
Plan Mode was mentioned only in passing across the existing 27 posts, never as the dedicated topic — a real content gap given how central it is to high-quality Claude Code workflows. The post covers what Plan Mode actually is (harness-enforced read-only state, not just chat), the five task categories where it pays off, when it's overhead, the Plan Mode → Subagent → Worktree pattern, common failure modes, and a concrete rate-limiting walkthrough. Cross-linked to cheat sheet, context engineering, subagents, worktrees, 10x workflows, and CLAUDE.md guides.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Reviewer: visit `/blog/claude-code-plan-mode-guide` locally and confirm the post renders with correct frontmatter, related-items links, and markdown formatting
- [ ] Reviewer: confirm the post appears at the top of the blog index