### PR TITLE
Fix plugin install commands to use real Claude Code syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ export const myPlugin: Plugin = {
   description: "What this plugin does",
   tags: ["tag1"],
   author: { name: "Your Name" },
-  installCommand: "claude plugin add my-plugin",
+  installCommand: "/plugin install my-plugin@my-marketplace",
   commands: [
     { name: "/command", description: "What it does" },
   ],

--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -38,12 +38,18 @@ function parseSourceRepo(source, hostRepo) {
   return { repoUrl: `https://github.com/${m[1]}/${m[2]}`, sourceRepo: `${m[1]}/${m[2]}` };
 }
 
-function pluginToListing(plugin, hostRepo, hostMeta) {
+function pluginToListing(plugin, hostRepo, hostMeta, marketplaceName) {
   const { repoUrl, sourceRepo } = parseSourceRepo(plugin.source, hostRepo);
   const slug = slugify(plugin.name || plugin.title);
   if (!slug) return null;
   const description = truncate(plugin.description || hostMeta?.description || "", 280);
-  const installCommand = `claude plugins add ${plugin.name}@${hostRepo.split("/").pop()}`;
+  const marketplace = marketplaceName || hostRepo.split("/").pop();
+  // The official Anthropic marketplace is auto-registered, so no `marketplace add`
+  // step is needed for it. All other marketplaces must be added first.
+  const installCommand =
+    marketplace === "claude-plugins-official"
+      ? `/plugin install ${plugin.name}@${marketplace}`
+      : `/plugin marketplace add ${hostRepo} && /plugin install ${plugin.name}@${marketplace}`;
   const tags = deriveTags(plugin.name, description, [plugin.category].filter(Boolean));
   return {
     slug,
@@ -95,9 +101,10 @@ async function ingestMarketplace(repo) {
   catch (e) { log(`  invalid JSON in ${usedPath}: ${e.message}`); return []; }
   const plugins = parsed.plugins || parsed.items || [];
   log(`  found ${plugins.length} entries in ${usedPath}`);
+  const marketplaceName = typeof parsed.name === "string" ? parsed.name : null;
   const out = [];
   for (const p of plugins) {
-    const listing = pluginToListing(p, repo, meta);
+    const listing = pluginToListing(p, repo, meta, marketplaceName);
     if (listing) out.push(listing);
   }
   return out;

--- a/src/data/_ingested/plugins.json
+++ b/src/data/_ingested/plugins.json
@@ -2,8 +2,8 @@
   {
     "slug": "42crunch-api-security-testing",
     "title": "42crunch Api Security Testing",
-    "description": "Automate API security directly in Claude Code with 42Crunch - automatically audit OpenAPI specs, detect vulnerabilities aligned with OWASP API Security risks (including BOLA/BFLA), and apply AI-powered fixes. Designed for AI-assisted development workflows, it provides continuous…",
-    "installCommand": "claude plugins add 42crunch-api-security-testing@claude-plugins-official",
+    "description": "Automate API security directly in Claude Code with 42Crunch - automatically audit OpenAPI specs, detect vulnerabilities aligned with OWASP API Security risks (including BOLA/BFLA), and apply AI-powered fixes. Designed for AI-assisted development workflows, it provides continuous\u2026",
+    "installCommand": "/plugin install 42crunch-api-security-testing@claude-plugins-official",
     "tags": [
       "security",
       "testing",
@@ -25,8 +25,8 @@
   {
     "slug": "adobe-for-creativity",
     "title": "Adobe For Creativity",
-    "description": "Harness Adobe's creative AI-powered tools to edit images, automate design workflows, and bring creative visions to life — from background removal to vectorization and professional retouching.",
-    "installCommand": "claude plugins add adobe-for-creativity@claude-plugins-official",
+    "description": "Harness Adobe's creative AI-powered tools to edit images, automate design workflows, and bring creative visions to life \u2014 from background removal to vectorization and professional retouching.",
+    "installCommand": "/plugin install adobe-for-creativity@claude-plugins-official",
     "tags": [
       "design",
       "ai"
@@ -47,7 +47,7 @@
     "slug": "agent-sdk-dev",
     "title": "Agent Sdk Dev",
     "description": "Development kit for working with the Claude Agent SDK",
-    "installCommand": "claude plugins add agent-sdk-dev@claude-plugins-official",
+    "installCommand": "/plugin install agent-sdk-dev@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -67,8 +67,8 @@
   {
     "slug": "agentforce-adlc",
     "title": "Agentforce Adlc",
-    "description": "Agentforce Agent Development Life Cycle — author, discover, scaffold, deploy, test, and optimize .agent files",
-    "installCommand": "claude plugins add agentforce-adlc@claude-plugins-official",
+    "description": "Agentforce Agent Development Life Cycle \u2014 author, discover, scaffold, deploy, test, and optimize .agent files",
+    "installCommand": "/plugin install agentforce-adlc@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -89,7 +89,7 @@
     "slug": "ai-plugins",
     "title": "Ai Plugins",
     "description": "Set up endorctl and use Endor Labs to scan, prioritize, and fix security risks across your software supply chain",
-    "installCommand": "claude plugins add ai-plugins@claude-plugins-official",
+    "installCommand": "/plugin install ai-plugins@claude-plugins-official",
     "tags": [
       "security",
       "ai"
@@ -108,8 +108,8 @@
   {
     "slug": "aikido",
     "title": "Aikido",
-    "description": "Aikido Security scanning for Claude Code — SAST, secrets, and IaC vulnerability detection powered by the Aikido MCP server.",
-    "installCommand": "claude plugins add aikido@claude-plugins-official",
+    "description": "Aikido Security scanning for Claude Code \u2014 SAST, secrets, and IaC vulnerability detection powered by the Aikido MCP server.",
+    "installCommand": "/plugin install aikido@claude-plugins-official",
     "tags": [
       "security",
       "ai"
@@ -129,7 +129,7 @@
     "slug": "alloydb",
     "title": "Alloydb",
     "description": "Create, connect, and interact with an AlloyDB for PostgreSQL database and data.",
-    "installCommand": "claude plugins add alloydb@claude-plugins-official",
+    "installCommand": "/plugin install alloydb@claude-plugins-official",
     "tags": [
       "database",
       "postgres"
@@ -150,7 +150,7 @@
     "slug": "amazon-location-service",
     "title": "Amazon Location Service",
     "description": "Guide developers through adding maps, places search, geocoding, routing, and other geospatial features with Amazon Location Service, including authentication setup, SDK integration, and best practices.",
-    "installCommand": "claude plugins add amazon-location-service@claude-plugins-official",
+    "installCommand": "/plugin install amazon-location-service@claude-plugins-official",
     "tags": [
       "location"
     ],
@@ -169,8 +169,8 @@
   {
     "slug": "amplitude",
     "title": "Amplitude",
-    "description": "Use Amplitude as an expert analyst — instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts.",
-    "installCommand": "claude plugins add amplitude@claude-plugins-official",
+    "description": "Use Amplitude as an expert analyst \u2014 instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts.",
+    "installCommand": "/plugin install amplitude@claude-plugins-official",
     "tags": [
       "monitoring"
     ],
@@ -189,8 +189,8 @@
   {
     "slug": "apollo",
     "title": "Apollo",
-    "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io — one-click MCP server integration for Claude Code and Cowork.",
-    "installCommand": "claude plugins add apollo@claude-plugins-official",
+    "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io \u2014 one-click MCP server integration for Claude Code and Cowork.",
+    "installCommand": "/plugin install apollo@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -210,7 +210,7 @@
     "slug": "asana",
     "title": "Asana",
     "description": "Asana project management integration. Create and manage tasks, search projects, update assignments, track progress, and integrate your development workflow with Asana's work management platform.",
-    "installCommand": "claude plugins add asana@claude-plugins-official",
+    "installCommand": "/plugin install asana@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -230,7 +230,7 @@
     "slug": "astronomer-data-agents",
     "title": "Astronomer Data Agents",
     "description": "Data engineering for Apache Airflow and Astronomer. Author DAGs with best practices, debug pipeline failures, trace data lineage, profile tables, migrate Airflow 2 to 3, and manage local and cloud deployments.",
-    "installCommand": "claude plugins add astronomer-data-agents@claude-plugins-official",
+    "installCommand": "/plugin install astronomer-data-agents@claude-plugins-official",
     "tags": [
       "development",
       "deployment",
@@ -253,7 +253,7 @@
     "slug": "atlan",
     "title": "Atlan",
     "description": "Atlan data catalog plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
-    "installCommand": "claude plugins add atlan@claude-plugins-official",
+    "installCommand": "/plugin install atlan@claude-plugins-official",
     "tags": [
       "go"
     ],
@@ -272,7 +272,7 @@
     "slug": "atlassian",
     "title": "Atlassian",
     "description": "Connect to Atlassian products including Jira and Confluence. Search and create issues, access documentation, manage sprints, and integrate your development workflow with Atlassian's collaboration tools.",
-    "installCommand": "claude plugins add atlassian@claude-plugins-official",
+    "installCommand": "/plugin install atlassian@claude-plugins-official",
     "tags": [
       "productivity",
       "jira"
@@ -292,8 +292,8 @@
   {
     "slug": "atomic-agents",
     "title": "Atomic Agents",
-    "description": "Comprehensive development workflow for building AI agents with the Atomic Agents framework. Includes specialized agents for schema design, architecture planning, code review, and tool development. Features guided workflows, progressive-disclosure skills, and best practice valida…",
-    "installCommand": "claude plugins add atomic-agents@claude-plugins-official",
+    "description": "Comprehensive development workflow for building AI agents with the Atomic Agents framework. Includes specialized agents for schema design, architecture planning, code review, and tool development. Features guided workflows, progressive-disclosure skills, and best practice valida\u2026",
+    "installCommand": "/plugin install atomic-agents@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -314,8 +314,8 @@
   {
     "slug": "auth0",
     "title": "Auth0",
-    "description": "Add authentication to any app with Auth0. This plugin detects your framework, scaffolds the right Auth0 SDK integration, and guides you through login, logout, sessions, and protected routes — using current SDK patterns.",
-    "installCommand": "claude plugins add auth0@claude-plugins-official",
+    "description": "Add authentication to any app with Auth0. This plugin detects your framework, scaffolds the right Auth0 SDK integration, and guides you through login, logout, sessions, and protected routes \u2014 using current SDK patterns.",
+    "installCommand": "/plugin install auth0@claude-plugins-official",
     "tags": [
       "security",
       "go"
@@ -336,7 +336,7 @@
     "slug": "aws-agents",
     "title": "Aws Agents",
     "description": "Build, deploy, and operate AI agents on AWS. Skills for scaffolding agents with Amazon Bedrock AgentCore, connecting tools, memory, policies, evaluation, debugging, and production hardening.",
-    "installCommand": "claude plugins add aws-agents@claude-plugins-official",
+    "installCommand": "/plugin install aws-agents@claude-plugins-official",
     "tags": [
       "development",
       "aws",
@@ -359,7 +359,7 @@
     "slug": "aws-amplify",
     "title": "Aws Amplify",
     "description": "Build full-stack apps with AWS Amplify Gen 2 using guided workflows for authentication, data models, storage, GraphQL APIs, and Lambda functions.",
-    "installCommand": "claude plugins add aws-amplify@claude-plugins-official",
+    "installCommand": "/plugin install aws-amplify@claude-plugins-official",
     "tags": [
       "development",
       "aws",
@@ -383,7 +383,7 @@
     "slug": "aws-core",
     "title": "Aws Core",
     "description": "Build, deploy, and operate applications on AWS. Skills to author infrastructure-as-code, use core services, and complete common tasks.",
-    "installCommand": "claude plugins add aws-core@claude-plugins-official",
+    "installCommand": "/plugin install aws-core@claude-plugins-official",
     "tags": [
       "development",
       "aws"
@@ -404,7 +404,7 @@
     "slug": "aws-data-analytics",
     "title": "Aws Data Analytics",
     "description": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena.",
-    "installCommand": "claude plugins add aws-data-analytics@claude-plugins-official",
+    "installCommand": "/plugin install aws-data-analytics@claude-plugins-official",
     "tags": [
       "development",
       "aws"
@@ -424,8 +424,8 @@
   {
     "slug": "aws-dev-toolkit",
     "title": "Aws Dev Toolkit",
-    "description": "AWS development toolkit — 34 skills, 11 agents, and 3 MCP servers for building, migrating, and performing architecture reviews on AWS.",
-    "installCommand": "claude plugins add aws-dev-toolkit@claude-plugins-official",
+    "description": "AWS development toolkit \u2014 34 skills, 11 agents, and 3 MCP servers for building, migrating, and performing architecture reviews on AWS.",
+    "installCommand": "/plugin install aws-dev-toolkit@claude-plugins-official",
     "tags": [
       "development",
       "aws",
@@ -447,7 +447,7 @@
     "slug": "aws-serverless",
     "title": "Aws Serverless",
     "description": "Design, build, deploy, test, and debug serverless applications with AWS Serverless services.",
-    "installCommand": "claude plugins add aws-serverless@claude-plugins-official",
+    "installCommand": "/plugin install aws-serverless@claude-plugins-official",
     "tags": [
       "development",
       "aws"
@@ -467,8 +467,8 @@
   {
     "slug": "azure",
     "title": "Azure",
-    "description": "Transform Claude into an Azure expert. This plugin integrates the Azure MCP server and specialized Azure skills to move beyond generic advice. It enables Claude to perform real-world tasks: listing resources, validating deployments, diagnosing infrastructure issues, and optimizi…",
-    "installCommand": "claude plugins add azure@claude-plugins-official",
+    "description": "Transform Claude into an Azure expert. This plugin integrates the Azure MCP server and specialized Azure skills to move beyond generic advice. It enables Claude to perform real-world tasks: listing resources, validating deployments, diagnosing infrastructure issues, and optimizi\u2026",
+    "installCommand": "/plugin install azure@claude-plugins-official",
     "tags": [
       "deployment",
       "azure"
@@ -488,8 +488,8 @@
   {
     "slug": "azure-cosmos-db-assistant",
     "title": "Azure Cosmos Db Assistant",
-    "description": "Expert assistant for Azure Cosmos DB — data modeling, query optimization, performance tuning, and best practices.",
-    "installCommand": "claude plugins add azure-cosmos-db-assistant@claude-plugins-official",
+    "description": "Expert assistant for Azure Cosmos DB \u2014 data modeling, query optimization, performance tuning, and best practices.",
+    "installCommand": "/plugin install azure-cosmos-db-assistant@claude-plugins-official",
     "tags": [
       "database",
       "azure",
@@ -511,7 +511,7 @@
     "slug": "base44",
     "title": "Base44",
     "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills",
-    "installCommand": "claude plugins add base44@claude-plugins-official",
+    "installCommand": "/plugin install base44@claude-plugins-official",
     "tags": [
       "development",
       "typescript",
@@ -533,7 +533,7 @@
     "slug": "bigdata-com",
     "title": "Bigdata Com",
     "description": "Official Bigdata.com plugin providing financial research, analytics, and intelligence tools powered by Bigdata MCP.",
-    "installCommand": "claude plugins add bigdata-com@claude-plugins-official",
+    "installCommand": "/plugin install bigdata-com@claude-plugins-official",
     "tags": [
       "database"
     ],
@@ -552,8 +552,8 @@
   {
     "slug": "box",
     "title": "Box",
-    "description": "Work with your Box content directly from Claude Code — search files, organize folders, collaborate with your team, and use Box AI to answer questions, summarize documents, and extract data without leaving your workflow.",
-    "installCommand": "claude plugins add box@claude-plugins-official",
+    "description": "Work with your Box content directly from Claude Code \u2014 search files, organize folders, collaborate with your team, and use Box AI to answer questions, summarize documents, and extract data without leaving your workflow.",
+    "installCommand": "/plugin install box@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -573,8 +573,8 @@
   {
     "slug": "brightdata-plugin",
     "title": "Brightdata Plugin",
-    "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 7 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, …",
-    "installCommand": "claude plugins add brightdata-plugin@claude-plugins-official",
+    "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 7 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, \u2026",
+    "installCommand": "/plugin install brightdata-plugin@claude-plugins-official",
     "tags": [
       "go",
       "scraping",
@@ -595,7 +595,7 @@
     "slug": "cds-mcp",
     "title": "Cds Mcp",
     "description": "AI-assisted development of SAP Cloud Application Programming Model (CAP) projects. Search CDS models and CAP documentation.",
-    "installCommand": "claude plugins add cds-mcp@claude-plugins-official",
+    "installCommand": "/plugin install cds-mcp@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -616,7 +616,7 @@
     "slug": "chrome-devtools-mcp",
     "title": "Chrome Devtools Mcp",
     "description": "Control and inspect a live Chrome browser from your coding agent. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions with Puppeteer.",
-    "installCommand": "claude plugins add chrome-devtools-mcp@claude-plugins-official",
+    "installCommand": "/plugin install chrome-devtools-mcp@claude-plugins-official",
     "tags": [
       "development",
       "performance",
@@ -639,7 +639,7 @@
     "slug": "circleback",
     "title": "Circleback",
     "description": "Circleback conversational context integration. Search and access meetings, emails, calendar events, and more.",
-    "installCommand": "claude plugins add circleback@claude-plugins-official",
+    "installCommand": "/plugin install circleback@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -660,7 +660,7 @@
     "slug": "clangd-lsp",
     "title": "Clangd Lsp",
     "description": "C/C++ language server (clangd) for code intelligence",
-    "installCommand": "claude plugins add clangd-lsp@claude-plugins-official",
+    "installCommand": "/plugin install clangd-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -680,7 +680,7 @@
     "slug": "claude-code-setup",
     "title": "Claude Code Setup",
     "description": "Analyze codebases and recommend tailored Claude Code automations such as hooks, skills, MCP servers, and subagents.",
-    "installCommand": "claude plugins add claude-code-setup@claude-plugins-official",
+    "installCommand": "/plugin install claude-code-setup@claude-plugins-official",
     "tags": [
       "productivity",
       "automation",
@@ -703,7 +703,7 @@
     "slug": "claude-md-management",
     "title": "Claude Md Management",
     "description": "Tools to maintain and improve CLAUDE.md files - audit quality, capture session learnings, and keep project memory current.",
-    "installCommand": "claude plugins add claude-md-management@claude-plugins-official",
+    "installCommand": "/plugin install claude-md-management@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -723,8 +723,8 @@
   {
     "slug": "clickhouse",
     "title": "Clickhouse",
-    "description": "Connect Claude to your ClickHouse Cloud databases. Browse organizations, services, databases, and table schemas. Run read-only SQL queries against your data and get instant analytical answers. Monitor service backups, review billing costs, and inspect ClickPipe configurations - …",
-    "installCommand": "claude plugins add clickhouse@claude-plugins-official",
+    "description": "Connect Claude to your ClickHouse Cloud databases. Browse organizations, services, databases, and table schemas. Run read-only SQL queries against your data and get instant analytical answers. Monitor service backups, review billing costs, and inspect ClickPipe configurations - \u2026",
+    "installCommand": "/plugin install clickhouse@claude-plugins-official",
     "tags": [
       "database",
       "ai"
@@ -745,7 +745,7 @@
     "slug": "cloud-sql-postgresql",
     "title": "Cloud Sql Postgresql",
     "description": "Create, connect, and interact with a Cloud SQL for PostgreSQL database and data.",
-    "installCommand": "claude plugins add cloud-sql-postgresql@claude-plugins-official",
+    "installCommand": "/plugin install cloud-sql-postgresql@claude-plugins-official",
     "tags": [
       "database",
       "postgres"
@@ -766,7 +766,7 @@
     "slug": "cloudflare",
     "title": "Cloudflare",
     "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
-    "installCommand": "claude plugins add cloudflare@claude-plugins-official",
+    "installCommand": "/plugin install cloudflare@claude-plugins-official",
     "tags": [
       "deployment",
       "cloudflare",
@@ -789,7 +789,7 @@
     "slug": "cloudinary",
     "title": "Cloudinary",
     "description": "Use Cloudinary directly in Claude. Manage assets, apply transformations, optimize media, and more through natural conversation.",
-    "installCommand": "claude plugins add cloudinary@claude-plugins-official",
+    "installCommand": "/plugin install cloudinary@claude-plugins-official",
     "tags": [],
     "author": {
       "name": "anthropics",
@@ -805,8 +805,8 @@
   {
     "slug": "cockroachdb",
     "title": "Cockroachdb",
-    "description": "Connect Claude Code directly to your CockroachDB clusters for hands-on database work — explore schemas, write optimized SQL, debug queries, and manage distributed database clusters. This plugin provides 14 tools across two active MCP backends (self-hosted MCP Toolbox and managed…",
-    "installCommand": "claude plugins add cockroachdb@claude-plugins-official",
+    "description": "Connect Claude Code directly to your CockroachDB clusters for hands-on database work \u2014 explore schemas, write optimized SQL, debug queries, and manage distributed database clusters. This plugin provides 14 tools across two active MCP backends (self-hosted MCP Toolbox and managed\u2026",
+    "installCommand": "/plugin install cockroachdb@claude-plugins-official",
     "tags": [
       "database"
     ],
@@ -826,7 +826,7 @@
     "slug": "code-modernization",
     "title": "Code Modernization",
     "description": "Modernize legacy codebases (COBOL, legacy Java/C++, monolith web apps) with a structured assess / map / extract-rules / reimagine / transform / harden workflow and specialist review agents",
-    "installCommand": "claude plugins add code-modernization@claude-plugins-official",
+    "installCommand": "/plugin install code-modernization@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -847,7 +847,7 @@
     "slug": "code-review",
     "title": "Code Review",
     "description": "Automated code review for pull requests using multiple specialized agents with confidence-based scoring to filter false positives",
-    "installCommand": "claude plugins add code-review@claude-plugins-official",
+    "installCommand": "/plugin install code-review@claude-plugins-official",
     "tags": [
       "productivity",
       "agent"
@@ -868,7 +868,7 @@
     "slug": "code-simplifier",
     "title": "Code Simplifier",
     "description": "Agent that simplifies and refines code for clarity, consistency, and maintainability while preserving functionality. Focuses on recently modified code.",
-    "installCommand": "claude plugins add code-simplifier@claude-plugins-official",
+    "installCommand": "/plugin install code-simplifier@claude-plugins-official",
     "tags": [
       "productivity",
       "ai",
@@ -889,8 +889,8 @@
   {
     "slug": "coderabbit",
     "title": "Coderabbit",
-    "description": "Your code review partner. CodeRabbit provides external validation using a specialized AI architecture and 40+ integrated static analyzers—offering a different perspective that catches bugs, security vulnerabilities, logic errors, and edge cases. Context-aware analysis via AST pa…",
-    "installCommand": "claude plugins add coderabbit@claude-plugins-official",
+    "description": "Your code review partner. CodeRabbit provides external validation using a specialized AI architecture and 40+ integrated static analyzers\u2014offering a different perspective that catches bugs, security vulnerabilities, logic errors, and edge cases. Context-aware analysis via AST pa\u2026",
+    "installCommand": "/plugin install coderabbit@claude-plugins-official",
     "tags": [
       "productivity",
       "security",
@@ -912,7 +912,7 @@
     "slug": "commit-commands",
     "title": "Commit Commands",
     "description": "Commands for git commit workflows including commit, push, and PR creation",
-    "installCommand": "claude plugins add commit-commands@claude-plugins-official",
+    "installCommand": "/plugin install commit-commands@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -932,7 +932,7 @@
     "slug": "context7",
     "title": "Context7",
     "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Pull version-specific documentation and code examples directly from source repositories into your LLM context.",
-    "installCommand": "claude plugins add context7@claude-plugins-official",
+    "installCommand": "/plugin install context7@claude-plugins-official",
     "tags": [
       "development",
       "llm"
@@ -953,7 +953,7 @@
     "slug": "crowdstrike-falcon-foundry",
     "title": "Crowdstrike Falcon Foundry",
     "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
-    "installCommand": "claude plugins add crowdstrike-falcon-foundry@claude-plugins-official",
+    "installCommand": "/plugin install crowdstrike-falcon-foundry@claude-plugins-official",
     "tags": [
       "security",
       "api"
@@ -974,7 +974,7 @@
     "slug": "csharp-lsp",
     "title": "Csharp Lsp",
     "description": "C# language server for code intelligence",
-    "installCommand": "claude plugins add csharp-lsp@claude-plugins-official",
+    "installCommand": "/plugin install csharp-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -993,8 +993,8 @@
   {
     "slug": "cwc-makers",
     "title": "Cwc Makers",
-    "description": "Onboard a Code-with-Claude Makers Cardputer with one /maker-setup command — clones the build-with-claude repo, flashes UIFlow firmware, and installs the Claude Buddy app bundle.",
-    "installCommand": "claude plugins add cwc-makers@claude-plugins-official",
+    "description": "Onboard a Code-with-Claude Makers Cardputer with one /maker-setup command \u2014 clones the build-with-claude repo, flashes UIFlow firmware, and installs the Claude Buddy app bundle.",
+    "installCommand": "/plugin install cwc-makers@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -1014,7 +1014,7 @@
     "slug": "dash0",
     "title": "Dash0",
     "description": "OpenTelemetry observability for Claude Code sessions. Captures tool calls, LLM invocations, token usage, and errors as OTel traces. Send telemetry to Dash0 or any OpenTelemetry-compatible backend.",
-    "installCommand": "claude plugins add dash0@claude-plugins-official",
+    "installCommand": "/plugin install dash0@claude-plugins-official",
     "tags": [
       "monitoring",
       "llm"
@@ -1035,7 +1035,7 @@
     "slug": "data",
     "title": "Data",
     "description": "Data engineering for Apache Airflow and Astronomer. Author DAGs with best practices, debug pipeline failures, trace data lineage, profile tables, migrate Airflow 2 to 3, and manage local and cloud deployments.",
-    "installCommand": "claude plugins add data@claude-plugins-official",
+    "installCommand": "/plugin install data@claude-plugins-official",
     "tags": [
       "development",
       "deployment",
@@ -1056,8 +1056,8 @@
   {
     "slug": "data-agent-kit-starter-pack",
     "title": "Data Agent Kit Starter Pack",
-    "description": "Specialized suite of skills for data engineers on Google Cloud — architect data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across BigQuery, Spanner, BigLake, and Dataproc.",
-    "installCommand": "claude plugins add data-agent-kit-starter-pack@claude-plugins-official",
+    "description": "Specialized suite of skills for data engineers on Google Cloud \u2014 architect data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across BigQuery, Spanner, BigLake, and Dataproc.",
+    "installCommand": "/plugin install data-agent-kit-starter-pack@claude-plugins-official",
     "tags": [
       "development",
       "go",
@@ -1079,7 +1079,7 @@
     "slug": "data-engineering",
     "title": "Data Engineering",
     "description": "Data engineering plugin - warehouse exploration, pipeline authoring, Airflow integration",
-    "installCommand": "claude plugins add data-engineering@claude-plugins-official",
+    "installCommand": "/plugin install data-engineering@claude-plugins-official",
     "tags": [
       "ai"
     ],
@@ -1098,7 +1098,7 @@
     "slug": "databases-on-aws",
     "title": "Databases On Aws",
     "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
-    "installCommand": "claude plugins add databases-on-aws@claude-plugins-official",
+    "installCommand": "/plugin install databases-on-aws@claude-plugins-official",
     "tags": [
       "database",
       "aws"
@@ -1119,7 +1119,7 @@
     "slug": "datadog",
     "title": "Datadog",
     "description": "Use Datadog directly in Claude Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation. This plugin is in preview.",
-    "installCommand": "claude plugins add datadog@claude-plugins-official",
+    "installCommand": "/plugin install datadog@claude-plugins-official",
     "tags": [
       "monitoring"
     ],
@@ -1138,8 +1138,8 @@
   {
     "slug": "datarobot-agent-skills",
     "title": "Datarobot Agent Skills",
-    "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
-    "installCommand": "claude plugins add datarobot-agent-skills@claude-plugins-official",
+    "description": "DataRobot skills for AI/ML workflows \u2014 model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
+    "installCommand": "/plugin install datarobot-agent-skills@claude-plugins-official",
     "tags": [
       "development",
       "deployment",
@@ -1162,8 +1162,8 @@
   {
     "slug": "dataverse",
     "title": "Dataverse",
-    "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-    "installCommand": "claude plugins add dataverse@claude-plugins-official",
+    "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse \u2014 with Dataverse MCP, PAC CLI, and Python SDK.",
+    "installCommand": "/plugin install dataverse@claude-plugins-official",
     "tags": [
       "database",
       "python",
@@ -1185,7 +1185,7 @@
     "slug": "deploy-on-aws",
     "title": "Deploy On Aws",
     "description": "Deploy applications to AWS with architecture recommendations, cost estimates, and IaC deployment.",
-    "installCommand": "claude plugins add deploy-on-aws@claude-plugins-official",
+    "installCommand": "/plugin install deploy-on-aws@claude-plugins-official",
     "tags": [
       "deployment",
       "aws"
@@ -1206,7 +1206,7 @@
     "slug": "desktop-commander",
     "title": "Desktop Commander",
     "description": "MCP server for terminal commands, process management, and file operations across text, code, PDF, DOCX, Excel, images, and structured data.",
-    "installCommand": "claude plugins add desktop-commander@claude-plugins-official",
+    "installCommand": "/plugin install desktop-commander@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -1226,7 +1226,7 @@
     "slug": "discord",
     "title": "Discord",
     "description": "Discord messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /discord:access.",
-    "installCommand": "claude plugins add discord@claude-plugins-official",
+    "installCommand": "/plugin install discord@claude-plugins-official",
     "tags": [
       "productivity",
       "discord",
@@ -1248,7 +1248,7 @@
     "slug": "exa",
     "title": "Exa",
     "description": "Exa AI web search, deep research, and content extraction. Provides MCP tools and research skills for comprehensive web search, people discovery, company research, academic papers, and more.",
-    "installCommand": "claude plugins add exa@claude-plugins-official",
+    "installCommand": "/plugin install exa@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -1269,7 +1269,7 @@
     "slug": "explanatory-output-style",
     "title": "Explanatory Output Style",
     "description": "Adds educational insights about implementation choices and codebase patterns (mimics the deprecated Explanatory output style)",
-    "installCommand": "claude plugins add explanatory-output-style@claude-plugins-official",
+    "installCommand": "/plugin install explanatory-output-style@claude-plugins-official",
     "tags": [
       "learning"
     ],
@@ -1288,8 +1288,8 @@
   {
     "slug": "expo",
     "title": "Expo",
-    "description": "Official Expo skills for building, deploying, upgrading, and debugging React Native apps with Expo. Covers UI development with Expo Router, SwiftUI and Jetpack Compose components, Tailwind CSS setup, API routes, data fetching, CI/CD workflows, App Store and Play Store deployment…",
-    "installCommand": "claude plugins add expo@claude-plugins-official",
+    "description": "Official Expo skills for building, deploying, upgrading, and debugging React Native apps with Expo. Covers UI development with Expo Router, SwiftUI and Jetpack Compose components, Tailwind CSS setup, API routes, data fetching, CI/CD workflows, App Store and Play Store deployment\u2026",
+    "installCommand": "/plugin install expo@claude-plugins-official",
     "tags": [
       "development",
       "swift",
@@ -1314,7 +1314,7 @@
     "slug": "fakechat",
     "title": "Fakechat",
     "description": "Localhost web chat for testing the channel notification flow. No tokens, no access control, no third-party service.",
-    "installCommand": "claude plugins add fakechat@claude-plugins-official",
+    "installCommand": "/plugin install fakechat@claude-plugins-official",
     "tags": [
       "development",
       "testing"
@@ -1335,7 +1335,7 @@
     "slug": "fastly-agent-toolkit",
     "title": "Fastly Agent Toolkit",
     "description": "Fastly development tools and platform skills",
-    "installCommand": "claude plugins add fastly-agent-toolkit@claude-plugins-official",
+    "installCommand": "/plugin install fastly-agent-toolkit@claude-plugins-official",
     "tags": [
       "agent"
     ],
@@ -1354,7 +1354,7 @@
     "slug": "feature-dev",
     "title": "Feature Dev",
     "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, and quality review",
-    "installCommand": "claude plugins add feature-dev@claude-plugins-official",
+    "installCommand": "/plugin install feature-dev@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -1375,7 +1375,7 @@
     "slug": "fiftyone",
     "title": "Fiftyone",
     "description": "Build high-quality datasets and computer vision models. Visualize datasets, analyze models, find duplicates, run inference, evaluate predictions, and develop custom plugins.",
-    "installCommand": "claude plugins add fiftyone@claude-plugins-official",
+    "installCommand": "/plugin install fiftyone@claude-plugins-official",
     "tags": [],
     "author": {
       "name": "anthropics",
@@ -1392,7 +1392,7 @@
     "slug": "figma",
     "title": "Figma",
     "description": "Figma design platform integration. Access design files, extract component information, read design tokens, and translate designs into code. Bridge the gap between design and development workflows.",
-    "installCommand": "claude plugins add figma@claude-plugins-official",
+    "installCommand": "/plugin install figma@claude-plugins-official",
     "tags": [
       "design"
     ],
@@ -1412,7 +1412,7 @@
     "slug": "firebase",
     "title": "Firebase",
     "description": "Google Firebase MCP integration. Manage Firestore databases, authentication, cloud functions, hosting, and storage. Build and manage your Firebase backend directly from your development workflow.",
-    "installCommand": "claude plugins add firebase@claude-plugins-official",
+    "installCommand": "/plugin install firebase@claude-plugins-official",
     "tags": [
       "database",
       "go",
@@ -1434,8 +1434,8 @@
   {
     "slug": "firecrawl",
     "title": "Firecrawl",
-    "description": "Web scraping and crawling powered by Firecrawl. Turn any website into clean, LLM-ready markdown or structured data. Scrape single pages, crawl entire sites, search the web, and extract structured information. Includes an AI agent for autonomous multi-source data gathering - just…",
-    "installCommand": "claude plugins add firecrawl@claude-plugins-official",
+    "description": "Web scraping and crawling powered by Firecrawl. Turn any website into clean, LLM-ready markdown or structured data. Scrape single pages, crawl entire sites, search the web, and extract structured information. Includes an AI agent for autonomous multi-source data gathering - just\u2026",
+    "installCommand": "/plugin install firecrawl@claude-plugins-official",
     "tags": [
       "development",
       "scraping",
@@ -1460,7 +1460,7 @@
     "slug": "frontend-design",
     "title": "Frontend Design",
     "description": "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code that avoids generic AI aesthetics.",
-    "installCommand": "claude plugins add frontend-design@claude-plugins-official",
+    "installCommand": "/plugin install frontend-design@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -1481,7 +1481,7 @@
     "slug": "fullstory",
     "title": "Fullstory",
     "description": "Connect Claude to Fullstory to query behavioral analytics, session replays, and customer experience insights.",
-    "installCommand": "claude plugins add fullstory@claude-plugins-official",
+    "installCommand": "/plugin install fullstory@claude-plugins-official",
     "tags": [
       "monitoring"
     ],
@@ -1501,7 +1501,7 @@
     "slug": "github",
     "title": "Github",
     "description": "Official GitHub MCP server for repository management. Create issues, manage pull requests, review code, search repositories, and interact with GitHub's full API directly from Claude Code.",
-    "installCommand": "claude plugins add github@claude-plugins-official",
+    "installCommand": "/plugin install github@claude-plugins-official",
     "tags": [
       "productivity",
       "github",
@@ -1523,7 +1523,7 @@
     "slug": "gitlab",
     "title": "Gitlab",
     "description": "GitLab DevOps platform integration. Manage repositories, merge requests, CI/CD pipelines, issues, and wikis. Full access to GitLab's comprehensive DevOps lifecycle tools.",
-    "installCommand": "claude plugins add gitlab@claude-plugins-official",
+    "installCommand": "/plugin install gitlab@claude-plugins-official",
     "tags": [
       "productivity",
       "gitlab"
@@ -1544,7 +1544,7 @@
     "slug": "gopls-lsp",
     "title": "Gopls Lsp",
     "description": "Go language server for code intelligence and refactoring",
-    "installCommand": "claude plugins add gopls-lsp@claude-plugins-official",
+    "installCommand": "/plugin install gopls-lsp@claude-plugins-official",
     "tags": [
       "development",
       "go"
@@ -1565,7 +1565,7 @@
     "slug": "greptile",
     "title": "Greptile",
     "description": "AI-powered codebase search and understanding. Query your repositories using natural language to find relevant code, understand dependencies, and get contextual answers about your codebase architecture.",
-    "installCommand": "claude plugins add greptile@claude-plugins-official",
+    "installCommand": "/plugin install greptile@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -1586,7 +1586,7 @@
     "slug": "hookify",
     "title": "Hookify",
     "description": "Easily create custom hooks to prevent unwanted behaviors by analyzing conversation patterns or from explicit instructions. Define rules via simple markdown files.",
-    "installCommand": "claude plugins add hookify@claude-plugins-official",
+    "installCommand": "/plugin install hookify@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -1606,7 +1606,7 @@
     "slug": "huggingface-skills",
     "title": "Huggingface Skills",
     "description": "Build, train, evaluate, and use open source AI models, datasets, and spaces.",
-    "installCommand": "claude plugins add huggingface-skills@claude-plugins-official",
+    "installCommand": "/plugin install huggingface-skills@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -1627,7 +1627,7 @@
     "slug": "imessage",
     "title": "Imessage",
     "description": "iMessage messaging bridge with built-in access control. Reads chat.db directly, sends via AppleScript. Manage pairing, allowlists, and policy via /imessage:access.",
-    "installCommand": "claude plugins add imessage@claude-plugins-official",
+    "installCommand": "/plugin install imessage@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -1648,7 +1648,7 @@
     "slug": "intercom",
     "title": "Intercom",
     "description": "Intercom integration for Claude Code. Search conversations, analyze customer support patterns, look up contacts and companies, and install the Intercom Messenger. Connect your Intercom workspace to get real-time insights from customer data.",
-    "installCommand": "claude plugins add intercom@claude-plugins-official",
+    "installCommand": "/plugin install intercom@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -1668,7 +1668,7 @@
     "slug": "jdtls-lsp",
     "title": "Jdtls Lsp",
     "description": "Java language server (Eclipse JDT.LS) for code intelligence",
-    "installCommand": "claude plugins add jdtls-lsp@claude-plugins-official",
+    "installCommand": "/plugin install jdtls-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1688,7 +1688,7 @@
     "slug": "jfrog",
     "title": "Jfrog",
     "description": "Use the JFrog Platform from Claude Code: Artifactory repos and artifacts, security findings and exposures, Catalog package safety and downloads, workflows across the SDLC, and platform administration.",
-    "installCommand": "claude plugins add jfrog@claude-plugins-official",
+    "installCommand": "/plugin install jfrog@claude-plugins-official",
     "tags": [
       "security"
     ],
@@ -1708,7 +1708,7 @@
     "slug": "kotlin-lsp",
     "title": "Kotlin Lsp",
     "description": "Kotlin language server for code intelligence",
-    "installCommand": "claude plugins add kotlin-lsp@claude-plugins-official",
+    "installCommand": "/plugin install kotlin-lsp@claude-plugins-official",
     "tags": [
       "development",
       "kotlin"
@@ -1729,7 +1729,7 @@
     "slug": "laravel-boost",
     "title": "Laravel Boost",
     "description": "Laravel development toolkit MCP server. Provides intelligent assistance for Laravel applications including Artisan commands, Eloquent queries, routing, migrations, and framework-specific code generation.",
-    "installCommand": "claude plugins add laravel-boost@claude-plugins-official",
+    "installCommand": "/plugin install laravel-boost@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1749,7 +1749,7 @@
     "slug": "learning-output-style",
     "title": "Learning Output Style",
     "description": "Interactive learning mode that requests meaningful code contributions at decision points (mimics the unshipped Learning output style)",
-    "installCommand": "claude plugins add learning-output-style@claude-plugins-official",
+    "installCommand": "/plugin install learning-output-style@claude-plugins-official",
     "tags": [
       "learning"
     ],
@@ -1769,7 +1769,7 @@
     "slug": "legalzoom",
     "title": "Legalzoom",
     "description": "Attorney guidance and legal tools for business and personal needs. AI-powered document review identifies critical risks and important clauses, advises when to engage an attorney, and routes to LegalZoom's network when professional expertise is needed.",
-    "installCommand": "claude plugins add legalzoom@claude-plugins-official",
+    "installCommand": "/plugin install legalzoom@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -1790,7 +1790,7 @@
     "slug": "linear",
     "title": "Linear",
     "description": "Linear issue tracking integration. Create issues, manage projects, update statuses, search across workspaces, and streamline your software development workflow with Linear's modern issue tracker.",
-    "installCommand": "claude plugins add linear@claude-plugins-official",
+    "installCommand": "/plugin install linear@claude-plugins-official",
     "tags": [
       "productivity",
       "linear"
@@ -1811,7 +1811,7 @@
     "slug": "liquid-lsp",
     "title": "Liquid Lsp",
     "description": "LSP integration for Shopify Liquid templates via the Shopify CLI theme language server.",
-    "installCommand": "claude plugins add liquid-lsp@claude-plugins-official",
+    "installCommand": "/plugin install liquid-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1831,7 +1831,7 @@
     "slug": "liquid-skills",
     "title": "Liquid Skills",
     "description": "Liquid language fundamentals, CSS/JS/HTML coding standards, and WCAG accessibility patterns for Shopify themes",
-    "installCommand": "claude plugins add liquid-skills@claude-plugins-official",
+    "installCommand": "/plugin install liquid-skills@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1851,7 +1851,7 @@
     "slug": "logfire",
     "title": "Logfire",
     "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more",
-    "installCommand": "claude plugins add logfire@claude-plugins-official",
+    "installCommand": "/plugin install logfire@claude-plugins-official",
     "tags": [
       "monitoring",
       "python",
@@ -1873,7 +1873,7 @@
     "slug": "lua-lsp",
     "title": "Lua Lsp",
     "description": "Lua language server for code intelligence",
-    "installCommand": "claude plugins add lua-lsp@claude-plugins-official",
+    "installCommand": "/plugin install lua-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1893,7 +1893,7 @@
     "slug": "math-olympiad",
     "title": "Math Olympiad",
     "description": "Solve competition math (IMO, Putnam, USAMO) with adversarial verification that catches what self-verification misses. Fresh-context verifiers attack proofs with specific failure patterns. Calibrated abstention over bluffing.",
-    "installCommand": "claude plugins add math-olympiad@claude-plugins-official",
+    "installCommand": "/plugin install math-olympiad@claude-plugins-official",
     "tags": [
       "math",
       "ai"
@@ -1914,7 +1914,7 @@
     "slug": "mcp-server-dev",
     "title": "Mcp Server Dev",
     "description": "Skills for designing and building MCP servers that work seamlessly with Claude. Guides you through deployment models (remote HTTP, MCPB, local), tool design patterns, auth, and interactive MCP apps.",
-    "installCommand": "claude plugins add mcp-server-dev@claude-plugins-official",
+    "installCommand": "/plugin install mcp-server-dev@claude-plugins-official",
     "tags": [
       "development",
       "deployment"
@@ -1935,7 +1935,7 @@
     "slug": "microsoft-docs",
     "title": "Microsoft Docs",
     "description": "Access official Microsoft documentation, API references, and code samples for Azure, .NET, Windows, and more.",
-    "installCommand": "claude plugins add microsoft-docs@claude-plugins-official",
+    "installCommand": "/plugin install microsoft-docs@claude-plugins-official",
     "tags": [
       "development",
       "azure",
@@ -1957,7 +1957,7 @@
     "slug": "mintlify",
     "title": "Mintlify",
     "description": "Build beautiful documentation sites with Mintlify. Convert non-markdown files into properly formatted MDX pages, add and modify content with correct component use, and automate documentation updates.",
-    "installCommand": "claude plugins add mintlify@claude-plugins-official",
+    "installCommand": "/plugin install mintlify@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -1977,7 +1977,7 @@
     "slug": "miro",
     "title": "Miro",
     "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
-    "installCommand": "claude plugins add miro@claude-plugins-official",
+    "installCommand": "/plugin install miro@claude-plugins-official",
     "tags": [
       "design",
       "security",
@@ -1999,7 +1999,7 @@
     "slug": "mongodb",
     "title": "Mongodb",
     "description": "Official Claude plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
-    "installCommand": "claude plugins add mongodb@claude-plugins-official",
+    "installCommand": "/plugin install mongodb@claude-plugins-official",
     "tags": [
       "database",
       "go",
@@ -2021,7 +2021,7 @@
     "slug": "neon",
     "title": "Neon",
     "description": "Manage your Neon projects and databases with the neon-postgres agent skill and the Neon MCP Server.",
-    "installCommand": "claude plugins add neon@claude-plugins-official",
+    "installCommand": "/plugin install neon@claude-plugins-official",
     "tags": [
       "database",
       "postgres",
@@ -2042,8 +2042,8 @@
   {
     "slug": "netlify-skills",
     "title": "Netlify Skills",
-    "description": "Netlify platform skills for Claude Code — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment.",
-    "installCommand": "claude plugins add netlify-skills@claude-plugins-official",
+    "description": "Netlify platform skills for Claude Code \u2014 functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment.",
+    "installCommand": "/plugin install netlify-skills@claude-plugins-official",
     "tags": [
       "development",
       "deployment",
@@ -2064,8 +2064,8 @@
   {
     "slug": "netsuite-suitecloud",
     "title": "Netsuite Suitecloud",
-    "description": "NetSuite agent skills from Oracle — authoring guidance for SuiteCloud Development Framework (SDF) objects and UIF single-page-app components, plus runtime guidance for the NetSuite AI Service Connector.",
-    "installCommand": "claude plugins add netsuite-suitecloud@claude-plugins-official",
+    "description": "NetSuite agent skills from Oracle \u2014 authoring guidance for SuiteCloud Development Framework (SDF) objects and UIF single-page-app components, plus runtime guidance for the NetSuite AI Service Connector.",
+    "installCommand": "/plugin install netsuite-suitecloud@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -2087,7 +2087,7 @@
     "slug": "nightvision",
     "title": "Nightvision",
     "description": "Skills for working with NightVision, a DAST and API Discovery platform that finds exploitable vulnerabilities in web applications and REST APIs",
-    "installCommand": "claude plugins add nightvision@claude-plugins-official",
+    "installCommand": "/plugin install nightvision@claude-plugins-official",
     "tags": [
       "api",
       "rest"
@@ -2106,8 +2106,8 @@
   {
     "slug": "nimble",
     "title": "Nimble",
-    "description": "Nimble web data toolkit — search, extract, map, crawl the web and work with structured data agents",
-    "installCommand": "claude plugins add nimble@claude-plugins-official",
+    "description": "Nimble web data toolkit \u2014 search, extract, map, crawl the web and work with structured data agents",
+    "installCommand": "/plugin install nimble@claude-plugins-official",
     "tags": [
       "agent"
     ],
@@ -2126,7 +2126,7 @@
     "slug": "notion",
     "title": "Notion",
     "description": "Notion workspace integration. Search pages, create and update documents, manage databases, and access your team's knowledge base directly from Claude Code for seamless documentation workflows.",
-    "installCommand": "claude plugins add notion@claude-plugins-official",
+    "installCommand": "/plugin install notion@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -2145,8 +2145,8 @@
   {
     "slug": "oracle-ai-data-platform-workbench-spark-connectors",
     "title": "Oracle Ai Data Platform Workbench Spark Connectors",
-    "description": "Oracle AI Data Platform Workbench Spark connectors for Claude Code. 18 connector skills covering every data source workbench customers commonly need: Oracle Autonomous DB family (ALH/ADW/ATP) via wallet/IAM-DB-Token/API-key, ExaCS, Fusion ERP REST, Fusion BICC, EPM Cloud Plannin…",
-    "installCommand": "claude plugins add oracle-ai-data-platform-workbench-spark-connectors@claude-plugins-official",
+    "description": "Oracle AI Data Platform Workbench Spark connectors for Claude Code. 18 connector skills covering every data source workbench customers commonly need: Oracle Autonomous DB family (ALH/ADW/ATP) via wallet/IAM-DB-Token/API-key, ExaCS, Fusion ERP REST, Fusion BICC, EPM Cloud Plannin\u2026",
+    "installCommand": "/plugin install oracle-ai-data-platform-workbench-spark-connectors@claude-plugins-official",
     "tags": [
       "development",
       "api",
@@ -2168,8 +2168,8 @@
   {
     "slug": "outputai",
     "title": "Outputai",
-    "description": "Output.ai workflow development toolkit for Claude Code. Adds 5 specialist agents (planner, builder, debugger, prompt writer, quality reviewer), 40+ slash-command skills covering scaffolding, debugging, evaluation, and credential management, plus a SessionStart hook that auto-loa…",
-    "installCommand": "claude plugins add outputai@claude-plugins-official",
+    "description": "Output.ai workflow development toolkit for Claude Code. Adds 5 specialist agents (planner, builder, debugger, prompt writer, quality reviewer), 40+ slash-command skills covering scaffolding, debugging, evaluation, and credential management, plus a SessionStart hook that auto-loa\u2026",
+    "installCommand": "/plugin install outputai@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -2191,7 +2191,7 @@
     "slug": "pagerduty",
     "title": "Pagerduty",
     "description": "Enhance code quality and security through PagerDuty risk scoring and incident correlation. Score pre-commit diffs against historical incident data and surface deployment risk before you ship.",
-    "installCommand": "claude plugins add pagerduty@claude-plugins-official",
+    "installCommand": "/plugin install pagerduty@claude-plugins-official",
     "tags": [
       "monitoring",
       "security",
@@ -2214,7 +2214,7 @@
     "slug": "php-lsp",
     "title": "Php Lsp",
     "description": "PHP language server (Intelephense) for code intelligence",
-    "installCommand": "claude plugins add php-lsp@claude-plugins-official",
+    "installCommand": "/plugin install php-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -2234,7 +2234,7 @@
     "slug": "pigment",
     "title": "Pigment",
     "description": "Analyze business data and build custom Pigment models, metrics, and boards through natural language.",
-    "installCommand": "claude plugins add pigment@claude-plugins-official",
+    "installCommand": "/plugin install pigment@claude-plugins-official",
     "tags": [
       "productivity"
     ],
@@ -2253,8 +2253,8 @@
   {
     "slug": "pinecone",
     "title": "Pinecone",
-    "description": "Pinecone vector database integration. Streamline your Pinecone development with powerful tools for managing vector indexes, querying data, and rapid prototyping. Use slash commands like /quickstart to generate AGENTS.md files and initialize Python projects and /query to quickly …",
-    "installCommand": "claude plugins add pinecone@claude-plugins-official",
+    "description": "Pinecone vector database integration. Streamline your Pinecone development with powerful tools for managing vector indexes, querying data, and rapid prototyping. Use slash commands like /quickstart to generate AGENTS.md files and initialize Python projects and /query to quickly \u2026",
+    "installCommand": "/plugin install pinecone@claude-plugins-official",
     "tags": [
       "database",
       "python",
@@ -2277,7 +2277,7 @@
     "slug": "planetscale",
     "title": "Planetscale",
     "description": "An authenticated hosted MCP server that accesses your PlanetScale organizations, databases, branches, schema, and Insights data. Query against your data, surface slow queries, and get organizational and account information.",
-    "installCommand": "claude plugins add planetscale@claude-plugins-official",
+    "installCommand": "/plugin install planetscale@claude-plugins-official",
     "tags": [
       "database",
       "ai"
@@ -2297,8 +2297,8 @@
   {
     "slug": "playground",
     "title": "Playground",
-    "description": "Creates interactive HTML playgrounds — self-contained single-file explorers with visual controls, live preview, and prompt output with copy button. Includes templates for design playgrounds, data explorers, concept maps, and document critique.",
-    "installCommand": "claude plugins add playground@claude-plugins-official",
+    "description": "Creates interactive HTML playgrounds \u2014 self-contained single-file explorers with visual controls, live preview, and prompt output with copy button. Includes templates for design playgrounds, data explorers, concept maps, and document critique.",
+    "installCommand": "/plugin install playground@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -2319,7 +2319,7 @@
     "slug": "playwright",
     "title": "Playwright",
     "description": "Browser automation and end-to-end testing MCP server by Microsoft. Enables Claude to interact with web pages, take screenshots, fill forms, click elements, and perform automated browser testing workflows.",
-    "installCommand": "claude plugins add playwright@claude-plugins-official",
+    "installCommand": "/plugin install playwright@claude-plugins-official",
     "tags": [
       "testing",
       "browser",
@@ -2341,7 +2341,7 @@
     "slug": "plugin-dev",
     "title": "Plugin Dev",
     "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
-    "installCommand": "claude plugins add plugin-dev@claude-plugins-official",
+    "installCommand": "/plugin install plugin-dev@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -2363,7 +2363,7 @@
     "slug": "posthog",
     "title": "Posthog",
     "description": "Access PostHog analytics, feature flags, experiments, error tracking, and insights directly from Claude Code.",
-    "installCommand": "claude plugins add posthog@claude-plugins-official",
+    "installCommand": "/plugin install posthog@claude-plugins-official",
     "tags": [
       "monitoring"
     ],
@@ -2383,7 +2383,7 @@
     "slug": "postiz",
     "title": "Postiz",
     "description": "Social media automation CLI for scheduling posts, managing integrations, uploading media, and tracking analytics across 28+ platforms including X, LinkedIn, Reddit, YouTube, TikTok, Instagram, and more",
-    "installCommand": "claude plugins add postiz@claude-plugins-official",
+    "installCommand": "/plugin install postiz@claude-plugins-official",
     "tags": [
       "automation"
     ],
@@ -2402,7 +2402,7 @@
     "slug": "postman",
     "title": "Postman",
     "description": "Full API lifecycle management for Claude Code. Sync collections, generate client code, discover APIs, run tests, create mocks, publish docs, and audit security. Powered by the Postman MCP Server.",
-    "installCommand": "claude plugins add postman@claude-plugins-official",
+    "installCommand": "/plugin install postman@claude-plugins-official",
     "tags": [
       "development",
       "security",
@@ -2424,7 +2424,7 @@
     "slug": "pr-review-toolkit",
     "title": "Pr Review Toolkit",
     "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
-    "installCommand": "claude plugins add pr-review-toolkit@claude-plugins-official",
+    "installCommand": "/plugin install pr-review-toolkit@claude-plugins-official",
     "tags": [
       "productivity",
       "agent"
@@ -2445,7 +2445,7 @@
     "slug": "prisma",
     "title": "Prisma",
     "description": "Prisma MCP integration for Postgres database management, schema migrations, SQL queries, and connection string management. Provision Prisma Postgres databases, run migrations, and interact with your data directly.",
-    "installCommand": "claude plugins add prisma@claude-plugins-official",
+    "installCommand": "/plugin install prisma@claude-plugins-official",
     "tags": [
       "postgres"
     ],
@@ -2464,7 +2464,7 @@
     "slug": "pydantic-ai",
     "title": "Pydantic Ai",
     "description": "Write accurate Pydantic AI code from the start. Up-to-date patterns, decision trees, and common gotchas for agents, tools, structured output, streaming, and multi-agent apps.",
-    "installCommand": "claude plugins add pydantic-ai@claude-plugins-official",
+    "installCommand": "/plugin install pydantic-ai@claude-plugins-official",
     "tags": [
       "development",
       "go",
@@ -2487,7 +2487,7 @@
     "slug": "pyright-lsp",
     "title": "Pyright Lsp",
     "description": "Python language server (Pyright) for type checking and code intelligence",
-    "installCommand": "claude plugins add pyright-lsp@claude-plugins-official",
+    "installCommand": "/plugin install pyright-lsp@claude-plugins-official",
     "tags": [
       "development",
       "python"
@@ -2508,7 +2508,7 @@
     "slug": "qdrant-skills",
     "title": "Qdrant Skills",
     "description": "Agent skills for Qdrant vector search covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java.",
-    "installCommand": "claude plugins add qdrant-skills@claude-plugins-official",
+    "installCommand": "/plugin install qdrant-skills@claude-plugins-official",
     "tags": [
       "database",
       "python",
@@ -2535,8 +2535,8 @@
   {
     "slug": "qodo-skills",
     "title": "Qodo Skills",
-    "description": "Qodo Skills provides a curated library of reusable AI agent capabilities that extend Claude's functionality for software development workflows. Each skill is designed to integrate seamlessly into your development process, enabling tasks like code quality checks, automated testin…",
-    "installCommand": "claude plugins add qodo-skills@claude-plugins-official",
+    "description": "Qodo Skills provides a curated library of reusable AI agent capabilities that extend Claude's functionality for software development workflows. Each skill is designed to integrate seamlessly into your development process, enabling tasks like code quality checks, automated testin\u2026",
+    "installCommand": "/plugin install qodo-skills@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -2557,8 +2557,8 @@
   {
     "slug": "qt-development-skills",
     "title": "Qt Development Skills",
-    "description": "Agentic engineering skills for Qt software development — Qt C++/QML code review, QML coding, and Qt C++/QML code documentation.",
-    "installCommand": "claude plugins add qt-development-skills@claude-plugins-official",
+    "description": "Agentic engineering skills for Qt software development \u2014 Qt C++/QML code review, QML coding, and Qt C++/QML code documentation.",
+    "installCommand": "/plugin install qt-development-skills@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -2579,7 +2579,7 @@
     "slug": "quarkus-agent",
     "title": "Quarkus Agent",
     "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
-    "installCommand": "claude plugins add quarkus-agent@claude-plugins-official",
+    "installCommand": "/plugin install quarkus-agent@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -2601,7 +2601,7 @@
     "slug": "railway",
     "title": "Railway",
     "description": "Deploy and manage apps, databases, and infrastructure on Railway. Covers project setup, deploys, environment configuration, networking, troubleshooting, and monitoring.",
-    "installCommand": "claude plugins add railway@claude-plugins-official",
+    "installCommand": "/plugin install railway@claude-plugins-official",
     "tags": [
       "deployment",
       "monitoring",
@@ -2623,7 +2623,7 @@
     "slug": "ralph-loop",
     "title": "Ralph Loop",
     "description": "Interactive self-referential AI loops for iterative development, implementing the Ralph Wiggum technique. Claude works on the same task repeatedly, seeing its previous work, until completion.",
-    "installCommand": "claude plugins add ralph-loop@claude-plugins-official",
+    "installCommand": "/plugin install ralph-loop@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -2644,7 +2644,7 @@
     "slug": "rc",
     "title": "Rc",
     "description": "Configure RevenueCat projects, apps, products, entitlements, and offerings directly from Claude Code. Manage your in-app purchase backend without leaving your development workflow.",
-    "installCommand": "claude plugins add rc@claude-plugins-official",
+    "installCommand": "/plugin install rc@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -2664,7 +2664,7 @@
     "slug": "remember",
     "title": "Remember",
     "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-    "installCommand": "claude plugins add remember@claude-plugins-official",
+    "installCommand": "/plugin install remember@claude-plugins-official",
     "tags": [
       "ai"
     ],
@@ -2683,7 +2683,7 @@
     "slug": "revenuecat",
     "title": "Revenuecat",
     "description": "Configure RevenueCat projects, apps, products, entitlements, and offerings directly from Claude Code. Manage your in-app purchase backend without leaving your development workflow.",
-    "installCommand": "claude plugins add revenuecat@claude-plugins-official",
+    "installCommand": "/plugin install revenuecat@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -2703,7 +2703,7 @@
     "slug": "ruby-lsp",
     "title": "Ruby Lsp",
     "description": "Ruby language server for code intelligence and analysis",
-    "installCommand": "claude plugins add ruby-lsp@claude-plugins-official",
+    "installCommand": "/plugin install ruby-lsp@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -2723,7 +2723,7 @@
     "slug": "rust-analyzer-lsp",
     "title": "Rust Analyzer Lsp",
     "description": "Rust language server for code intelligence and analysis",
-    "installCommand": "claude plugins add rust-analyzer-lsp@claude-plugins-official",
+    "installCommand": "/plugin install rust-analyzer-lsp@claude-plugins-official",
     "tags": [
       "development",
       "rust"
@@ -2744,7 +2744,7 @@
     "slug": "sanity",
     "title": "Sanity",
     "description": "Sanity content platform integration with MCP server, agent skills, and slash commands. Query and author content, build and optimize GROQ queries, design schemas, and set up Visual Editing.",
-    "installCommand": "claude plugins add sanity@claude-plugins-official",
+    "installCommand": "/plugin install sanity@claude-plugins-official",
     "tags": [
       "development",
       "agent"
@@ -2764,8 +2764,8 @@
   {
     "slug": "sap-mdk-server",
     "title": "Sap Mdk Server",
-    "description": "MCP server for SAP Mobile Development Kit (MDK). Build and modify MDK applications with AI assistance — schema lookups, action validation, rule editing, and project scaffolding.",
-    "installCommand": "claude plugins add sap-mdk-server@claude-plugins-official",
+    "description": "MCP server for SAP Mobile Development Kit (MDK). Build and modify MDK applications with AI assistance \u2014 schema lookups, action validation, rule editing, and project scaffolding.",
+    "installCommand": "/plugin install sap-mdk-server@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -2786,7 +2786,7 @@
     "slug": "security-guidance",
     "title": "Security Guidance",
     "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
-    "installCommand": "claude plugins add security-guidance@claude-plugins-official",
+    "installCommand": "/plugin install security-guidance@claude-plugins-official",
     "tags": [
       "security"
     ],
@@ -2806,7 +2806,7 @@
     "slug": "semgrep",
     "title": "Semgrep",
     "description": "Semgrep catches security vulnerabilities in real-time and guides Claude to write secure code from the start.",
-    "installCommand": "claude plugins add semgrep@claude-plugins-official",
+    "installCommand": "/plugin install semgrep@claude-plugins-official",
     "tags": [
       "security"
     ],
@@ -2826,7 +2826,7 @@
     "slug": "sentry",
     "title": "Sentry",
     "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
-    "installCommand": "claude plugins add sentry@claude-plugins-official",
+    "installCommand": "/plugin install sentry@claude-plugins-official",
     "tags": [
       "monitoring"
     ],
@@ -2846,7 +2846,7 @@
     "slug": "serena",
     "title": "Serena",
     "description": "Semantic code analysis MCP server providing intelligent code understanding, refactoring suggestions, and codebase navigation through language server protocol integration.",
-    "installCommand": "claude plugins add serena@claude-plugins-official",
+    "installCommand": "/plugin install serena@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -2866,7 +2866,7 @@
     "slug": "servicenow-sdk",
     "title": "Servicenow Sdk",
     "description": "Create, edit, and deploy ServiceNow applications with the Fluent SDK effortlessly through Claude AI.",
-    "installCommand": "claude plugins add servicenow-sdk@claude-plugins-official",
+    "installCommand": "/plugin install servicenow-sdk@claude-plugins-official",
     "tags": [
       "development",
       "ai"
@@ -2886,8 +2886,8 @@
   {
     "slug": "session-report",
     "title": "Session Report",
-    "description": "Generate an explorable HTML report of Claude Code session usage — tokens, cache efficiency, subagents, skills, and the most expensive prompts — from local ~/.claude/projects transcripts.",
-    "installCommand": "claude plugins add session-report@claude-plugins-official",
+    "description": "Generate an explorable HTML report of Claude Code session usage \u2014 tokens, cache efficiency, subagents, skills, and the most expensive prompts \u2014 from local ~/.claude/projects transcripts.",
+    "installCommand": "/plugin install session-report@claude-plugins-official",
     "tags": [
       "productivity",
       "agent"
@@ -2907,8 +2907,8 @@
   {
     "slug": "shopify",
     "title": "Shopify",
-    "description": "Shopify developer tools for Claude Code — search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code",
-    "installCommand": "claude plugins add shopify@claude-plugins-official",
+    "description": "Shopify developer tools for Claude Code \u2014 search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code",
+    "installCommand": "/plugin install shopify@claude-plugins-official",
     "tags": [
       "development",
       "graphql"
@@ -2928,8 +2928,8 @@
   {
     "slug": "shopify-ai-toolkit",
     "title": "Shopify Ai Toolkit",
-    "description": "Shopify's AI Toolkit provides 18 development skills for building on the Shopify platform, covering documentation search, API schema access, GraphQL and Liquid code validation, Hydrogen storefronts, Polaris UI extensions, store management via CLI, and onboarding guidance for both…",
-    "installCommand": "claude plugins add shopify-ai-toolkit@claude-plugins-official",
+    "description": "Shopify's AI Toolkit provides 18 development skills for building on the Shopify platform, covering documentation search, API schema access, GraphQL and Liquid code validation, Hydrogen storefronts, Polaris UI extensions, store management via CLI, and onboarding guidance for both\u2026",
+    "installCommand": "/plugin install shopify-ai-toolkit@claude-plugins-official",
     "tags": [
       "development",
       "api",
@@ -2952,7 +2952,7 @@
     "slug": "skill-creator",
     "title": "Skill Creator",
     "description": "Create new skills, improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, or benchmark skill performance with variance analysis.",
-    "installCommand": "claude plugins add skill-creator@claude-plugins-official",
+    "installCommand": "/plugin install skill-creator@claude-plugins-official",
     "tags": [
       "development",
       "performance"
@@ -2973,7 +2973,7 @@
     "slug": "slack",
     "title": "Slack",
     "description": "Slack workspace integration. Search messages, access channels, read threads, and stay connected with your team's communications while coding. Find relevant discussions and context quickly.",
-    "installCommand": "claude plugins add slack@claude-plugins-official",
+    "installCommand": "/plugin install slack@claude-plugins-official",
     "tags": [
       "productivity",
       "slack"
@@ -2994,7 +2994,7 @@
     "slug": "snowflake-cortex-code",
     "title": "Snowflake Cortex Code",
     "description": "Automatically route Snowflake prompts from Claude Code to Cortex Code for execution. Provides slash commands for code review and task delegation, plus skills for routing, run, and setup.",
-    "installCommand": "claude plugins add snowflake-cortex-code@claude-plugins-official",
+    "installCommand": "/plugin install snowflake-cortex-code@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -3013,8 +3013,8 @@
   {
     "slug": "sonarqube",
     "title": "Sonarqube",
-    "description": "Automatically enforce SonarQube code quality and security in the agent coding loop — 7,000+ rules, secrets scanning, agentic analysis, and quality gates across 40+ languages. PostToolUse hooks run analysis after every file edit. Pre-tool secrets scanning prevents 450+ patterns f…",
-    "installCommand": "claude plugins add sonarqube@claude-plugins-official",
+    "description": "Automatically enforce SonarQube code quality and security in the agent coding loop \u2014 7,000+ rules, secrets scanning, agentic analysis, and quality gates across 40+ languages. PostToolUse hooks run analysis after every file edit. Pre-tool secrets scanning prevents 450+ patterns f\u2026",
+    "installCommand": "/plugin install sonarqube@claude-plugins-official",
     "tags": [
       "security",
       "agent"
@@ -3035,7 +3035,7 @@
     "slug": "sonatype-guide",
     "title": "Sonatype Guide",
     "description": "Sonatype Guide MCP server for software supply chain intelligence and dependency security. Analyze dependencies for vulnerabilities, get secure version recommendations, and check component quality metrics.",
-    "installCommand": "claude plugins add sonatype-guide@claude-plugins-official",
+    "installCommand": "/plugin install sonatype-guide@claude-plugins-official",
     "tags": [
       "security",
       "ai"
@@ -3056,7 +3056,7 @@
     "slug": "sourcegraph",
     "title": "Sourcegraph",
     "description": "Code search and understanding across codebases. Search, read, and trace references across repositories; analyze refactor impact; investigate incidents via commit and diff search; run targeted security sweeps.",
-    "installCommand": "claude plugins add sourcegraph@claude-plugins-official",
+    "installCommand": "/plugin install sourcegraph@claude-plugins-official",
     "tags": [
       "development",
       "security"
@@ -3076,8 +3076,8 @@
   {
     "slug": "spotify-ads-api",
     "title": "Spotify Ads Api",
-    "description": "Manage Spotify ad campaigns with natural language. Create campaigns, ad sets, ads, pull reports, and handle OAuth — all through conversation.",
-    "installCommand": "claude plugins add spotify-ads-api@claude-plugins-official",
+    "description": "Manage Spotify ad campaigns with natural language. Create campaigns, ad sets, ads, pull reports, and handle OAuth \u2014 all through conversation.",
+    "installCommand": "/plugin install spotify-ads-api@claude-plugins-official",
     "tags": [
       "productivity",
       "api",
@@ -3099,7 +3099,7 @@
     "slug": "stripe",
     "title": "Stripe",
     "description": "Stripe development plugin for Claude",
-    "installCommand": "claude plugins add stripe@claude-plugins-official",
+    "installCommand": "/plugin install stripe@claude-plugins-official",
     "tags": [
       "development"
     ],
@@ -3119,7 +3119,7 @@
     "slug": "sumup",
     "title": "Sumup",
     "description": "SumUp payment integrations across terminal and online checkout flows. Build Android and iOS POS apps with SumUp card readers, online checkout with server SDKs and the checkout widget, and control card readers remotely via Cloud API.",
-    "installCommand": "claude plugins add sumup@claude-plugins-official",
+    "installCommand": "/plugin install sumup@claude-plugins-official",
     "tags": [
       "development",
       "api"
@@ -3140,7 +3140,7 @@
     "slug": "supabase",
     "title": "Supabase",
     "description": "Supabase MCP integration for database operations, authentication, storage, and real-time subscriptions. Manage your Supabase projects, run SQL queries, and interact with your backend directly.",
-    "installCommand": "claude plugins add supabase@claude-plugins-official",
+    "installCommand": "/plugin install supabase@claude-plugins-official",
     "tags": [
       "database",
       "rag"
@@ -3161,7 +3161,7 @@
     "slug": "superpowers",
     "title": "Superpowers",
     "description": "Superpowers teaches Claude brainstorming, subagent driven development with built in code review, systematic debugging, and red/green TDD. Additionally, it teaches Claude how to author and test new skills.",
-    "installCommand": "claude plugins add superpowers@claude-plugins-official",
+    "installCommand": "/plugin install superpowers@claude-plugins-official",
     "tags": [
       "development",
       "ai",
@@ -3183,7 +3183,7 @@
     "slug": "swift-lsp",
     "title": "Swift Lsp",
     "description": "Swift language server (SourceKit-LSP) for code intelligence",
-    "installCommand": "claude plugins add swift-lsp@claude-plugins-official",
+    "installCommand": "/plugin install swift-lsp@claude-plugins-official",
     "tags": [
       "development",
       "swift"
@@ -3204,7 +3204,7 @@
     "slug": "telegram",
     "title": "Telegram",
     "description": "Telegram messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /telegram:access.",
-    "installCommand": "claude plugins add telegram@claude-plugins-official",
+    "installCommand": "/plugin install telegram@claude-plugins-official",
     "tags": [
       "productivity",
       "ai"
@@ -3225,7 +3225,7 @@
     "slug": "terraform",
     "title": "Terraform",
     "description": "The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development.",
-    "installCommand": "claude plugins add terraform@claude-plugins-official",
+    "installCommand": "/plugin install terraform@claude-plugins-official",
     "tags": [
       "development",
       "automation"
@@ -3245,8 +3245,8 @@
   {
     "slug": "twilio-developer-kit",
     "title": "Twilio Developer Kit",
-    "description": "Twilio Skills provide procedural knowledge for AI coding agents — which APIs to use, in what order, and what to avoid. Covers SMS, Voice, WhatsApp, Verify, SendGrid, Compliance, and 30+ products.",
-    "installCommand": "claude plugins add twilio-developer-kit@claude-plugins-official",
+    "description": "Twilio Skills provide procedural knowledge for AI coding agents \u2014 which APIs to use, in what order, and what to avoid. Covers SMS, Voice, WhatsApp, Verify, SendGrid, Compliance, and 30+ products.",
+    "installCommand": "/plugin install twilio-developer-kit@claude-plugins-official",
     "tags": [
       "development",
       "api",
@@ -3269,7 +3269,7 @@
     "slug": "typescript-lsp",
     "title": "Typescript Lsp",
     "description": "TypeScript/JavaScript language server for enhanced code intelligence",
-    "installCommand": "claude plugins add typescript-lsp@claude-plugins-official",
+    "installCommand": "/plugin install typescript-lsp@claude-plugins-official",
     "tags": [
       "development",
       "typescript",
@@ -3291,7 +3291,7 @@
     "slug": "ui5",
     "title": "Ui5",
     "description": "SAPUI5 / OpenUI5 plugin for Claude. Create and validate UI5 projects, access API documentation, run UI5 linter, get development guidelines and best practices for UI5 development.",
-    "installCommand": "claude plugins add ui5@claude-plugins-official",
+    "installCommand": "/plugin install ui5@claude-plugins-official",
     "tags": [
       "development",
       "api"
@@ -3312,7 +3312,7 @@
     "slug": "ui5-typescript-conversion",
     "title": "Ui5 Typescript Conversion",
     "description": "SAPUI5 / OpenUI5 plugin for Claude. Convert JavaScript based UI5 projects to TypeScript.",
-    "installCommand": "claude plugins add ui5-typescript-conversion@claude-plugins-official",
+    "installCommand": "/plugin install ui5-typescript-conversion@claude-plugins-official",
     "tags": [
       "development",
       "typescript",
@@ -3334,7 +3334,7 @@
     "slug": "vanta-mcp-plugin",
     "title": "Vanta Mcp Plugin",
     "description": "The Vanta plugin connects Claude Code to Vanta's security and compliance platform through the Vanta MCP server. It combines Vanta's test-specific remediation intelligence with your local repository context to help you fix compliance failures faster.",
-    "installCommand": "claude plugins add vanta-mcp-plugin@claude-plugins-official",
+    "installCommand": "/plugin install vanta-mcp-plugin@claude-plugins-official",
     "tags": [
       "security",
       "ai"
@@ -3355,7 +3355,7 @@
     "slug": "vercel",
     "title": "Vercel",
     "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Claude Code.",
-    "installCommand": "claude plugins add vercel@claude-plugins-official",
+    "installCommand": "/plugin install vercel@claude-plugins-official",
     "tags": [
       "deployment",
       "vercel",
@@ -3376,8 +3376,8 @@
   {
     "slug": "windsor-ai",
     "title": "Windsor Ai",
-    "description": "Connect Claude Code to 325+ business data sources via Windsor.ai. Query marketing, sales, CRM, ecommerce, finance, and analytics data from Google Ads, Meta, HubSpot, Salesforce, Shopify, Stripe, and hundreds more — directly from your terminal.",
-    "installCommand": "claude plugins add windsor-ai@claude-plugins-official",
+    "description": "Connect Claude Code to 325+ business data sources via Windsor.ai. Query marketing, sales, CRM, ecommerce, finance, and analytics data from Google Ads, Meta, HubSpot, Salesforce, Shopify, Stripe, and hundreds more \u2014 directly from your terminal.",
+    "installCommand": "/plugin install windsor-ai@claude-plugins-official",
     "tags": [
       "productivity",
       "go",
@@ -3399,7 +3399,7 @@
     "slug": "wix",
     "title": "Wix",
     "description": "Build, manage, and deploy Wix sites and apps. CLI development skills for dashboard extensions, backend APIs, site widgets, and service plugins with the Wix Design System, plus MCP server for site management.",
-    "installCommand": "claude plugins add wix@claude-plugins-official",
+    "installCommand": "/plugin install wix@claude-plugins-official",
     "tags": [
       "development",
       "api"
@@ -3420,7 +3420,7 @@
     "slug": "wordpress-com",
     "title": "Wordpress.com",
     "description": "Uses Claude Code to create and edit WordPress sites with WordPress Studio before deploying changes to your WordPress.com site.",
-    "installCommand": "claude plugins add wordpress.com@claude-plugins-official",
+    "installCommand": "/plugin install wordpress.com@claude-plugins-official",
     "tags": [],
     "author": {
       "name": "anthropics",
@@ -3437,7 +3437,7 @@
     "slug": "youdotcom-agent-skills",
     "title": "Youdotcom Agent Skills",
     "description": "You.com agent skills for web search, research with citations, and content extraction. Guided integrations for Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, crewAI, LangChain, Microsoft Teams.ai, direct REST API, and bash CLI.",
-    "installCommand": "claude plugins add youdotcom-agent-skills@claude-plugins-official",
+    "installCommand": "/plugin install youdotcom-agent-skills@claude-plugins-official",
     "tags": [
       "productivity",
       "vercel",
@@ -3462,7 +3462,7 @@
     "slug": "zapier",
     "title": "Zapier",
     "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
-    "installCommand": "claude plugins add zapier@claude-plugins-official",
+    "installCommand": "/plugin install zapier@claude-plugins-official",
     "tags": [
       "productivity",
       "api",
@@ -3484,7 +3484,7 @@
     "slug": "zilliz",
     "title": "Zilliz",
     "description": "Zilliz Cloud management plugin with 14 skills covering cluster lifecycle, collection schema, vector search, index tuning, bulk import, RBAC, backups, and monitoring.",
-    "installCommand": "claude plugins add zilliz@claude-plugins-official",
+    "installCommand": "/plugin install zilliz@claude-plugins-official",
     "tags": [
       "database",
       "monitoring"
@@ -3505,7 +3505,7 @@
     "slug": "zoom-plugin",
     "title": "Zoom Plugin",
     "description": "Claude plugin for planning, building, and debugging Zoom integrations across REST APIs, SDKs, webhooks, bots, and MCP workflows.",
-    "installCommand": "claude plugins add zoom-plugin@claude-plugins-official",
+    "installCommand": "/plugin install zoom-plugin@claude-plugins-official",
     "tags": [
       "development",
       "api",
@@ -3526,8 +3526,8 @@
   {
     "slug": "zscaler",
     "title": "Zscaler",
-    "description": "Manage Zscaler cloud security platform including ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), EASM (attack surface), and Z-Insights (analytics). Create and manage policies, troubleshoot connectivity, audit security configurations…",
-    "installCommand": "claude plugins add zscaler@claude-plugins-official",
+    "description": "Manage Zscaler cloud security platform including ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), EASM (attack surface), and Z-Insights (analytics). Create and manage policies, troubleshoot connectivity, audit security configurations\u2026",
+    "installCommand": "/plugin install zscaler@claude-plugins-official",
     "tags": [
       "security"
     ],
@@ -3546,8 +3546,8 @@
   {
     "slug": "000-jeremy-content-consistency-validator",
     "title": "000 Jeremy Content Consistency Validator",
-    "description": "Read-only validator that generates comprehensive discrepancy reports comparing messaging consistency across ANY HTML-based website (WordPress, Hugo, Next.js, React, Vue, static HTML, etc.), GitHub repositories, and local documentation. Detects mixed messaging without making chan…",
-    "installCommand": "claude plugins add 000-jeremy-content-consistency-validator@claude-code-plugins-plus-skills",
+    "description": "Read-only validator that generates comprehensive discrepancy reports comparing messaging consistency across ANY HTML-based website (WordPress, Hugo, Next.js, React, Vue, static HTML, etc.), GitHub repositories, and local documentation. Detects mixed messaging without making chan\u2026",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install 000-jeremy-content-consistency-validator@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "go",
@@ -3571,7 +3571,7 @@
     "slug": "002-jeremy-yaml-master-agent",
     "title": "002 Jeremy Yaml Master Agent",
     "description": "Intelligent YAML validation, generation, and transformation agent with schema inference, linting, and format conversion capabilities",
-    "installCommand": "claude plugins add 002-jeremy-yaml-master-agent@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install 002-jeremy-yaml-master-agent@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "agent"
@@ -3592,7 +3592,7 @@
     "slug": "003-jeremy-vertex-ai-media-master",
     "title": "003 Jeremy Vertex Ai Media Master",
     "description": "Comprehensive Google Vertex AI multimodal mastery for Jeremy - video processing (6+ hours), audio generation, image creation with Gemini 2.0/2.5 and Imagen 4. Marketing campaign automation, content generation, and media asset production.",
-    "installCommand": "claude plugins add 003-jeremy-vertex-ai-media-master@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install 003-jeremy-vertex-ai-media-master@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "go",
@@ -3615,7 +3615,7 @@
     "slug": "004-jeremy-google-cloud-agent-sdk",
     "title": "004 Jeremy Google Cloud Agent Sdk",
     "description": "Google Cloud Agent Development Kit (ADK) and Agent Starter Pack mastery - build containerized multi-agent systems with production-ready templates, deploy to Cloud Run/GKE/Agent Engine, RAG agents, ReAct agents, and multi-agent orchestration.",
-    "installCommand": "claude plugins add 004-jeremy-google-cloud-agent-sdk@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install 004-jeremy-google-cloud-agent-sdk@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "go",
@@ -3640,7 +3640,7 @@
     "slug": "access-control-auditor",
     "title": "Access Control Auditor",
     "description": "Audit access control implementations",
-    "installCommand": "claude plugins add access-control-auditor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install access-control-auditor@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -3660,7 +3660,7 @@
     "slug": "accessibility-test-scanner",
     "title": "Accessibility Test Scanner",
     "description": "A11y compliance testing with WCAG 2.1/2.2 validation, screen reader compatibility, and automated accessibility audits",
-    "installCommand": "claude plugins add accessibility-test-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install accessibility-test-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -3680,7 +3680,7 @@
     "slug": "agent-context-manager",
     "title": "Agent Context Manager",
     "description": "Automatically detects and loads AGENTS.md files to provide agent-specific instructions",
-    "installCommand": "claude plugins add agent-context-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install agent-context-manager@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "agent"
@@ -3701,7 +3701,7 @@
     "slug": "ai-commit-gen",
     "title": "Ai Commit Gen",
     "description": "AI-powered commit message generator - analyzes your git diff and creates conventional commit messages instantly",
-    "installCommand": "claude plugins add ai-commit-gen@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ai-commit-gen@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai"
@@ -3722,7 +3722,7 @@
     "slug": "ai-ethics-validator",
     "title": "Ai Ethics Validator",
     "description": "AI ethics and fairness validation",
-    "installCommand": "claude plugins add ai-ethics-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ai-ethics-validator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "ai"
@@ -3743,7 +3743,7 @@
     "slug": "ai-experiment-logger",
     "title": "Ai Experiment Logger",
     "description": "Track and analyze AI experiments with a web dashboard and MCP tools",
-    "installCommand": "claude plugins add ai-experiment-logger@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ai-experiment-logger@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "ai"
@@ -3764,7 +3764,7 @@
     "slug": "ai-ml-engineering-pack",
     "title": "Ai Ml Engineering Pack",
     "description": "Professional AI/ML Engineering toolkit: Prompt engineering, LLM integration, RAG systems, AI safety with 12 expert plugins",
-    "installCommand": "claude plugins add ai-ml-engineering-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ai-ml-engineering-pack@claude-code-plugins-plus-skills",
     "tags": [
       "packages",
       "ai",
@@ -3787,7 +3787,7 @@
     "slug": "ai-sdk-agents",
     "title": "Ai Sdk Agents",
     "description": "Multi-agent orchestration with AI SDK v5 - handoffs, routing, and coordination for any AI provider (OpenAI, Anthropic, Google)",
-    "installCommand": "claude plugins add ai-sdk-agents@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ai-sdk-agents@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "go",
@@ -3810,7 +3810,7 @@
     "slug": "alerting-rule-creator",
     "title": "Alerting Rule Creator",
     "description": "Create intelligent alerting rules for performance monitoring",
-    "installCommand": "claude plugins add alerting-rule-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install alerting-rule-creator@claude-code-plugins-plus-skills",
     "tags": [
       "performance",
       "monitoring"
@@ -3831,7 +3831,7 @@
     "slug": "anomaly-detection-system",
     "title": "Anomaly Detection System",
     "description": "Detect anomalies and outliers in data",
-    "installCommand": "claude plugins add anomaly-detection-system@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install anomaly-detection-system@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -3851,7 +3851,7 @@
     "slug": "ansible-playbook-creator",
     "title": "Ansible Playbook Creator",
     "description": "Create Ansible playbooks for configuration management",
-    "installCommand": "claude plugins add ansible-playbook-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ansible-playbook-creator@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -3871,7 +3871,7 @@
     "slug": "api-authentication-builder",
     "title": "Api Authentication Builder",
     "description": "Build authentication systems with JWT, OAuth2, and API keys",
-    "installCommand": "claude plugins add api-authentication-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-authentication-builder@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -3892,7 +3892,7 @@
     "slug": "api-batch-processor",
     "title": "Api Batch Processor",
     "description": "Implement batch API operations with bulk processing and job queues",
-    "installCommand": "claude plugins add api-batch-processor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-batch-processor@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -3913,7 +3913,7 @@
     "slug": "api-cache-manager",
     "title": "Api Cache Manager",
     "description": "Implement caching strategies with Redis, CDN, and HTTP headers",
-    "installCommand": "claude plugins add api-cache-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-cache-manager@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "redis",
@@ -3935,7 +3935,7 @@
     "slug": "api-contract-generator",
     "title": "Api Contract Generator",
     "description": "Generate API contracts for consumer-driven contract testing",
-    "installCommand": "claude plugins add api-contract-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-contract-generator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "testing",
@@ -3957,7 +3957,7 @@
     "slug": "api-documentation-generator",
     "title": "Api Documentation Generator",
     "description": "Generate comprehensive API documentation from OpenAPI/Swagger specs",
-    "installCommand": "claude plugins add api-documentation-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-documentation-generator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -3978,7 +3978,7 @@
     "slug": "api-error-handler",
     "title": "Api Error Handler",
     "description": "Implement standardized error handling with proper HTTP status codes",
-    "installCommand": "claude plugins add api-error-handler@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-error-handler@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -3999,7 +3999,7 @@
     "slug": "api-event-emitter",
     "title": "Api Event Emitter",
     "description": "Implement event-driven APIs with message queues and event streaming",
-    "installCommand": "claude plugins add api-event-emitter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-event-emitter@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4020,7 +4020,7 @@
     "slug": "api-fuzzer",
     "title": "Api Fuzzer",
     "description": "Fuzz testing for APIs with malformed inputs, edge cases, and security vulnerability detection",
-    "installCommand": "claude plugins add api-fuzzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-fuzzer@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "security",
@@ -4042,7 +4042,7 @@
     "slug": "api-gateway-builder",
     "title": "Api Gateway Builder",
     "description": "Build API gateway with routing, authentication, and rate limiting",
-    "installCommand": "claude plugins add api-gateway-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-gateway-builder@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4063,7 +4063,7 @@
     "slug": "api-load-tester",
     "title": "Api Load Tester",
     "description": "Load test APIs with k6, Gatling, or Artillery",
-    "installCommand": "claude plugins add api-load-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-load-tester@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4084,7 +4084,7 @@
     "slug": "api-migration-tool",
     "title": "Api Migration Tool",
     "description": "Migrate APIs between versions with backward compatibility",
-    "installCommand": "claude plugins add api-migration-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-migration-tool@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4105,7 +4105,7 @@
     "slug": "api-mock-server",
     "title": "Api Mock Server",
     "description": "Create mock API servers from OpenAPI specs for testing",
-    "installCommand": "claude plugins add api-mock-server@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-mock-server@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "testing",
@@ -4127,7 +4127,7 @@
     "slug": "api-monitoring-dashboard",
     "title": "Api Monitoring Dashboard",
     "description": "Create monitoring dashboards for API health, metrics, and alerts",
-    "installCommand": "claude plugins add api-monitoring-dashboard@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-monitoring-dashboard@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "monitoring",
@@ -4149,7 +4149,7 @@
     "slug": "api-rate-limiter",
     "title": "Api Rate Limiter",
     "description": "Implement rate limiting with token bucket, sliding window, and Redis",
-    "installCommand": "claude plugins add api-rate-limiter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-rate-limiter@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "redis",
@@ -4171,7 +4171,7 @@
     "slug": "api-request-logger",
     "title": "Api Request Logger",
     "description": "Log API requests with structured logging and correlation IDs",
-    "installCommand": "claude plugins add api-request-logger@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-request-logger@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4192,7 +4192,7 @@
     "slug": "api-response-validator",
     "title": "Api Response Validator",
     "description": "Validate API responses against schemas and contracts",
-    "installCommand": "claude plugins add api-response-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-response-validator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api",
@@ -4214,7 +4214,7 @@
     "slug": "api-schema-validator",
     "title": "Api Schema Validator",
     "description": "Validate API schemas with JSON Schema, Joi, Yup, or Zod",
-    "installCommand": "claude plugins add api-schema-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-schema-validator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4235,7 +4235,7 @@
     "slug": "api-sdk-generator",
     "title": "Api Sdk Generator",
     "description": "Generate client SDKs from OpenAPI specs for multiple languages",
-    "installCommand": "claude plugins add api-sdk-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-sdk-generator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4256,7 +4256,7 @@
     "slug": "api-security-scanner",
     "title": "Api Security Scanner",
     "description": "Scan APIs for security vulnerabilities and OWASP API Top 10",
-    "installCommand": "claude plugins add api-security-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-security-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "security",
@@ -4278,7 +4278,7 @@
     "slug": "api-test-automation",
     "title": "Api Test Automation",
     "description": "Automated API endpoint testing with request generation, validation, and comprehensive test coverage",
-    "installCommand": "claude plugins add api-test-automation@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-test-automation@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "automation",
@@ -4301,7 +4301,7 @@
     "slug": "api-throttling-manager",
     "title": "Api Throttling Manager",
     "description": "Manage API throttling with dynamic rate limits and quota management",
-    "installCommand": "claude plugins add api-throttling-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-throttling-manager@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4322,7 +4322,7 @@
     "slug": "api-versioning-manager",
     "title": "Api Versioning Manager",
     "description": "Manage API versions with migration strategies and backward compatibility",
-    "installCommand": "claude plugins add api-versioning-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install api-versioning-manager@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api"
@@ -4343,7 +4343,7 @@
     "slug": "apm-dashboard-creator",
     "title": "Apm Dashboard Creator",
     "description": "Create Application Performance Monitoring dashboards",
-    "installCommand": "claude plugins add apm-dashboard-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install apm-dashboard-creator@claude-code-plugins-plus-skills",
     "tags": [
       "performance",
       "monitoring"
@@ -4364,7 +4364,7 @@
     "slug": "application-profiler",
     "title": "Application Profiler",
     "description": "Profile application performance with CPU, memory, and execution time analysis",
-    "installCommand": "claude plugins add application-profiler@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install application-profiler@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -4384,7 +4384,7 @@
     "slug": "arbitrage-opportunity-finder",
     "title": "Arbitrage Opportunity Finder",
     "description": "Find and analyze arbitrage opportunities across exchanges and DeFi protocols",
-    "installCommand": "claude plugins add arbitrage-opportunity-finder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install arbitrage-opportunity-finder@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "rag"
@@ -4405,7 +4405,7 @@
     "slug": "authentication-validator",
     "title": "Authentication Validator",
     "description": "Validate authentication implementations",
-    "installCommand": "claude plugins add authentication-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install authentication-validator@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -4425,7 +4425,7 @@
     "slug": "auto-scaling-configurator",
     "title": "Auto Scaling Configurator",
     "description": "Configure auto-scaling policies for applications and infrastructure",
-    "installCommand": "claude plugins add auto-scaling-configurator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install auto-scaling-configurator@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -4445,7 +4445,7 @@
     "slug": "automl-pipeline-builder",
     "title": "Automl Pipeline Builder",
     "description": "Build AutoML pipelines",
-    "installCommand": "claude plugins add automl-pipeline-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install automl-pipeline-builder@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -4465,7 +4465,7 @@
     "slug": "backup-strategy-implementor",
     "title": "Backup Strategy Implementor",
     "description": "Implement backup strategies for databases and applications",
-    "installCommand": "claude plugins add backup-strategy-implementor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install backup-strategy-implementor@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -4485,7 +4485,7 @@
     "slug": "blockchain-explorer-cli",
     "title": "Blockchain Explorer Cli",
     "description": "Command-line blockchain explorer for transactions, addresses, and contracts",
-    "installCommand": "claude plugins add blockchain-explorer-cli@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install blockchain-explorer-cli@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -4506,7 +4506,7 @@
     "slug": "bottleneck-detector",
     "title": "Bottleneck Detector",
     "description": "Detect and resolve performance bottlenecks",
-    "installCommand": "claude plugins add bottleneck-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install bottleneck-detector@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -4526,7 +4526,7 @@
     "slug": "browser-compatibility-tester",
     "title": "Browser Compatibility Tester",
     "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-    "installCommand": "claude plugins add browser-compatibility-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install browser-compatibility-tester@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "browser"
@@ -4547,7 +4547,7 @@
     "slug": "cache-performance-optimizer",
     "title": "Cache Performance Optimizer",
     "description": "Optimize caching strategies for improved performance",
-    "installCommand": "claude plugins add cache-performance-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cache-performance-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -4567,7 +4567,7 @@
     "slug": "calendar-to-workflow",
     "title": "Calendar To Workflow",
     "description": "Enhances calendar Skills by automating meeting prep and workflow triggers",
-    "installCommand": "claude plugins add calendar-to-workflow@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install calendar-to-workflow@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers"
     ],
@@ -4587,7 +4587,7 @@
     "slug": "capacity-planning-analyzer",
     "title": "Capacity Planning Analyzer",
     "description": "Analyze and plan for capacity requirements",
-    "installCommand": "claude plugins add capacity-planning-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install capacity-planning-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -4607,7 +4607,7 @@
     "slug": "chaos-engineering-toolkit",
     "title": "Chaos Engineering Toolkit",
     "description": "Chaos testing for resilience with failure injection, latency simulation, and system resilience validation",
-    "installCommand": "claude plugins add chaos-engineering-toolkit@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install chaos-engineering-toolkit@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "ai"
@@ -4628,7 +4628,7 @@
     "slug": "ci-cd-pipeline-builder",
     "title": "Ci Cd Pipeline Builder",
     "description": "Build CI/CD pipelines for GitHub Actions, GitLab CI, Jenkins, and more",
-    "installCommand": "claude plugins add ci-cd-pipeline-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ci-cd-pipeline-builder@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "github",
@@ -4650,7 +4650,7 @@
     "slug": "classification-model-builder",
     "title": "Classification Model Builder",
     "description": "Build classification models",
-    "installCommand": "claude plugins add classification-model-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install classification-model-builder@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -4670,7 +4670,7 @@
     "slug": "cloud-cost-optimizer",
     "title": "Cloud Cost Optimizer",
     "description": "Optimize cloud costs and generate cost reports",
-    "installCommand": "claude plugins add cloud-cost-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cloud-cost-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -4690,7 +4690,7 @@
     "slug": "clustering-algorithm-runner",
     "title": "Clustering Algorithm Runner",
     "description": "Run clustering algorithms on datasets",
-    "installCommand": "claude plugins add clustering-algorithm-runner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clustering-algorithm-runner@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "go"
@@ -4711,7 +4711,7 @@
     "slug": "compliance-checker",
     "title": "Compliance Checker",
     "description": "Check infrastructure compliance (SOC2, HIPAA, PCI-DSS)",
-    "installCommand": "claude plugins add compliance-checker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install compliance-checker@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -4731,7 +4731,7 @@
     "slug": "compliance-report-generator",
     "title": "Compliance Report Generator",
     "description": "Generate compliance reports",
-    "installCommand": "claude plugins add compliance-report-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install compliance-report-generator@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -4751,7 +4751,7 @@
     "slug": "computer-vision-processor",
     "title": "Computer Vision Processor",
     "description": "Computer vision image processing and analysis",
-    "installCommand": "claude plugins add computer-vision-processor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install computer-vision-processor@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -4771,7 +4771,7 @@
     "slug": "container-registry-manager",
     "title": "Container Registry Manager",
     "description": "Manage container registries (ECR, GCR, Harbor)",
-    "installCommand": "claude plugins add container-registry-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install container-registry-manager@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "ai"
@@ -4792,7 +4792,7 @@
     "slug": "container-security-scanner",
     "title": "Container Security Scanner",
     "description": "Scan containers for vulnerabilities using Trivy, Snyk, and other security tools",
-    "installCommand": "claude plugins add container-security-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install container-security-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "security",
@@ -4814,7 +4814,7 @@
     "slug": "contract-test-validator",
     "title": "Contract Test Validator",
     "description": "API contract testing with Pact, OpenAPI validation, and consumer-driven contract verification",
-    "installCommand": "claude plugins add contract-test-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install contract-test-validator@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "api"
@@ -4835,7 +4835,7 @@
     "slug": "conversational-api-debugger",
     "title": "Conversational Api Debugger",
     "description": "Debug REST API failures using OpenAPI specs and HTTP logs (HAR) - root cause analysis with cURL generation",
-    "installCommand": "claude plugins add conversational-api-debugger@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install conversational-api-debugger@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "api",
@@ -4858,7 +4858,7 @@
     "slug": "cors-policy-validator",
     "title": "Cors Policy Validator",
     "description": "Validate CORS policies",
-    "installCommand": "claude plugins add cors-policy-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cors-policy-validator@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -4878,7 +4878,7 @@
     "slug": "cpu-usage-monitor",
     "title": "Cpu Usage Monitor",
     "description": "Monitor and analyze CPU usage patterns in applications",
-    "installCommand": "claude plugins add cpu-usage-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cpu-usage-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -4898,7 +4898,7 @@
     "slug": "creator-studio-pack",
     "title": "Creator Studio Pack",
     "description": "Complete plugin suite for builder-filmmakers: Build products AND create viral videos. 20 plugins covering documentation, video production, content strategy, and workflow optimization. Transform from code to published video in 30 minutes.",
-    "installCommand": "claude plugins add creator-studio-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install creator-studio-pack@claude-code-plugins-plus-skills",
     "tags": [
       "packages"
     ],
@@ -4918,7 +4918,7 @@
     "slug": "cross-chain-bridge-monitor",
     "title": "Cross Chain Bridge Monitor",
     "description": "Monitor cross-chain bridge activity, track transfers, analyze security, and detect bridge exploits",
-    "installCommand": "claude plugins add cross-chain-bridge-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cross-chain-bridge-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "security",
@@ -4940,7 +4940,7 @@
     "slug": "crypto-derivatives-tracker",
     "title": "Crypto Derivatives Tracker",
     "description": "Track crypto futures, options, perpetual swaps with funding rates, open interest, and derivatives market analysis",
-    "installCommand": "claude plugins add crypto-derivatives-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install crypto-derivatives-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "rest"
@@ -4961,7 +4961,7 @@
     "slug": "crypto-news-aggregator",
     "title": "Crypto News Aggregator",
     "description": "Aggregate and analyze crypto news from multiple sources with sentiment analysis",
-    "installCommand": "claude plugins add crypto-news-aggregator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install crypto-news-aggregator@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -4981,7 +4981,7 @@
     "slug": "crypto-portfolio-tracker",
     "title": "Crypto Portfolio Tracker",
     "description": "Professional crypto portfolio tracking with real-time prices, PnL analysis, and risk metrics",
-    "installCommand": "claude plugins add crypto-portfolio-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install crypto-portfolio-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -5001,7 +5001,7 @@
     "slug": "crypto-signal-generator",
     "title": "Crypto Signal Generator",
     "description": "Generate trading signals from technical indicators and market analysis",
-    "installCommand": "claude plugins add crypto-signal-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install crypto-signal-generator@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -5021,7 +5021,7 @@
     "slug": "crypto-tax-calculator",
     "title": "Crypto Tax Calculator",
     "description": "Calculate crypto taxes with FIFO/LIFO methods and generate tax reports",
-    "installCommand": "claude plugins add crypto-tax-calculator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install crypto-tax-calculator@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -5041,7 +5041,7 @@
     "slug": "csrf-protection-validator",
     "title": "Csrf Protection Validator",
     "description": "Validate CSRF protection",
-    "installCommand": "claude plugins add csrf-protection-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install csrf-protection-validator@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -5061,7 +5061,7 @@
     "slug": "data-preprocessing-pipeline",
     "title": "Data Preprocessing Pipeline",
     "description": "Automated data preprocessing and cleaning pipelines",
-    "installCommand": "claude plugins add data-preprocessing-pipeline@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install data-preprocessing-pipeline@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -5081,7 +5081,7 @@
     "slug": "data-privacy-scanner",
     "title": "Data Privacy Scanner",
     "description": "Scan for data privacy issues",
-    "installCommand": "claude plugins add data-privacy-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install data-privacy-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -5101,7 +5101,7 @@
     "slug": "data-seeder-generator",
     "title": "Data Seeder Generator",
     "description": "Generate realistic test data and database seed scripts for development and testing environments",
-    "installCommand": "claude plugins add data-seeder-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install data-seeder-generator@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "testing"
@@ -5122,7 +5122,7 @@
     "slug": "data-validation-engine",
     "title": "Data Validation Engine",
     "description": "Database plugin for data-validation-engine",
-    "installCommand": "claude plugins add data-validation-engine@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install data-validation-engine@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5142,7 +5142,7 @@
     "slug": "data-visualization-creator",
     "title": "Data Visualization Creator",
     "description": "Create data visualizations and plots",
-    "installCommand": "claude plugins add data-visualization-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install data-visualization-creator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -5162,7 +5162,7 @@
     "slug": "database-archival-system",
     "title": "Database Archival System",
     "description": "Database plugin for database-archival-system",
-    "installCommand": "claude plugins add database-archival-system@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-archival-system@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5182,7 +5182,7 @@
     "slug": "database-audit-logger",
     "title": "Database Audit Logger",
     "description": "Database plugin for database-audit-logger",
-    "installCommand": "claude plugins add database-audit-logger@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-audit-logger@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5202,7 +5202,7 @@
     "slug": "database-backup-automator",
     "title": "Database Backup Automator",
     "description": "Automate database backups with scheduling, compression, encryption, and restore procedures",
-    "installCommand": "claude plugins add database-backup-automator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-backup-automator@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "rest"
@@ -5223,7 +5223,7 @@
     "slug": "database-cache-layer",
     "title": "Database Cache Layer",
     "description": "Database plugin for database-cache-layer",
-    "installCommand": "claude plugins add database-cache-layer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-cache-layer@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5243,7 +5243,7 @@
     "slug": "database-connection-pooler",
     "title": "Database Connection Pooler",
     "description": "Implement and optimize database connection pooling for improved performance and resource management",
-    "installCommand": "claude plugins add database-connection-pooler@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-connection-pooler@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "performance"
@@ -5264,7 +5264,7 @@
     "slug": "database-deadlock-detector",
     "title": "Database Deadlock Detector",
     "description": "Database plugin for database-deadlock-detector",
-    "installCommand": "claude plugins add database-deadlock-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-deadlock-detector@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5284,7 +5284,7 @@
     "slug": "database-diff-tool",
     "title": "Database Diff Tool",
     "description": "Database plugin for database-diff-tool",
-    "installCommand": "claude plugins add database-diff-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-diff-tool@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5304,7 +5304,7 @@
     "slug": "database-documentation-gen",
     "title": "Database Documentation Gen",
     "description": "Database plugin for database-documentation-gen",
-    "installCommand": "claude plugins add database-documentation-gen@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-documentation-gen@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5324,7 +5324,7 @@
     "slug": "database-health-monitor",
     "title": "Database Health Monitor",
     "description": "Database plugin for database-health-monitor",
-    "installCommand": "claude plugins add database-health-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-health-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5344,7 +5344,7 @@
     "slug": "database-index-advisor",
     "title": "Database Index Advisor",
     "description": "Analyze query patterns and recommend optimal database indexes with impact analysis",
-    "installCommand": "claude plugins add database-index-advisor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-index-advisor@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5364,7 +5364,7 @@
     "slug": "database-migration-manager",
     "title": "Database Migration Manager",
     "description": "Manage database migrations with version control, rollback capabilities, and automated schema evolution tracking",
-    "installCommand": "claude plugins add database-migration-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-migration-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5384,7 +5384,7 @@
     "slug": "database-partition-manager",
     "title": "Database Partition Manager",
     "description": "Database plugin for database-partition-manager",
-    "installCommand": "claude plugins add database-partition-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-partition-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5404,7 +5404,7 @@
     "slug": "database-query-profiler",
     "title": "Database Query Profiler",
     "description": "Profile and optimize database queries for performance",
-    "installCommand": "claude plugins add database-query-profiler@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-query-profiler@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -5424,7 +5424,7 @@
     "slug": "database-recovery-manager",
     "title": "Database Recovery Manager",
     "description": "Database plugin for database-recovery-manager",
-    "installCommand": "claude plugins add database-recovery-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-recovery-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5444,7 +5444,7 @@
     "slug": "database-replication-manager",
     "title": "Database Replication Manager",
     "description": "Manage database replication, failover, and high availability configurations",
-    "installCommand": "claude plugins add database-replication-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-replication-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "ai"
@@ -5465,7 +5465,7 @@
     "slug": "database-schema-designer",
     "title": "Database Schema Designer",
     "description": "Design and visualize database schemas with normalization guidance, relationship mapping, and ERD generation",
-    "installCommand": "claude plugins add database-schema-designer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-schema-designer@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5485,7 +5485,7 @@
     "slug": "database-security-scanner",
     "title": "Database Security Scanner",
     "description": "Database plugin for database-security-scanner",
-    "installCommand": "claude plugins add database-security-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-security-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "security"
@@ -5506,7 +5506,7 @@
     "slug": "database-sharding-manager",
     "title": "Database Sharding Manager",
     "description": "Database plugin for database-sharding-manager",
-    "installCommand": "claude plugins add database-sharding-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-sharding-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5526,7 +5526,7 @@
     "slug": "database-test-manager",
     "title": "Database Test Manager",
     "description": "Database testing utilities with test data setup, transaction rollback, and schema validation",
-    "installCommand": "claude plugins add database-test-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-test-manager@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -5546,7 +5546,7 @@
     "slug": "database-transaction-monitor",
     "title": "Database Transaction Monitor",
     "description": "Database plugin for database-transaction-monitor",
-    "installCommand": "claude plugins add database-transaction-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install database-transaction-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -5566,7 +5566,7 @@
     "slug": "dataset-splitter",
     "title": "Dataset Splitter",
     "description": "Split datasets for training, validation, and testing",
-    "installCommand": "claude plugins add dataset-splitter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install dataset-splitter@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "testing",
@@ -5588,7 +5588,7 @@
     "slug": "deep-learning-optimizer",
     "title": "Deep Learning Optimizer",
     "description": "Deep learning optimization techniques",
-    "installCommand": "claude plugins add deep-learning-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install deep-learning-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -5608,7 +5608,7 @@
     "slug": "defi-yield-optimizer",
     "title": "Defi Yield Optimizer",
     "description": "Optimize DeFi yield farming strategies across protocols with APY tracking and risk assessment",
-    "installCommand": "claude plugins add defi-yield-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install defi-yield-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -5628,7 +5628,7 @@
     "slug": "dependency-checker",
     "title": "Dependency Checker",
     "description": "Check dependencies for known vulnerabilities, outdated packages, and license compliance",
-    "installCommand": "claude plugins add dependency-checker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install dependency-checker@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -5648,7 +5648,7 @@
     "slug": "deployment-pipeline-orchestrator",
     "title": "Deployment Pipeline Orchestrator",
     "description": "Orchestrate complex multi-stage deployment pipelines",
-    "installCommand": "claude plugins add deployment-pipeline-orchestrator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install deployment-pipeline-orchestrator@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "deployment"
@@ -5669,7 +5669,7 @@
     "slug": "deployment-rollback-manager",
     "title": "Deployment Rollback Manager",
     "description": "Manage and execute deployment rollbacks with safety checks",
-    "installCommand": "claude plugins add deployment-rollback-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install deployment-rollback-manager@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "deployment"
@@ -5690,7 +5690,7 @@
     "slug": "design-to-code",
     "title": "Design To Code",
     "description": "Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility",
-    "installCommand": "claude plugins add design-to-code@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install design-to-code@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "react",
@@ -5712,7 +5712,7 @@
     "slug": "devops-automation-pack",
     "title": "Devops Automation Pack",
     "description": "Complete DevOps automation suite with 25 plugins covering Git workflows, CI/CD pipelines, Docker optimization, Kubernetes management, Terraform IaC, and deployment strategies",
-    "installCommand": "claude plugins add devops-automation-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install devops-automation-pack@claude-code-plugins-plus-skills",
     "tags": [
       "packages",
       "kubernetes",
@@ -5736,7 +5736,7 @@
     "slug": "dex-aggregator-router",
     "title": "Dex Aggregator Router",
     "description": "Find optimal DEX routes for token swaps across multiple exchanges",
-    "installCommand": "claude plugins add dex-aggregator-router@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install dex-aggregator-router@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -5756,7 +5756,7 @@
     "slug": "disaster-recovery-planner",
     "title": "Disaster Recovery Planner",
     "description": "Plan and implement disaster recovery procedures",
-    "installCommand": "claude plugins add disaster-recovery-planner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install disaster-recovery-planner@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -5776,7 +5776,7 @@
     "slug": "discovery-questionnaire",
     "title": "Discovery Questionnaire",
     "description": "Generate custom discovery questionnaires for AI agency prospects",
-    "installCommand": "claude plugins add discovery-questionnaire@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install discovery-questionnaire@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "ai"
@@ -5797,7 +5797,7 @@
     "slug": "distributed-tracing-setup",
     "title": "Distributed Tracing Setup",
     "description": "Set up distributed tracing for microservices",
-    "installCommand": "claude plugins add distributed-tracing-setup@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install distributed-tracing-setup@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -5817,7 +5817,7 @@
     "slug": "docker-compose-generator",
     "title": "Docker Compose Generator",
     "description": "Generate Docker Compose configurations for multi-container applications with best practices",
-    "installCommand": "claude plugins add docker-compose-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install docker-compose-generator@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "docker",
@@ -5839,7 +5839,7 @@
     "slug": "domain-memory-agent",
     "title": "Domain Memory Agent",
     "description": "Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required",
-    "installCommand": "claude plugins add domain-memory-agent@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install domain-memory-agent@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "ai",
@@ -5861,7 +5861,7 @@
     "slug": "lumera-agent-memory",
     "title": "Lumera Agent Memory",
     "description": "Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across sessions.",
-    "installCommand": "claude plugins add lumera-agent-memory@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install lumera-agent-memory@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "rag",
@@ -5883,7 +5883,7 @@
     "slug": "e2e-test-framework",
     "title": "E2e Test Framework",
     "description": "End-to-end test automation with Playwright, Cypress, and Selenium for browser-based testing",
-    "installCommand": "claude plugins add e2e-test-framework@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install e2e-test-framework@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "browser",
@@ -5905,7 +5905,7 @@
     "slug": "encryption-tool",
     "title": "Encryption Tool",
     "description": "Encrypt and decrypt data with various algorithms",
-    "installCommand": "claude plugins add encryption-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install encryption-tool@claude-code-plugins-plus-skills",
     "tags": [
       "security",
       "go"
@@ -5925,8 +5925,8 @@
   {
     "slug": "engineer-design-diagram",
     "title": "Engineer Design Diagram",
-    "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph…",
-    "installCommand": "claude plugins add engineer-design-diagram@claude-code-plugins-plus-skills",
+    "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI \u2014 package manifests, docker-compose, k8s, terraform, import graph\u2026",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install engineer-design-diagram@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "docker",
@@ -5948,7 +5948,7 @@
     "slug": "environment-config-manager",
     "title": "Environment Config Manager",
     "description": "Manage environment configurations and secrets across deployments",
-    "installCommand": "claude plugins add environment-config-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install environment-config-manager@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "deployment"
@@ -5969,7 +5969,7 @@
     "slug": "error-rate-monitor",
     "title": "Error Rate Monitor",
     "description": "Monitor and analyze application error rates",
-    "installCommand": "claude plugins add error-rate-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install error-rate-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -5989,7 +5989,7 @@
     "slug": "excel-analyst-pro",
     "title": "Excel Analyst Pro",
     "description": "Professional financial modeling toolkit for Claude Code with auto-invoked Skills and Excel MCP integration. Build DCF models, LBO analysis, variance reports, and pivot tables using natural language.",
-    "installCommand": "claude plugins add excel-analyst-pro@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install excel-analyst-pro@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools"
     ],
@@ -6009,7 +6009,7 @@
     "slug": "brand-strategy-framework",
     "title": "Brand Strategy Framework",
     "description": "A 7-part brand strategy framework for building comprehensive brand foundations - the same methodology top agencies use with Fortune 500 clients.",
-    "installCommand": "claude plugins add brand-strategy-framework@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install brand-strategy-framework@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools"
     ],
@@ -6029,7 +6029,7 @@
     "slug": "experiment-tracking-setup",
     "title": "Experiment Tracking Setup",
     "description": "Set up ML experiment tracking",
-    "installCommand": "claude plugins add experiment-tracking-setup@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install experiment-tracking-setup@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -6049,7 +6049,7 @@
     "slug": "fairdb-operations-kit",
     "title": "Fairdb Operations Kit",
     "description": "Complete operations kit for FairDB PostgreSQL as a Service - VPS setup, PostgreSQL management, customer provisioning, monitoring, and backup automation",
-    "installCommand": "claude plugins add fairdb-operations-kit@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fairdb-operations-kit@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "postgres",
@@ -6073,7 +6073,7 @@
     "slug": "fairdb-ops-manager",
     "title": "Fairdb Ops Manager",
     "description": "Database operations management for FairDB PostgreSQL clusters",
-    "installCommand": "claude plugins add fairdb-ops-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fairdb-ops-manager@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "postgres",
@@ -6095,7 +6095,7 @@
     "slug": "feature-engineering-toolkit",
     "title": "Feature Engineering Toolkit",
     "description": "Feature creation, selection, and transformation tools",
-    "installCommand": "claude plugins add feature-engineering-toolkit@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install feature-engineering-toolkit@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -6115,7 +6115,7 @@
     "slug": "file-to-code",
     "title": "File To Code",
     "description": "Converts file references into executable code implementations",
-    "installCommand": "claude plugins add file-to-code@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install file-to-code@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers"
     ],
@@ -6135,7 +6135,7 @@
     "slug": "flash-loan-simulator",
     "title": "Flash Loan Simulator",
     "description": "Simulate and analyze flash loan strategies including arbitrage, liquidations, and collateral swaps",
-    "installCommand": "claude plugins add flash-loan-simulator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install flash-loan-simulator@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "rag"
@@ -6156,7 +6156,7 @@
     "slug": "formatter",
     "title": "Formatter",
     "description": "Code formatting plugin using hooks to auto-format on save",
-    "installCommand": "claude plugins add formatter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install formatter@claude-code-plugins-plus-skills",
     "tags": [
       "examples"
     ],
@@ -6175,8 +6175,8 @@
   {
     "slug": "freshie-inventory-manager",
     "title": "Freshie Inventory Manager",
-    "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
-    "installCommand": "claude plugins add freshie-inventory-manager@claude-code-plugins-plus-skills",
+    "description": "Interactive command center for the freshie ecosystem inventory database \u2014 conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install freshie-inventory-manager@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "ai",
@@ -6198,7 +6198,7 @@
     "slug": "fullstack-starter-pack",
     "title": "Fullstack Starter Pack",
     "description": "Complete fullstack development toolkit: React, Express/FastAPI, PostgreSQL scaffolding with AI agents",
-    "installCommand": "claude plugins add fullstack-starter-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fullstack-starter-pack@claude-code-plugins-plus-skills",
     "tags": [
       "packages",
       "react",
@@ -6223,7 +6223,7 @@
     "slug": "gas-fee-optimizer",
     "title": "Gas Fee Optimizer",
     "description": "Optimize transaction gas fees with timing and routing recommendations",
-    "installCommand": "claude plugins add gas-fee-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gas-fee-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -6243,7 +6243,7 @@
     "slug": "gdpr-compliance-scanner",
     "title": "Gdpr Compliance Scanner",
     "description": "Scan for GDPR compliance issues",
-    "installCommand": "claude plugins add gdpr-compliance-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gdpr-compliance-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -6263,7 +6263,7 @@
     "slug": "git-commit-smart",
     "title": "Git Commit Smart",
     "description": "AI-powered conventional commit message generator with smart analysis",
-    "installCommand": "claude plugins add git-commit-smart@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install git-commit-smart@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "ai"
@@ -6284,7 +6284,7 @@
     "slug": "gitops-workflow-builder",
     "title": "Gitops Workflow Builder",
     "description": "Build GitOps workflows with ArgoCD and Flux",
-    "installCommand": "claude plugins add gitops-workflow-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gitops-workflow-builder@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "go"
@@ -6305,7 +6305,7 @@
     "slug": "graphql-server-builder",
     "title": "Graphql Server Builder",
     "description": "Build GraphQL servers with schema-first design, resolvers, and subscriptions",
-    "installCommand": "claude plugins add graphql-server-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install graphql-server-builder@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "graphql"
@@ -6326,7 +6326,7 @@
     "slug": "grpc-service-generator",
     "title": "Grpc Service Generator",
     "description": "Generate gRPC services with Protocol Buffers and streaming support",
-    "installCommand": "claude plugins add grpc-service-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install grpc-service-generator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development"
     ],
@@ -6346,7 +6346,7 @@
     "slug": "hello-world",
     "title": "Hello World",
     "description": "Simple example plugin demonstrating basic slash commands",
-    "installCommand": "claude plugins add hello-world@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hello-world@claude-code-plugins-plus-skills",
     "tags": [
       "examples"
     ],
@@ -6366,7 +6366,7 @@
     "slug": "helm-chart-generator",
     "title": "Helm Chart Generator",
     "description": "Generate Helm charts for Kubernetes applications",
-    "installCommand": "claude plugins add helm-chart-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install helm-chart-generator@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "kubernetes"
@@ -6387,7 +6387,7 @@
     "slug": "hipaa-compliance-checker",
     "title": "Hipaa Compliance Checker",
     "description": "Check HIPAA compliance",
-    "installCommand": "claude plugins add hipaa-compliance-checker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hipaa-compliance-checker@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -6407,7 +6407,7 @@
     "slug": "hyperparameter-tuner",
     "title": "Hyperparameter Tuner",
     "description": "Optimize hyperparameters using grid/random/bayesian search",
-    "installCommand": "claude plugins add hyperparameter-tuner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hyperparameter-tuner@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -6427,7 +6427,7 @@
     "slug": "infrastructure-as-code-generator",
     "title": "Infrastructure As Code Generator",
     "description": "Generate Infrastructure as Code for Terraform, CloudFormation, Pulumi, and more",
-    "installCommand": "claude plugins add infrastructure-as-code-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install infrastructure-as-code-generator@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -6447,7 +6447,7 @@
     "slug": "infrastructure-drift-detector",
     "title": "Infrastructure Drift Detector",
     "description": "Detect infrastructure drift from desired state",
-    "installCommand": "claude plugins add infrastructure-drift-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install infrastructure-drift-detector@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -6467,7 +6467,7 @@
     "slug": "infrastructure-metrics-collector",
     "title": "Infrastructure Metrics Collector",
     "description": "Collect comprehensive infrastructure performance metrics",
-    "installCommand": "claude plugins add infrastructure-metrics-collector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install infrastructure-metrics-collector@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -6487,7 +6487,7 @@
     "slug": "input-validation-scanner",
     "title": "Input Validation Scanner",
     "description": "Scan input validation practices",
-    "installCommand": "claude plugins add input-validation-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install input-validation-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -6507,7 +6507,7 @@
     "slug": "integration-test-runner",
     "title": "Integration Test Runner",
     "description": "Run and manage integration test suites with environment setup, database seeding, and cleanup",
-    "installCommand": "claude plugins add integration-test-runner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install integration-test-runner@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -6527,7 +6527,7 @@
     "slug": "kubernetes-deployment-creator",
     "title": "Kubernetes Deployment Creator",
     "description": "Create Kubernetes deployments, services, and configurations with best practices",
-    "installCommand": "claude plugins add kubernetes-deployment-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install kubernetes-deployment-creator@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "kubernetes",
@@ -6549,7 +6549,7 @@
     "slug": "liquidity-pool-analyzer",
     "title": "Liquidity Pool Analyzer",
     "description": "Analyze DeFi liquidity pools for impermanent loss, APY, and optimization opportunities",
-    "installCommand": "claude plugins add liquidity-pool-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install liquidity-pool-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -6569,7 +6569,7 @@
     "slug": "load-balancer-configurator",
     "title": "Load Balancer Configurator",
     "description": "Configure load balancers (ALB, NLB, Nginx, HAProxy)",
-    "installCommand": "claude plugins add load-balancer-configurator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install load-balancer-configurator@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -6589,7 +6589,7 @@
     "slug": "load-balancer-tester",
     "title": "Load Balancer Tester",
     "description": "Test load balancing strategies with traffic distribution validation and failover testing",
-    "installCommand": "claude plugins add load-balancer-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install load-balancer-tester@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "ai"
@@ -6610,7 +6610,7 @@
     "slug": "load-test-runner",
     "title": "Load Test Runner",
     "description": "Create and execute load tests for performance validation",
-    "installCommand": "claude plugins add load-test-runner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install load-test-runner@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -6630,7 +6630,7 @@
     "slug": "log-aggregation-setup",
     "title": "Log Aggregation Setup",
     "description": "Set up log aggregation (ELK, Loki, Splunk)",
-    "installCommand": "claude plugins add log-aggregation-setup@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install log-aggregation-setup@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -6650,7 +6650,7 @@
     "slug": "log-analysis-tool",
     "title": "Log Analysis Tool",
     "description": "Analyze logs for performance insights and issues",
-    "installCommand": "claude plugins add log-analysis-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install log-analysis-tool@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -6670,7 +6670,7 @@
     "slug": "make-scenario-builder",
     "title": "Make Scenario Builder",
     "description": "Create Make.com (Integromat) scenarios with AI assistance",
-    "installCommand": "claude plugins add make-scenario-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install make-scenario-builder@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "ai"
@@ -6691,7 +6691,7 @@
     "slug": "market-movers-scanner",
     "title": "Market Movers Scanner",
     "description": "Scan for top market movers - gainers, losers, volume spikes, and unusual activity",
-    "installCommand": "claude plugins add market-movers-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install market-movers-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -6712,7 +6712,7 @@
     "slug": "market-price-tracker",
     "title": "Market Price Tracker",
     "description": "Real-time market price tracking with multi-exchange feeds and advanced alerts",
-    "installCommand": "claude plugins add market-price-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install market-price-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -6732,7 +6732,7 @@
     "slug": "market-sentiment-analyzer",
     "title": "Market Sentiment Analyzer",
     "description": "Analyze market sentiment from social media, news, and on-chain data",
-    "installCommand": "claude plugins add market-sentiment-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install market-sentiment-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -6753,7 +6753,7 @@
     "slug": "memory-leak-detector",
     "title": "Memory Leak Detector",
     "description": "Detect memory leaks and analyze memory usage patterns",
-    "installCommand": "claude plugins add memory-leak-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install memory-leak-detector@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -6773,7 +6773,7 @@
     "slug": "mempool-analyzer",
     "title": "Mempool Analyzer",
     "description": "Advanced mempool analysis for MEV opportunities, pending transaction monitoring, and gas price optimization",
-    "installCommand": "claude plugins add mempool-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mempool-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "monitoring"
@@ -6794,7 +6794,7 @@
     "slug": "metrics-aggregator",
     "title": "Metrics Aggregator",
     "description": "Aggregate and centralize performance metrics",
-    "installCommand": "claude plugins add metrics-aggregator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install metrics-aggregator@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -6814,7 +6814,7 @@
     "slug": "ml-model-trainer",
     "title": "Ml Model Trainer",
     "description": "Train and optimize machine learning models with automated workflows",
-    "installCommand": "claude plugins add ml-model-trainer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ml-model-trainer@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "ai"
@@ -6835,7 +6835,7 @@
     "slug": "mobile-app-tester",
     "title": "Mobile App Tester",
     "description": "Mobile app test automation with Appium, Detox, XCUITest - test iOS and Android apps",
-    "installCommand": "claude plugins add mobile-app-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mobile-app-tester@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "automation"
@@ -6856,7 +6856,7 @@
     "slug": "model-deployment-helper",
     "title": "Model Deployment Helper",
     "description": "Deploy ML models to production",
-    "installCommand": "claude plugins add model-deployment-helper@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install model-deployment-helper@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "deployment"
@@ -6877,7 +6877,7 @@
     "slug": "model-evaluation-suite",
     "title": "Model Evaluation Suite",
     "description": "Comprehensive model evaluation with multiple metrics",
-    "installCommand": "claude plugins add model-evaluation-suite@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install model-evaluation-suite@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -6897,7 +6897,7 @@
     "slug": "model-explainability-tool",
     "title": "Model Explainability Tool",
     "description": "Model interpretability and explainability",
-    "installCommand": "claude plugins add model-explainability-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install model-explainability-tool@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "ai"
@@ -6918,7 +6918,7 @@
     "slug": "model-versioning-tracker",
     "title": "Model Versioning Tracker",
     "description": "Track and manage model versions",
-    "installCommand": "claude plugins add model-versioning-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install model-versioning-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -6938,7 +6938,7 @@
     "slug": "monitoring-stack-deployer",
     "title": "Monitoring Stack Deployer",
     "description": "Deploy monitoring stacks (Prometheus, Grafana, Datadog)",
-    "installCommand": "claude plugins add monitoring-stack-deployer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install monitoring-stack-deployer@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "monitoring"
@@ -6959,7 +6959,7 @@
     "slug": "mutation-test-runner",
     "title": "Mutation Test Runner",
     "description": "Mutation testing to validate test quality by introducing code changes and verifying tests catch them",
-    "installCommand": "claude plugins add mutation-test-runner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mutation-test-runner@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -6979,7 +6979,7 @@
     "slug": "n8n-workflow-designer",
     "title": "N8n Workflow Designer",
     "description": "Design complex n8n workflows with AI assistance - loops, branching, error handling",
-    "installCommand": "claude plugins add n8n-workflow-designer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install n8n-workflow-designer@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "ai"
@@ -7000,7 +7000,7 @@
     "slug": "network-latency-analyzer",
     "title": "Network Latency Analyzer",
     "description": "Analyze network latency and optimize request patterns",
-    "installCommand": "claude plugins add network-latency-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install network-latency-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -7020,7 +7020,7 @@
     "slug": "network-policy-manager",
     "title": "Network Policy Manager",
     "description": "Manage Kubernetes network policies and firewall rules",
-    "installCommand": "claude plugins add network-policy-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install network-policy-manager@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "kubernetes"
@@ -7041,7 +7041,7 @@
     "slug": "neural-network-builder",
     "title": "Neural Network Builder",
     "description": "Build and configure neural network architectures",
-    "installCommand": "claude plugins add neural-network-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install neural-network-builder@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -7061,7 +7061,7 @@
     "slug": "nft-rarity-analyzer",
     "title": "Nft Rarity Analyzer",
     "description": "Analyze NFT rarity scores and valuations across collections",
-    "installCommand": "claude plugins add nft-rarity-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install nft-rarity-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -7081,7 +7081,7 @@
     "slug": "nlp-text-analyzer",
     "title": "Nlp Text Analyzer",
     "description": "Natural language processing and text analysis",
-    "installCommand": "claude plugins add nlp-text-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install nlp-text-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -7101,7 +7101,7 @@
     "slug": "ollama-local-ai",
     "title": "Ollama Local Ai",
     "description": "Run AI models locally with Ollama - free alternative to OpenAI, Anthropic, and other paid LLM APIs. Zero-cost, privacy-first AI infrastructure.",
-    "installCommand": "claude plugins add ollama-local-ai@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ollama-local-ai@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "api",
@@ -7124,7 +7124,7 @@
     "slug": "nosql-data-modeler",
     "title": "Nosql Data Modeler",
     "description": "Database plugin for nosql-data-modeler",
-    "installCommand": "claude plugins add nosql-data-modeler@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install nosql-data-modeler@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -7144,7 +7144,7 @@
     "slug": "on-chain-analytics",
     "title": "On Chain Analytics",
     "description": "Analyze on-chain metrics including whale movements, network activity, and holder distribution",
-    "installCommand": "claude plugins add on-chain-analytics@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install on-chain-analytics@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -7165,7 +7165,7 @@
     "slug": "openbb-terminal",
     "title": "Openbb Terminal",
     "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-    "installCommand": "claude plugins add openbb-terminal@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install openbb-terminal@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -7186,7 +7186,7 @@
     "slug": "options-flow-analyzer",
     "title": "Options Flow Analyzer",
     "description": "Track institutional options flow, unusual activity, and smart money movements",
-    "installCommand": "claude plugins add options-flow-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install options-flow-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -7206,7 +7206,7 @@
     "slug": "orm-code-generator",
     "title": "Orm Code Generator",
     "description": "Generate ORM models from database schemas or create database schemas from models for TypeORM, Prisma, Sequelize, SQLAlchemy, and more",
-    "installCommand": "claude plugins add orm-code-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install orm-code-generator@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -7226,7 +7226,7 @@
     "slug": "overnight-dev",
     "title": "Overnight Dev",
     "description": "Run Claude autonomously for 6-8 hours overnight using Git hooks that enforce TDD - wake up to fully tested features",
-    "installCommand": "claude plugins add overnight-dev@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install overnight-dev@claude-code-plugins-plus-skills",
     "tags": [
       "productivity"
     ],
@@ -7246,7 +7246,7 @@
     "slug": "owasp-compliance-checker",
     "title": "Owasp Compliance Checker",
     "description": "Check OWASP Top 10 compliance",
-    "installCommand": "claude plugins add owasp-compliance-checker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install owasp-compliance-checker@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7266,7 +7266,7 @@
     "slug": "pci-dss-validator",
     "title": "Pci Dss Validator",
     "description": "Validate PCI DSS compliance",
-    "installCommand": "claude plugins add pci-dss-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install pci-dss-validator@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7286,7 +7286,7 @@
     "slug": "penetration-tester",
     "title": "Penetration Tester",
     "description": "Automated penetration testing for web applications with OWASP Top 10 coverage",
-    "installCommand": "claude plugins add penetration-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install penetration-tester@claude-code-plugins-plus-skills",
     "tags": [
       "security",
       "testing",
@@ -7308,7 +7308,7 @@
     "slug": "performance-budget-validator",
     "title": "Performance Budget Validator",
     "description": "Validate application against performance budgets",
-    "installCommand": "claude plugins add performance-budget-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install performance-budget-validator@claude-code-plugins-plus-skills",
     "tags": [
       "performance",
       "ai"
@@ -7329,7 +7329,7 @@
     "slug": "performance-optimization-advisor",
     "title": "Performance Optimization Advisor",
     "description": "Get comprehensive performance optimization recommendations",
-    "installCommand": "claude plugins add performance-optimization-advisor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install performance-optimization-advisor@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -7349,7 +7349,7 @@
     "slug": "performance-regression-detector",
     "title": "Performance Regression Detector",
     "description": "Detect performance regressions in CI/CD pipeline",
-    "installCommand": "claude plugins add performance-regression-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install performance-regression-detector@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -7369,7 +7369,7 @@
     "slug": "performance-test-suite",
     "title": "Performance Test Suite",
     "description": "Load testing and performance benchmarking with metrics analysis and bottleneck identification",
-    "installCommand": "claude plugins add performance-test-suite@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install performance-test-suite@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "performance"
@@ -7390,7 +7390,7 @@
     "slug": "pi-pathfinder",
     "title": "Pi Pathfinder",
     "description": "PI Pathfinder - Finds the path through 229 plugins. Automatically picks the best plugin for your task, extracts its skills, and applies them. You don't pick plugins, PI does. Part of our initiative to update all plugins with appropriate skill sets.",
-    "installCommand": "claude plugins add pi-pathfinder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install pi-pathfinder@claude-code-plugins-plus-skills",
     "tags": [
       "examples"
     ],
@@ -7409,8 +7409,8 @@
   {
     "slug": "code-cleanup",
     "title": "Code Cleanup",
-    "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
-    "installCommand": "claude plugins add code-cleanup@claude-code-plugins-plus-skills",
+    "description": "Comprehensive codebase cleanup across 11 quality dimensions \u2014 dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install code-cleanup@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "security",
@@ -7433,7 +7433,7 @@
     "slug": "project-health-auditor",
     "title": "Project Health Auditor",
     "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
-    "installCommand": "claude plugins add project-health-auditor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install project-health-auditor@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "rag"
@@ -7453,8 +7453,8 @@
   {
     "slug": "promptbook",
     "title": "Promptbook",
-    "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after se…",
-    "installCommand": "claude plugins add promptbook@claude-code-plugins-plus-skills",
+    "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating \u2014 no data transmitted without explicit opt-in. Background submission after se\u2026",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install promptbook@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools"
     ],
@@ -7474,7 +7474,7 @@
     "slug": "query-performance-analyzer",
     "title": "Query Performance Analyzer",
     "description": "Analyze query performance with EXPLAIN plan interpretation, bottleneck identification, and optimization recommendations",
-    "installCommand": "claude plugins add query-performance-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install query-performance-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "performance",
@@ -7496,7 +7496,7 @@
     "slug": "real-user-monitoring",
     "title": "Real User Monitoring",
     "description": "Implement Real User Monitoring for actual performance data",
-    "installCommand": "claude plugins add real-user-monitoring@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install real-user-monitoring@claude-code-plugins-plus-skills",
     "tags": [
       "performance",
       "monitoring"
@@ -7517,7 +7517,7 @@
     "slug": "recommendation-engine",
     "title": "Recommendation Engine",
     "description": "Build recommendation systems and engines",
-    "installCommand": "claude plugins add recommendation-engine@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install recommendation-engine@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -7537,7 +7537,7 @@
     "slug": "regression-analysis-tool",
     "title": "Regression Analysis Tool",
     "description": "Regression analysis and modeling",
-    "installCommand": "claude plugins add regression-analysis-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install regression-analysis-tool@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -7557,7 +7557,7 @@
     "slug": "regression-test-tracker",
     "title": "Regression Test Tracker",
     "description": "Track and run regression tests to ensure new changes don't break existing functionality",
-    "installCommand": "claude plugins add regression-test-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install regression-test-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -7577,7 +7577,7 @@
     "slug": "research-to-deploy",
     "title": "Research To Deploy",
     "description": "Transforms research findings into deployed solutions automatically",
-    "installCommand": "claude plugins add research-to-deploy@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install research-to-deploy@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers"
     ],
@@ -7597,7 +7597,7 @@
     "slug": "resource-usage-tracker",
     "title": "Resource Usage Tracker",
     "description": "Track and optimize resource usage across the stack",
-    "installCommand": "claude plugins add resource-usage-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install resource-usage-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -7617,7 +7617,7 @@
     "slug": "response-time-tracker",
     "title": "Response Time Tracker",
     "description": "Track and optimize application response times",
-    "installCommand": "claude plugins add response-time-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install response-time-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -7637,7 +7637,7 @@
     "slug": "rest-api-generator",
     "title": "Rest Api Generator",
     "description": "Generate RESTful APIs from schemas with proper routing, validation, and documentation",
-    "installCommand": "claude plugins add rest-api-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install rest-api-generator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development",
       "api",
@@ -7659,7 +7659,7 @@
     "slug": "roi-calculator",
     "title": "Roi Calculator",
     "description": "Calculate and present ROI for AI automation projects",
-    "installCommand": "claude plugins add roi-calculator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install roi-calculator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "automation",
@@ -7681,7 +7681,7 @@
     "slug": "search-to-slack",
     "title": "Search To Slack",
     "description": "Automatically posts search results to Slack channels",
-    "installCommand": "claude plugins add search-to-slack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install search-to-slack@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers",
       "slack"
@@ -7702,7 +7702,7 @@
     "slug": "secret-scanner",
     "title": "Secret Scanner",
     "description": "Scan codebase for exposed secrets, API keys, passwords, and sensitive credentials",
-    "installCommand": "claude plugins add secret-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install secret-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security",
       "api"
@@ -7723,7 +7723,7 @@
     "slug": "severity1-marketplace",
     "title": "Severity1 Marketplace",
     "description": "Severity level classification and prompt improvement for marketplace plugins. Assigns severity ratings (S1-Critical through S4-Low) and enhances plugin prompts for clarity, safety, and effectiveness.",
-    "installCommand": "claude plugins add severity1-marketplace@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install severity1-marketplace@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7743,7 +7743,7 @@
     "slug": "secrets-manager-integrator",
     "title": "Secrets Manager Integrator",
     "description": "Integrate with secrets managers (Vault, AWS Secrets Manager, etc)",
-    "installCommand": "claude plugins add secrets-manager-integrator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install secrets-manager-integrator@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "aws"
@@ -7764,7 +7764,7 @@
     "slug": "security-agent",
     "title": "Security Agent",
     "description": "Security review subagent for code analysis",
-    "installCommand": "claude plugins add security-agent@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-agent@claude-code-plugins-plus-skills",
     "tags": [
       "examples",
       "security",
@@ -7786,7 +7786,7 @@
     "slug": "security-audit-reporter",
     "title": "Security Audit Reporter",
     "description": "Generate comprehensive security audit reports",
-    "installCommand": "claude plugins add security-audit-reporter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-audit-reporter@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7806,7 +7806,7 @@
     "slug": "security-headers-analyzer",
     "title": "Security Headers Analyzer",
     "description": "Analyze HTTP security headers",
-    "installCommand": "claude plugins add security-headers-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-headers-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7826,7 +7826,7 @@
     "slug": "security-incident-responder",
     "title": "Security Incident Responder",
     "description": "Assist with security incident response",
-    "installCommand": "claude plugins add security-incident-responder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-incident-responder@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7846,7 +7846,7 @@
     "slug": "security-misconfiguration-finder",
     "title": "Security Misconfiguration Finder",
     "description": "Find security misconfigurations",
-    "installCommand": "claude plugins add security-misconfiguration-finder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-misconfiguration-finder@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7866,7 +7866,7 @@
     "slug": "security-pro-pack",
     "title": "Security Pro Pack",
     "description": "Professional security tools for Claude Code: vulnerability scanning, compliance, cryptography audit, container & API security",
-    "installCommand": "claude plugins add security-pro-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-pro-pack@claude-code-plugins-plus-skills",
     "tags": [
       "packages",
       "security",
@@ -7889,7 +7889,7 @@
     "slug": "security-test-scanner",
     "title": "Security Test Scanner",
     "description": "Automated security vulnerability testing covering OWASP Top 10, SQL injection, XSS, CSRF, and authentication issues",
-    "installCommand": "claude plugins add security-test-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install security-test-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "security"
@@ -7910,7 +7910,7 @@
     "slug": "sentiment-analysis-tool",
     "title": "Sentiment Analysis Tool",
     "description": "Sentiment analysis on text data",
-    "installCommand": "claude plugins add sentiment-analysis-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sentiment-analysis-tool@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -7930,7 +7930,7 @@
     "slug": "service-mesh-configurator",
     "title": "Service Mesh Configurator",
     "description": "Configure service mesh (Istio, Linkerd) for microservices",
-    "installCommand": "claude plugins add service-mesh-configurator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install service-mesh-configurator@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -7950,7 +7950,7 @@
     "slug": "session-security-checker",
     "title": "Session Security Checker",
     "description": "Check session security implementation",
-    "installCommand": "claude plugins add session-security-checker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install session-security-checker@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -7970,7 +7970,7 @@
     "slug": "jeremy-plugin-tool",
     "title": "Jeremy Plugin Tool",
     "description": "Production-grade plugin creator with nixtla-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
-    "installCommand": "claude plugins add jeremy-plugin-tool@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-plugin-tool@claude-code-plugins-plus-skills",
     "tags": [
       "examples",
       "agent"
@@ -7991,7 +7991,7 @@
     "slug": "sla-sli-tracker",
     "title": "Sla Sli Tracker",
     "description": "Track SLAs, SLIs, and SLOs for service reliability",
-    "installCommand": "claude plugins add sla-sli-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sla-sli-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -8011,7 +8011,7 @@
     "slug": "smoke-test-runner",
     "title": "Smoke Test Runner",
     "description": "Quick smoke test suites to verify critical functionality after deployments",
-    "installCommand": "claude plugins add smoke-test-runner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install smoke-test-runner@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "deployment"
@@ -8032,7 +8032,7 @@
     "slug": "snapshot-test-manager",
     "title": "Snapshot Test Manager",
     "description": "Manage and update snapshot tests with intelligent diff analysis and selective updates",
-    "installCommand": "claude plugins add snapshot-test-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install snapshot-test-manager@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8052,7 +8052,7 @@
     "slug": "soc2-audit-helper",
     "title": "Soc2 Audit Helper",
     "description": "Assist with SOC2 audit preparation",
-    "installCommand": "claude plugins add soc2-audit-helper@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install soc2-audit-helper@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -8072,7 +8072,7 @@
     "slug": "sow-generator",
     "title": "Sow Generator",
     "description": "Generate professional Statements of Work for AI projects",
-    "installCommand": "claude plugins add sow-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sow-generator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "ai"
@@ -8093,7 +8093,7 @@
     "slug": "sql-injection-detector",
     "title": "Sql Injection Detector",
     "description": "Detect SQL injection vulnerabilities",
-    "installCommand": "claude plugins add sql-injection-detector@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sql-injection-detector@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -8113,7 +8113,7 @@
     "slug": "sql-query-optimizer",
     "title": "Sql Query Optimizer",
     "description": "Analyze and optimize SQL queries for better performance, suggesting indexes, query rewrites, and execution plan improvements",
-    "installCommand": "claude plugins add sql-query-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sql-query-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "database",
       "performance"
@@ -8134,7 +8134,7 @@
     "slug": "ssl-certificate-manager",
     "title": "Ssl Certificate Manager",
     "description": "Manage and monitor SSL/TLS certificates",
-    "installCommand": "claude plugins add ssl-certificate-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ssl-certificate-manager@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -8154,7 +8154,7 @@
     "slug": "staking-rewards-optimizer",
     "title": "Staking Rewards Optimizer",
     "description": "Optimize staking rewards across multiple protocols and chains",
-    "installCommand": "claude plugins add staking-rewards-optimizer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install staking-rewards-optimizer@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -8175,7 +8175,7 @@
     "slug": "stored-procedure-generator",
     "title": "Stored Procedure Generator",
     "description": "Database plugin for stored-procedure-generator",
-    "installCommand": "claude plugins add stored-procedure-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install stored-procedure-generator@claude-code-plugins-plus-skills",
     "tags": [
       "database"
     ],
@@ -8195,7 +8195,7 @@
     "slug": "jeremy-firestore",
     "title": "Jeremy Firestore",
     "description": "Firestore database specialist for schema design, queries, and real-time sync",
-    "installCommand": "claude plugins add jeremy-firestore@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-firestore@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "rest"
@@ -8216,7 +8216,7 @@
     "slug": "sugar",
     "title": "Sugar",
     "description": "Transform Claude Code into an autonomous AI development powerhouse with rich task context, specialized agents, and intelligent workflow automation",
-    "installCommand": "claude plugins add sugar@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sugar@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "automation",
@@ -8239,7 +8239,7 @@
     "slug": "synthetic-monitoring-setup",
     "title": "Synthetic Monitoring Setup",
     "description": "Set up synthetic monitoring for proactive performance tracking",
-    "installCommand": "claude plugins add synthetic-monitoring-setup@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install synthetic-monitoring-setup@claude-code-plugins-plus-skills",
     "tags": [
       "performance",
       "monitoring"
@@ -8260,7 +8260,7 @@
     "slug": "terraform-module-builder",
     "title": "Terraform Module Builder",
     "description": "Build reusable Terraform modules",
-    "installCommand": "claude plugins add terraform-module-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install terraform-module-builder@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -8280,7 +8280,7 @@
     "slug": "test-coverage-analyzer",
     "title": "Test Coverage Analyzer",
     "description": "Analyze code coverage metrics, identify untested code, and generate comprehensive coverage reports",
-    "installCommand": "claude plugins add test-coverage-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-coverage-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "rag"
@@ -8301,7 +8301,7 @@
     "slug": "test-data-generator",
     "title": "Test Data Generator",
     "description": "Generate realistic test data including users, products, orders, and custom schemas for comprehensive testing",
-    "installCommand": "claude plugins add test-data-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-data-generator@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8321,7 +8321,7 @@
     "slug": "test-doubles-generator",
     "title": "Test Doubles Generator",
     "description": "Generate mocks, stubs, spies, and fakes for unit testing with Jest, Sinon, and test frameworks",
-    "installCommand": "claude plugins add test-doubles-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-doubles-generator@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8341,7 +8341,7 @@
     "slug": "test-environment-manager",
     "title": "Test Environment Manager",
     "description": "Manage test environments with Docker Compose, Testcontainers, and environment isolation",
-    "installCommand": "claude plugins add test-environment-manager@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-environment-manager@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "docker",
@@ -8363,7 +8363,7 @@
     "slug": "test-orchestrator",
     "title": "Test Orchestrator",
     "description": "Orchestrate complex test workflows with dependencies, parallel execution, and smart test selection",
-    "installCommand": "claude plugins add test-orchestrator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-orchestrator@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8383,7 +8383,7 @@
     "slug": "test-report-generator",
     "title": "Test Report Generator",
     "description": "Generate comprehensive test reports with coverage, trends, and stakeholder-friendly formats",
-    "installCommand": "claude plugins add test-report-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install test-report-generator@claude-code-plugins-plus-skills",
     "tags": [
       "testing",
       "rag"
@@ -8404,7 +8404,7 @@
     "slug": "throughput-analyzer",
     "title": "Throughput Analyzer",
     "description": "Analyze and optimize system throughput",
-    "installCommand": "claude plugins add throughput-analyzer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install throughput-analyzer@claude-code-plugins-plus-skills",
     "tags": [
       "performance"
     ],
@@ -8424,7 +8424,7 @@
     "slug": "time-series-forecaster",
     "title": "Time Series Forecaster",
     "description": "Time series forecasting and analysis",
-    "installCommand": "claude plugins add time-series-forecaster@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install time-series-forecaster@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -8444,7 +8444,7 @@
     "slug": "token-launch-tracker",
     "title": "Token Launch Tracker",
     "description": "Track new token launches, detect rugpulls, and analyze contract security for early-stage crypto projects",
-    "installCommand": "claude plugins add token-launch-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install token-launch-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "security"
@@ -8465,7 +8465,7 @@
     "slug": "trading-strategy-backtester",
     "title": "Trading Strategy Backtester",
     "description": "Backtest trading strategies with historical data, performance metrics, and risk analysis",
-    "installCommand": "claude plugins add trading-strategy-backtester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install trading-strategy-backtester@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "performance"
@@ -8486,7 +8486,7 @@
     "slug": "transfer-learning-adapter",
     "title": "Transfer Learning Adapter",
     "description": "Transfer learning adaptation",
-    "installCommand": "claude plugins add transfer-learning-adapter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install transfer-learning-adapter@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -8506,7 +8506,7 @@
     "slug": "travel-assistant",
     "title": "Travel Assistant",
     "description": "Intelligent travel assistant with real-time weather, currency conversion, timezone info, and AI-powered itinerary planning. Your complete travel companion.",
-    "installCommand": "claude plugins add travel-assistant@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install travel-assistant@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai"
@@ -8527,7 +8527,7 @@
     "slug": "unit-test-generator",
     "title": "Unit Test Generator",
     "description": "Automatically generate comprehensive unit tests from source code with multiple testing framework support",
-    "installCommand": "claude plugins add unit-test-generator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install unit-test-generator@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8547,7 +8547,7 @@
     "slug": "visual-regression-tester",
     "title": "Visual Regression Tester",
     "description": "Visual diff testing with Percy, Chromatic, BackstopJS - catch unintended UI changes",
-    "installCommand": "claude plugins add visual-regression-tester@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install visual-regression-tester@claude-code-plugins-plus-skills",
     "tags": [
       "testing"
     ],
@@ -8567,7 +8567,7 @@
     "slug": "vulnerability-scanner",
     "title": "Vulnerability Scanner",
     "description": "Comprehensive vulnerability scanning for code, dependencies, and configurations with CVE detection",
-    "installCommand": "claude plugins add vulnerability-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install vulnerability-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -8587,7 +8587,7 @@
     "slug": "wallet-portfolio-tracker",
     "title": "Wallet Portfolio Tracker",
     "description": "Track crypto wallets across multiple chains with portfolio analytics and transaction history",
-    "installCommand": "claude plugins add wallet-portfolio-tracker@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wallet-portfolio-tracker@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "ai"
@@ -8608,7 +8608,7 @@
     "slug": "web-to-github-issue",
     "title": "Web To Github Issue",
     "description": "Enhances web_search Skill by automatically creating GitHub issues from research findings. Research topics, extract key insights, and generate formatted tickets in seconds.",
-    "installCommand": "claude plugins add web-to-github-issue@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install web-to-github-issue@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers",
       "github"
@@ -8629,7 +8629,7 @@
     "slug": "webhook-handler-creator",
     "title": "Webhook Handler Creator",
     "description": "Create secure webhook endpoints with signature verification and retry logic",
-    "installCommand": "claude plugins add webhook-handler-creator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install webhook-handler-creator@claude-code-plugins-plus-skills",
     "tags": [
       "api-development"
     ],
@@ -8649,7 +8649,7 @@
     "slug": "websocket-server-builder",
     "title": "Websocket Server Builder",
     "description": "Build WebSocket servers for real-time bidirectional communication",
-    "installCommand": "claude plugins add websocket-server-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install websocket-server-builder@claude-code-plugins-plus-skills",
     "tags": [
       "api-development"
     ],
@@ -8669,7 +8669,7 @@
     "slug": "whale-alert-monitor",
     "title": "Whale Alert Monitor",
     "description": "Monitor large crypto transactions and whale wallet movements in real-time",
-    "installCommand": "claude plugins add whale-alert-monitor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install whale-alert-monitor@claude-code-plugins-plus-skills",
     "tags": [
       "crypto"
     ],
@@ -8689,7 +8689,7 @@
     "slug": "workflow-orchestrator",
     "title": "Workflow Orchestrator",
     "description": "DAG-based workflow automation with parallel task execution and dependency management",
-    "installCommand": "claude plugins add workflow-orchestrator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install workflow-orchestrator@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "automation"
@@ -8710,7 +8710,7 @@
     "slug": "xss-vulnerability-scanner",
     "title": "Xss Vulnerability Scanner",
     "description": "Scan for XSS vulnerabilities",
-    "installCommand": "claude plugins add xss-vulnerability-scanner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install xss-vulnerability-scanner@claude-code-plugins-plus-skills",
     "tags": [
       "security"
     ],
@@ -8730,7 +8730,7 @@
     "slug": "zapier-zap-builder",
     "title": "Zapier Zap Builder",
     "description": "Create multi-step Zapier Zaps with filters, paths, and formatters",
-    "installCommand": "claude plugins add zapier-zap-builder@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install zapier-zap-builder@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "api"
@@ -8751,7 +8751,7 @@
     "slug": "jeremy-genkit-pro",
     "title": "Jeremy Genkit Pro",
     "description": "Firebase Genkit expert for production-ready AI workflows with RAG and tool calling",
-    "installCommand": "claude plugins add jeremy-genkit-pro@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-genkit-pro@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "ai",
@@ -8773,7 +8773,7 @@
     "slug": "jeremy-adk-orchestrator",
     "title": "Jeremy Adk Orchestrator",
     "description": "Production ADK orchestrator for A2A protocol and multi-agent coordination on Vertex AI",
-    "installCommand": "claude plugins add jeremy-adk-orchestrator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-adk-orchestrator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "ai",
@@ -8795,7 +8795,7 @@
     "slug": "jeremy-vertex-validator",
     "title": "Jeremy Vertex Validator",
     "description": "Production readiness validator for Vertex AI deployments and configurations",
-    "installCommand": "claude plugins add jeremy-vertex-validator@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-vertex-validator@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "deployment",
@@ -8816,8 +8816,8 @@
   {
     "slug": "jeremy-google-adk",
     "title": "Jeremy Google Adk",
-    "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
-    "installCommand": "claude plugins add jeremy-google-adk@claude-code-plugins-plus-skills",
+    "description": "Google Agent Development Kit (ADK) starter for building production AI agents \u2014 ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-google-adk@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "go",
@@ -8842,7 +8842,7 @@
     "slug": "jeremy-vertex-ai",
     "title": "Jeremy Vertex Ai",
     "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
-    "installCommand": "claude plugins add jeremy-vertex-ai@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-vertex-ai@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "deployment",
@@ -8866,7 +8866,7 @@
     "slug": "jeremy-genkit-terraform",
     "title": "Jeremy Genkit Terraform",
     "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
-    "installCommand": "claude plugins add jeremy-genkit-terraform@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-genkit-terraform@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "deployment"
@@ -8887,7 +8887,7 @@
     "slug": "jeremy-adk-terraform",
     "title": "Jeremy Adk Terraform",
     "description": "Terraform infrastructure as code for ADK and Vertex AI Agent Engine deployments",
-    "installCommand": "claude plugins add jeremy-adk-terraform@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-adk-terraform@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "deployment",
@@ -8910,7 +8910,7 @@
     "slug": "jeremy-vertex-terraform",
     "title": "Jeremy Vertex Terraform",
     "description": "Terraform configurations for Vertex AI platform and Agent Engine",
-    "installCommand": "claude plugins add jeremy-vertex-terraform@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-vertex-terraform@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "ai",
@@ -8932,7 +8932,7 @@
     "slug": "jeremy-vertex-engine",
     "title": "Jeremy Vertex Engine",
     "description": "Vertex AI Agent Engine deployment inspector and runtime validator",
-    "installCommand": "claude plugins add jeremy-vertex-engine@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-vertex-engine@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "deployment",
@@ -8955,7 +8955,7 @@
     "slug": "jeremy-gcp-starter-examples",
     "title": "Jeremy Gcp Starter Examples",
     "description": "Google Cloud starter kits and example code aggregator with ADK samples",
-    "installCommand": "claude plugins add jeremy-gcp-starter-examples@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-gcp-starter-examples@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "go",
@@ -8977,7 +8977,7 @@
     "slug": "jeremy-github-actions-gcp",
     "title": "Jeremy Github Actions Gcp",
     "description": "GitHub Actions CI/CD workflows for Google Cloud and Vertex AI deployments",
-    "installCommand": "claude plugins add jeremy-github-actions-gcp@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-github-actions-gcp@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "go",
@@ -9002,7 +9002,7 @@
     "slug": "prettier-markdown-hook",
     "title": "Prettier Markdown Hook",
     "description": "Automatically format markdown files with prettier when Claude stops responding, with configurable organization and path exclusions",
-    "installCommand": "claude plugins add prettier-markdown-hook@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install prettier-markdown-hook@claude-code-plugins-plus-skills",
     "tags": [
       "productivity"
     ],
@@ -9022,7 +9022,7 @@
     "slug": "axiom",
     "title": "Axiom",
     "description": "Battle-tested Claude Code skills for modern xOS (iOS, iPadOS, watchOS, tvOS) development - 13 production-ready skills covering debugging, concurrency, persistence, UI, and performance",
-    "installCommand": "claude plugins add axiom@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install axiom@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers",
       "performance"
@@ -9043,7 +9043,7 @@
     "slug": "claude-never-forgets",
     "title": "Claude Never Forgets",
     "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-    "installCommand": "claude plugins add claude-never-forgets@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install claude-never-forgets@claude-code-plugins-plus-skills",
     "tags": [
       "community"
     ],
@@ -9063,7 +9063,7 @@
     "slug": "geepers-agents",
     "title": "Geepers Agents",
     "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, games, and more. Includes orchestrators for checkpoint, deploy, quality, fullstack, research, games, corpus, web, and python workflows.",
-    "installCommand": "claude plugins add geepers-agents@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install geepers-agents@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "python",
@@ -9086,7 +9086,7 @@
     "slug": "sprint",
     "title": "Sprint",
     "description": "Autonomous multi-agent development framework with spec-driven sprints. Write specs, run /sprint, and let coordinated agents (backend, frontend, QA, UI testing) handle implementation through self-iterating convergent loops.",
-    "installCommand": "claude plugins add sprint@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sprint@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "testing",
@@ -9108,7 +9108,7 @@
     "slug": "vibe-guide",
     "title": "Vibe Guide",
     "description": "Non-technical progress summaries for Claude Code work (hides diffs/log noise).",
-    "installCommand": "claude plugins add vibe-guide@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install vibe-guide@claude-code-plugins-plus-skills",
     "tags": [
       "productivity"
     ],
@@ -9128,7 +9128,7 @@
     "slug": "jeremy-adk-software-engineer",
     "title": "Jeremy Adk Software Engineer",
     "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
-    "installCommand": "claude plugins add jeremy-adk-software-engineer@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-adk-software-engineer@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml",
       "deployment",
@@ -9151,7 +9151,7 @@
     "slug": "geepers",
     "title": "Geepers",
     "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
-    "installCommand": "claude plugins add geepers@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install geepers@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "deployment",
@@ -9173,7 +9173,7 @@
     "slug": "jeremy-firebase",
     "title": "Jeremy Firebase",
     "description": "Firebase platform expert for Firestore, Auth, Functions, and Vertex AI integration",
-    "installCommand": "claude plugins add jeremy-firebase@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install jeremy-firebase@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "rest",
@@ -9195,7 +9195,7 @@
     "slug": "wallet-security-auditor",
     "title": "Wallet Security Auditor",
     "description": "Crypto wallet security auditor for reviewing wallet implementations, key management, signing flows, and common vulnerability patterns.",
-    "installCommand": "claude plugins add wallet-security-auditor@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wallet-security-auditor@claude-code-plugins-plus-skills",
     "tags": [
       "crypto",
       "security"
@@ -9216,7 +9216,7 @@
     "slug": "mattyp-changelog",
     "title": "Mattyp Changelog",
     "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-    "installCommand": "claude plugins add mattyp-changelog@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mattyp-changelog@claude-code-plugins-plus-skills",
     "tags": [
       "devops"
     ],
@@ -9236,7 +9236,7 @@
     "slug": "supabase-pack",
     "title": "Supabase Pack",
     "description": "Complete Supabase integration skill pack with 30 skills covering authentication, database, storage, realtime, edge functions, and production operations. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add supabase-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install supabase-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "rag"
@@ -9257,7 +9257,7 @@
     "slug": "vercel-pack",
     "title": "Vercel Pack",
     "description": "Complete Vercel integration skill pack with 30 skills covering deployments, edge functions, preview environments, performance optimization, and production operations. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add vercel-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install vercel-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "vercel",
@@ -9280,7 +9280,7 @@
     "slug": "clay-pack",
     "title": "Clay Pack",
     "description": "Complete Clay integration skill pack with 30 skills covering data enrichment, waterfall workflows, AI agents, and GTM automation. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add clay-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clay-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9303,7 +9303,7 @@
     "slug": "cursor-pack",
     "title": "Cursor Pack",
     "description": "Complete Cursor integration skill pack with 30 skills covering AI code editing, composer workflows, codebase indexing, and productivity features. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add cursor-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cursor-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9324,7 +9324,7 @@
     "slug": "exa-pack",
     "title": "Exa Pack",
     "description": "Complete Exa integration skill pack with 30 skills covering neural search, semantic retrieval, web search API, and AI-powered discovery. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add exa-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install exa-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "api",
@@ -9346,7 +9346,7 @@
     "slug": "firecrawl-pack",
     "title": "Firecrawl Pack",
     "description": "Complete Firecrawl integration skill pack with 30 skills covering web scraping, crawling, markdown conversion, and LLM-ready data extraction. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add firecrawl-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install firecrawl-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "scraping",
@@ -9369,7 +9369,7 @@
     "slug": "klingai-pack",
     "title": "Klingai Pack",
     "description": "Complete Kling AI integration skill pack with 30 skills covering AI video generation, text-to-video, image-to-video, and creative workflows. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add klingai-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install klingai-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9390,7 +9390,7 @@
     "slug": "openrouter-pack",
     "title": "Openrouter Pack",
     "description": "Complete OpenRouter integration skill pack with 30 skills covering LLM routing, model selection, cost optimization, and multi-provider orchestration. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add openrouter-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install openrouter-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "llm"
@@ -9411,7 +9411,7 @@
     "slug": "perplexity-pack",
     "title": "Perplexity Pack",
     "description": "Complete Perplexity integration skill pack with 30 skills covering AI search, real-time answers, citations, and research workflows. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add perplexity-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install perplexity-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9432,7 +9432,7 @@
     "slug": "replit-pack",
     "title": "Replit Pack",
     "description": "Complete Replit integration skill pack with 30 skills covering cloud IDE, deployments, AI assistance, and collaborative coding. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add replit-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install replit-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "deployment",
@@ -9454,7 +9454,7 @@
     "slug": "retellai-pack",
     "title": "Retellai Pack",
     "description": "Complete Retell AI integration skill pack with 30 skills covering AI voice agents, phone automation, conversational AI, and call center solutions. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add retellai-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install retellai-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9477,7 +9477,7 @@
     "slug": "sentry-pack",
     "title": "Sentry Pack",
     "description": "Complete Sentry integration skill pack with 30 skills covering error monitoring, performance tracking, session replay, and observability. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add sentry-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install sentry-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "performance",
@@ -9499,7 +9499,7 @@
     "slug": "windsurf-pack",
     "title": "Windsurf Pack",
     "description": "Complete Windsurf integration skill pack with 30 skills covering AI code editing, Cascade workflows, codebase understanding, and developer productivity. Flagship+ tier vendor pack.",
-    "installCommand": "claude plugins add windsurf-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install windsurf-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9520,7 +9520,7 @@
     "slug": "coderabbit-pack",
     "title": "Coderabbit Pack",
     "description": "Complete CodeRabbit integration skill pack with 24 skills covering AI code review, PR automation, and code quality analysis. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add coderabbit-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install coderabbit-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9542,7 +9542,7 @@
     "slug": "fireflies-pack",
     "title": "Fireflies Pack",
     "description": "Complete Fireflies integration skill pack with 24 skills covering meeting transcription, AI summaries, and conversation intelligence. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add fireflies-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fireflies-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9563,7 +9563,7 @@
     "slug": "groq-pack",
     "title": "Groq Pack",
     "description": "Complete Groq integration skill pack with 24 skills covering LPU inference, ultra-fast AI, and Groq Cloud deployment. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add groq-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install groq-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "deployment",
@@ -9585,7 +9585,7 @@
     "slug": "ideogram-pack",
     "title": "Ideogram Pack",
     "description": "Complete Ideogram integration skill pack with 24 skills covering AI image generation, text rendering, and creative design workflows. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add ideogram-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ideogram-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9606,7 +9606,7 @@
     "slug": "instantly-pack",
     "title": "Instantly Pack",
     "description": "Complete Instantly integration skill pack with 24 skills covering cold email, outreach automation, and lead generation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add instantly-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install instantly-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9628,7 +9628,7 @@
     "slug": "posthog-pack",
     "title": "Posthog Pack",
     "description": "Complete PostHog integration skill pack with 24 skills covering product analytics, feature flags, session replay, and experimentation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add posthog-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install posthog-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -9648,7 +9648,7 @@
     "slug": "vastai-pack",
     "title": "Vastai Pack",
     "description": "Complete Vast.ai integration skill pack with 24 skills covering GPU marketplace, cloud compute, and ML infrastructure. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add vastai-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install vastai-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9669,7 +9669,7 @@
     "slug": "apollo-pack",
     "title": "Apollo Pack",
     "description": "Complete Apollo integration skill pack with 24 skills covering sales engagement, prospecting, sequencing, analytics, and outbound automation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add apollo-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install apollo-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation"
@@ -9690,7 +9690,7 @@
     "slug": "deepgram-pack",
     "title": "Deepgram Pack",
     "description": "Complete Deepgram integration skill pack with 24 skills covering speech-to-text, real-time transcription, voice intelligence, and audio processing. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add deepgram-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install deepgram-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -9710,7 +9710,7 @@
     "slug": "juicebox-pack",
     "title": "Juicebox Pack",
     "description": "Complete Juicebox integration skill pack with 24 skills covering people data, enrichment, contact search, and AI-powered discovery. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add juicebox-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install juicebox-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9731,7 +9731,7 @@
     "slug": "customerio-pack",
     "title": "Customerio Pack",
     "description": "Complete Customer.io integration skill pack with 24 skills covering marketing automation, email campaigns, SMS, push notifications, and customer journeys. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add customerio-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install customerio-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9752,8 +9752,8 @@
   {
     "slug": "langchain-pack",
     "title": "Langchain Pack",
-    "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated — use langchain-py-pack or langchain-ts-pack.",
-    "installCommand": "claude plugins add langchain-pack@claude-code-plugins-plus-skills",
+    "description": "Legacy LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Deprecated \u2014 use langchain-py-pack or langchain-ts-pack.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install langchain-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai",
@@ -9776,8 +9776,8 @@
   {
     "slug": "langchain-py-pack",
     "title": "Langchain Py Pack",
-    "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 sk…",
-    "installCommand": "claude plugins add langchain-py-pack@claude-code-plugins-plus-skills",
+    "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 sk\u2026",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install langchain-py-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "python",
@@ -9800,7 +9800,7 @@
     "slug": "lindy-pack",
     "title": "Lindy Pack",
     "description": "Complete Lindy integration skill pack with 24 skills covering AI assistants, task automation, workflows, and intelligent automation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add lindy-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install lindy-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -9822,7 +9822,7 @@
     "slug": "granola-pack",
     "title": "Granola Pack",
     "description": "Complete Granola integration skill pack with 24 skills covering AI meeting notes, transcription, summaries, and meeting intelligence. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add granola-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install granola-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9843,7 +9843,7 @@
     "slug": "gamma-pack",
     "title": "Gamma Pack",
     "description": "Complete Gamma integration skill pack with 24 skills covering AI presentations, document generation, templates, and visual content creation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add gamma-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gamma-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -9864,7 +9864,7 @@
     "slug": "clerk-pack",
     "title": "Clerk Pack",
     "description": "Complete Clerk integration skill pack with 24 skills covering authentication, user management, embeddable UIs, and identity platform. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add clerk-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clerk-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -9884,7 +9884,7 @@
     "slug": "linear-pack",
     "title": "Linear Pack",
     "description": "Complete Linear integration skill pack with 24 skills covering issue tracking, project management, workflows, and team collaboration. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add linear-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install linear-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "linear"
@@ -9905,7 +9905,7 @@
     "slug": "databricks-pack",
     "title": "Databricks Pack",
     "description": "Complete Databricks integration skill pack with 24 skills covering Delta Lake, MLflow, notebooks, clusters, and data engineering workflows. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add databricks-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install databricks-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -9925,7 +9925,7 @@
     "slug": "mistral-pack",
     "title": "Mistral Pack",
     "description": "Complete Mistral AI integration skill pack with 24 skills covering model inference, embeddings, fine-tuning, and production deployments. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add mistral-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mistral-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "deployment",
@@ -9948,7 +9948,7 @@
     "slug": "langfuse-pack",
     "title": "Langfuse Pack",
     "description": "Complete Langfuse integration skill pack with 24 skills covering LLM observability, tracing, prompt management, and evaluation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add langfuse-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install langfuse-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "llm"
@@ -9969,7 +9969,7 @@
     "slug": "obsidian-pack",
     "title": "Obsidian Pack",
     "description": "Complete Obsidian integration skill pack with 24 skills covering vault management, plugins, sync, templates, and knowledge management. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add obsidian-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install obsidian-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -9989,7 +9989,7 @@
     "slug": "documenso-pack",
     "title": "Documenso Pack",
     "description": "Complete Documenso integration skill pack with 24 skills covering document signing, templates, workflows, and e-signature automation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add documenso-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install documenso-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation"
@@ -10010,7 +10010,7 @@
     "slug": "evernote-pack",
     "title": "Evernote Pack",
     "description": "Complete Evernote integration skill pack with 24 skills covering note management, notebooks, tags, search, and productivity workflows. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add evernote-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install evernote-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10030,7 +10030,7 @@
     "slug": "guidewire-pack",
     "title": "Guidewire Pack",
     "description": "Complete Guidewire integration skill pack with 24 skills covering InsuranceSuite, PolicyCenter, ClaimCenter, and insurance platform development. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add guidewire-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install guidewire-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -10051,7 +10051,7 @@
     "slug": "lokalise-pack",
     "title": "Lokalise Pack",
     "description": "Complete Lokalise integration skill pack with 24 skills covering translation management, localization workflows, and i18n automation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add lokalise-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install lokalise-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation"
@@ -10072,7 +10072,7 @@
     "slug": "maintainx-pack",
     "title": "Maintainx Pack",
     "description": "Complete MaintainX integration skill pack with 24 skills covering work orders, preventive maintenance, asset management, and CMMS workflows. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add maintainx-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install maintainx-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -10093,7 +10093,7 @@
     "slug": "openevidence-pack",
     "title": "Openevidence Pack",
     "description": "Complete OpenEvidence integration skill pack with 24 skills covering medical AI, clinical decision support, evidence-based queries, and healthcare workflows. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add openevidence-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install openevidence-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -10114,7 +10114,7 @@
     "slug": "speak-pack",
     "title": "Speak Pack",
     "description": "Complete Speak integration skill pack with 24 skills covering AI language learning, speech recognition, conversation practice, and education technology. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add speak-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install speak-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -10135,7 +10135,7 @@
     "slug": "twinmind-pack",
     "title": "Twinmind Pack",
     "description": "Complete TwinMind integration skill pack with 24 skills covering AI meeting assistant, transcription, summaries, and productivity automation. Flagship tier vendor pack.",
-    "installCommand": "claude plugins add twinmind-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install twinmind-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "automation",
@@ -10157,7 +10157,7 @@
     "slug": "gastown",
     "title": "Gastown",
     "description": "Multi-agent orchestrator for Claude Code. Track work with convoys, sling to polecats. The Cognition Engine for AI-powered software factories.",
-    "installCommand": "claude plugins add gastown@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gastown@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "ai",
@@ -10179,7 +10179,7 @@
     "slug": "zai-cli",
     "title": "Zai Cli",
     "description": "Z.AI vision, search, reader, and GitHub exploration via CLI and MCP. Analyze images, search the web, read pages as markdown, explore repos.",
-    "installCommand": "claude plugins add zai-cli@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install zai-cli@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "github",
@@ -10201,7 +10201,7 @@
     "slug": "claude-reflect",
     "title": "Claude Reflect",
     "description": "Self-learning system for Claude Code that captures corrections and updates CLAUDE.md automatically",
-    "installCommand": "claude plugins add claude-reflect@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install claude-reflect@claude-code-plugins-plus-skills",
     "tags": [
       "community"
     ],
@@ -10221,7 +10221,7 @@
     "slug": "neurodivergent-visual-org",
     "title": "Neurodivergent Visual Org",
     "description": "Create ADHD-friendly visual organizational tools (Mermaid diagrams) optimized for neurodivergent thinking patterns with accessibility modes",
-    "installCommand": "claude plugins add neurodivergent-visual-org@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install neurodivergent-visual-org@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai"
@@ -10242,7 +10242,7 @@
     "slug": "gh-dash",
     "title": "Gh Dash",
     "description": "GitHub PR dashboard for Claude Code. View PR status, CI/CD progress, bot comments, and merge PRs directly from your terminal.",
-    "installCommand": "claude plugins add gh-dash@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install gh-dash@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "github"
@@ -10263,7 +10263,7 @@
     "slug": "youtube-strategy",
     "title": "Youtube Strategy",
     "description": "Complete YouTube content production workflow: research competitors, generate video ideas, build briefs, craft titles and thumbnails, and create detailed video outlines with demo prep checklists.",
-    "installCommand": "claude plugins add youtube-strategy@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install youtube-strategy@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai"
@@ -10283,8 +10283,8 @@
   {
     "slug": "b12-claude-plugin",
     "title": "B12 Claude Plugin",
-    "description": "B12 Website Generator — an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
-    "installCommand": "claude plugins add b12-claude-plugin@claude-code-plugins-plus-skills",
+    "description": "B12 Website Generator \u2014 an official plugin by B12.io. Ships a single auto-activating skill (website-generator) that collects a business name and description, then generates a production-ready B12 website signup link instantly.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install b12-claude-plugin@claude-code-plugins-plus-skills",
     "tags": [
       "community"
     ],
@@ -10304,7 +10304,7 @@
     "slug": "wondelai-blue-ocean-strategy",
     "title": "Wondelai Blue Ocean Strategy",
     "description": "Blue Ocean Strategy framework for creating uncontested market space. Use the Strategy Canvas, Four Actions Framework (ERRC), and value innovation to break the value-cost trade-off.",
-    "installCommand": "claude plugins add wondelai-blue-ocean-strategy@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-blue-ocean-strategy@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10325,7 +10325,7 @@
     "slug": "wondelai-contagious",
     "title": "Wondelai Contagious",
     "description": "Word-of-mouth and virality framework using the STEPPS model (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Engineer products and content that people naturally share.",
-    "installCommand": "claude plugins add wondelai-contagious@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-contagious@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10346,7 +10346,7 @@
     "slug": "wondelai-cro-methodology",
     "title": "Wondelai Cro Methodology",
     "description": "Customer-centric conversion rate optimization methodology. Audit landing pages, identify conversion blockers, write persuasive copy, design A/B tests, and optimize funnels.",
-    "installCommand": "claude plugins add wondelai-cro-methodology@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-cro-methodology@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10367,7 +10367,7 @@
     "slug": "wondelai-crossing-the-chasm",
     "title": "Wondelai Crossing The Chasm",
     "description": "Technology adoption and go-to-market strategy for crossing from early adopters to mainstream market. Choose beachhead segments, build whole products, and position against incumbents.",
-    "installCommand": "claude plugins add wondelai-crossing-the-chasm@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-crossing-the-chasm@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "go",
@@ -10389,7 +10389,7 @@
     "slug": "wondelai-design-everyday-things",
     "title": "Wondelai Design Everyday Things",
     "description": "Fundamental design principles from Don Norman. Design affordances, signifiers, constraints, and feedback mechanisms. Apply human-centered design and fault-tolerant systems.",
-    "installCommand": "claude plugins add wondelai-design-everyday-things@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-design-everyday-things@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10410,7 +10410,7 @@
     "slug": "wondelai-design-sprint",
     "title": "Wondelai Design Sprint",
     "description": "Google Ventures Design Sprint methodology. Validate product ideas in 5 days with rapid prototyping, user testing, and structured decision-making.",
-    "installCommand": "claude plugins add wondelai-design-sprint@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-design-sprint@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "go",
@@ -10434,7 +10434,7 @@
     "slug": "wondelai-drive-motivation",
     "title": "Wondelai Drive Motivation",
     "description": "Intrinsic motivation science framework (Autonomy, Mastery, Purpose). Design features that leverage intrinsic motivation, create progress systems, and craft purpose-driven messaging.",
-    "installCommand": "claude plugins add wondelai-drive-motivation@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-drive-motivation@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai",
@@ -10456,7 +10456,7 @@
     "slug": "wondelai-hooked-ux",
     "title": "Wondelai Hooked Ux",
     "description": "Hook Model framework for building habit-forming products. Design trigger-action-reward-investment loops, increase retention, and optimize onboarding for habit formation.",
-    "installCommand": "claude plugins add wondelai-hooked-ux@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-hooked-ux@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10477,7 +10477,7 @@
     "slug": "wondelai-hundred-million-offers",
     "title": "Wondelai Hundred Million Offers",
     "description": "Grand Slam Offer creation framework. Create irresistible offers using the Value Equation, stack bonuses, design risk-reversing guarantees, and apply ethical scarcity.",
-    "installCommand": "claude plugins add wondelai-hundred-million-offers@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-hundred-million-offers@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10498,7 +10498,7 @@
     "slug": "wondelai-influence-psychology",
     "title": "Wondelai Influence Psychology",
     "description": "Persuasion science framework based on Cialdini's six principles (Reciprocity, Commitment, Social Proof, Authority, Liking, Scarcity). Apply ethical persuasion to product design and marketing.",
-    "installCommand": "claude plugins add wondelai-influence-psychology@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-influence-psychology@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10519,7 +10519,7 @@
     "slug": "wondelai-ios-hig-design",
     "title": "Wondelai Ios Hig Design",
     "description": "Native iOS app design following Apple Human Interface Guidelines. Design SwiftUI/UIKit components, implement navigation patterns, and ensure accessibility compliance.",
-    "installCommand": "claude plugins add wondelai-ios-hig-design@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-ios-hig-design@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "swift",
@@ -10541,7 +10541,7 @@
     "slug": "wondelai-jobs-to-be-done",
     "title": "Wondelai Jobs To Be Done",
     "description": "Strategic product innovation framework using Clayton Christensen's JTBD theory. Discover customer motivations, conduct discovery interviews, and design products around the jobs customers hire them for.",
-    "installCommand": "claude plugins add wondelai-jobs-to-be-done@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-jobs-to-be-done@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10562,7 +10562,7 @@
     "slug": "wondelai-lean-startup",
     "title": "Wondelai Lean Startup",
     "description": "Lean Startup methodology for validated learning, MVPs, and innovation accounting. Design experiments, decide when to pivot vs. persevere, and reduce development waste.",
-    "installCommand": "claude plugins add wondelai-lean-startup@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-lean-startup@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai"
@@ -10583,7 +10583,7 @@
     "slug": "navigating-github",
     "title": "Navigating Github",
     "description": "First-time GitHub setup and interactive git learning. Walks users from zero to a working GitHub repo, then teaches git through 9 hands-on lessons on their actual project. Adapts to any skill level automatically.",
-    "installCommand": "claude plugins add navigating-github@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install navigating-github@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "github"
@@ -10604,7 +10604,7 @@
     "slug": "wondelai-made-to-stick",
     "title": "Wondelai Made To Stick",
     "description": "Sticky messaging framework using the SUCCESs model (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Make product messaging memorable and create compelling presentations.",
-    "installCommand": "claude plugins add wondelai-made-to-stick@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-made-to-stick@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10625,7 +10625,7 @@
     "slug": "wondelai-negotiation",
     "title": "Wondelai Negotiation",
     "description": "Tactical negotiation framework based on Chris Voss's techniques. Use mirroring, labeling, calibrated questions, the Ackerman method, and accusation audits for business and salary negotiations.",
-    "installCommand": "claude plugins add wondelai-negotiation@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-negotiation@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "go",
@@ -10647,7 +10647,7 @@
     "slug": "wondelai-obviously-awesome",
     "title": "Wondelai Obviously Awesome",
     "description": "Product positioning framework for competitive differentiation. Define competitive alternatives, identify unique attributes, map value themes, and choose the right market category.",
-    "installCommand": "claude plugins add wondelai-obviously-awesome@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-obviously-awesome@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "go",
@@ -10669,7 +10669,7 @@
     "slug": "wondelai-one-page-marketing",
     "title": "Wondelai One Page Marketing",
     "description": "End-to-end marketing plan framework. Define target market, craft USP, choose channels, design lead capture and nurture sequences, optimize conversion, and build referral systems.",
-    "installCommand": "claude plugins add wondelai-one-page-marketing@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-one-page-marketing@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10690,7 +10690,7 @@
     "slug": "wondelai-predictable-revenue",
     "title": "Wondelai Predictable Revenue",
     "description": "Outbound sales methodology for scalable B2B pipeline. Implement Cold Calling 2.0, structure SDR/AE/CSM roles, design prospecting sequences, and build predictable revenue engines.",
-    "installCommand": "claude plugins add wondelai-predictable-revenue@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-predictable-revenue@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10711,7 +10711,7 @@
     "slug": "wondelai-refactoring-ui",
     "title": "Wondelai Refactoring Ui",
     "description": "Practical UI design system for professional interfaces. Fix visual hierarchy, choose typography and color scales, add depth with shadows, and style components in Tailwind CSS.",
-    "installCommand": "claude plugins add wondelai-refactoring-ui@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-refactoring-ui@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10732,7 +10732,7 @@
     "slug": "wondelai-scorecard-marketing",
     "title": "Wondelai Scorecard Marketing",
     "description": "Lead generation framework using quiz and assessment funnels. Create lead magnets that convert 30-50%, design qualifying questions, and segment automated follow-up sequences.",
-    "installCommand": "claude plugins add wondelai-scorecard-marketing@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-scorecard-marketing@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10753,7 +10753,7 @@
     "slug": "wondelai-storybrand-messaging",
     "title": "Wondelai Storybrand Messaging",
     "description": "StoryBrand messaging framework that positions customer as hero. Create brand scripts, write website copy that converts, craft one-liners, and build narrative-driven landing pages.",
-    "installCommand": "claude plugins add wondelai-storybrand-messaging@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-storybrand-messaging@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10774,7 +10774,7 @@
     "slug": "wondelai-top-design",
     "title": "Wondelai Top Design",
     "description": "Award-winning web design framework for premium brand experiences. Build immersive websites with custom animations, dramatic typography, and scroll-based compositions.",
-    "installCommand": "claude plugins add wondelai-top-design@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-top-design@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10795,7 +10795,7 @@
     "slug": "wondelai-traction-eos",
     "title": "Wondelai Traction Eos",
     "description": "Entrepreneurial Operating System (EOS) for business execution. Create V/TO, set quarterly rocks, run Level 10 meetings, build accountability charts, and solve issues with IDS.",
-    "installCommand": "claude plugins add wondelai-traction-eos@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-traction-eos@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -10816,7 +10816,7 @@
     "slug": "wondelai-ux-heuristics",
     "title": "Wondelai Ux Heuristics",
     "description": "Usability heuristics and UX audit framework based on Nielsen and Krug. Conduct heuristic evaluations, identify usability problems, and prioritize fixes by severity.",
-    "installCommand": "claude plugins add wondelai-ux-heuristics@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-ux-heuristics@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10837,7 +10837,7 @@
     "slug": "wondelai-web-typography",
     "title": "Wondelai Web Typography",
     "description": "Web typography framework for readable, beautiful type. Select and pair typefaces, set optimal line length and height, implement responsive typography, and optimize web font loading.",
-    "installCommand": "claude plugins add wondelai-web-typography@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wondelai-web-typography@claude-code-plugins-plus-skills",
     "tags": [
       "design",
       "ai"
@@ -10858,7 +10858,7 @@
     "slug": "abridge-pack",
     "title": "Abridge Pack",
     "description": "Claude Code skill pack for Abridge (18 skills)",
-    "installCommand": "claude plugins add abridge-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install abridge-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10878,7 +10878,7 @@
     "slug": "adobe-pack",
     "title": "Adobe Pack",
     "description": "Claude Code skill pack for Adobe (30 skills)",
-    "installCommand": "claude plugins add adobe-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install adobe-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10898,7 +10898,7 @@
     "slug": "alchemy-pack",
     "title": "Alchemy Pack",
     "description": "Claude Code skill pack for Alchemy (18 skills)",
-    "installCommand": "claude plugins add alchemy-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install alchemy-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10918,7 +10918,7 @@
     "slug": "algolia-pack",
     "title": "Algolia Pack",
     "description": "Claude Code skill pack for Algolia (24 skills)",
-    "installCommand": "claude plugins add algolia-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install algolia-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "go"
@@ -10939,7 +10939,7 @@
     "slug": "anima-pack",
     "title": "Anima Pack",
     "description": "Claude Code skill pack for Anima (18 skills)",
-    "installCommand": "claude plugins add anima-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install anima-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10959,7 +10959,7 @@
     "slug": "anthropic-pack",
     "title": "Anthropic Pack",
     "description": "Claude Code skill pack for Anthropic (30 skills)",
-    "installCommand": "claude plugins add anthropic-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install anthropic-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -10979,7 +10979,7 @@
     "slug": "apify-pack",
     "title": "Apify Pack",
     "description": "Claude Code skill pack for Apify (18 skills)",
-    "installCommand": "claude plugins add apify-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install apify-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "api"
@@ -11000,7 +11000,7 @@
     "slug": "appfolio-pack",
     "title": "Appfolio Pack",
     "description": "Claude Code skill pack for AppFolio (18 skills)",
-    "installCommand": "claude plugins add appfolio-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install appfolio-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11020,7 +11020,7 @@
     "slug": "apple-notes-pack",
     "title": "Apple Notes Pack",
     "description": "Claude Code skill pack for Apple Notes (24 skills)",
-    "installCommand": "claude plugins add apple-notes-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install apple-notes-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11040,7 +11040,7 @@
     "slug": "assemblyai-pack",
     "title": "Assemblyai Pack",
     "description": "Claude Code skill pack for AssemblyAI (18 skills)",
-    "installCommand": "claude plugins add assemblyai-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install assemblyai-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -11061,7 +11061,7 @@
     "slug": "attio-pack",
     "title": "Attio Pack",
     "description": "Claude Code skill pack for Attio (18 skills)",
-    "installCommand": "claude plugins add attio-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install attio-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11081,7 +11081,7 @@
     "slug": "bamboohr-pack",
     "title": "Bamboohr Pack",
     "description": "Claude Code skill pack for BambooHR (18 skills)",
-    "installCommand": "claude plugins add bamboohr-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install bamboohr-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11101,7 +11101,7 @@
     "slug": "brightdata-pack",
     "title": "Brightdata Pack",
     "description": "Claude Code skill pack for Bright Data (18 skills)",
-    "installCommand": "claude plugins add brightdata-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install brightdata-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11121,7 +11121,7 @@
     "slug": "canva-pack",
     "title": "Canva Pack",
     "description": "Claude Code skill pack for Canva (30 skills)",
-    "installCommand": "claude plugins add canva-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install canva-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11141,7 +11141,7 @@
     "slug": "castai-pack",
     "title": "Castai Pack",
     "description": "Claude Code skill pack for Cast AI (18 skills)",
-    "installCommand": "claude plugins add castai-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install castai-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -11162,7 +11162,7 @@
     "slug": "clari-pack",
     "title": "Clari Pack",
     "description": "Claude Code skill pack for Clari (18 skills)",
-    "installCommand": "claude plugins add clari-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clari-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11182,7 +11182,7 @@
     "slug": "clickhouse-pack",
     "title": "Clickhouse Pack",
     "description": "Claude Code skill pack for ClickHouse (24 skills)",
-    "installCommand": "claude plugins add clickhouse-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clickhouse-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11202,7 +11202,7 @@
     "slug": "clickup-pack",
     "title": "Clickup Pack",
     "description": "Claude Code skill pack for ClickUp (24 skills)",
-    "installCommand": "claude plugins add clickup-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install clickup-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11222,7 +11222,7 @@
     "slug": "cohere-pack",
     "title": "Cohere Pack",
     "description": "Claude Code skill pack for Cohere (24 skills)",
-    "installCommand": "claude plugins add cohere-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install cohere-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11242,7 +11242,7 @@
     "slug": "coreweave-pack",
     "title": "Coreweave Pack",
     "description": "Claude Code skill pack for CoreWeave (24 skills)",
-    "installCommand": "claude plugins add coreweave-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install coreweave-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11262,7 +11262,7 @@
     "slug": "elevenlabs-pack",
     "title": "Elevenlabs Pack",
     "description": "Claude Code skill pack for ElevenLabs (18 skills)",
-    "installCommand": "claude plugins add elevenlabs-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install elevenlabs-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11282,7 +11282,7 @@
     "slug": "fathom-pack",
     "title": "Fathom Pack",
     "description": "Claude Code skill pack for Fathom (18 skills)",
-    "installCommand": "claude plugins add fathom-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fathom-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11302,7 +11302,7 @@
     "slug": "figma-pack",
     "title": "Figma Pack",
     "description": "Claude Code skill pack for Figma (30 skills)",
-    "installCommand": "claude plugins add figma-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install figma-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11322,7 +11322,7 @@
     "slug": "finta-pack",
     "title": "Finta Pack",
     "description": "Claude Code skill pack for Finta (18 skills)",
-    "installCommand": "claude plugins add finta-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install finta-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11342,7 +11342,7 @@
     "slug": "flexport-pack",
     "title": "Flexport Pack",
     "description": "Claude Code skill pack for Flexport (24 skills)",
-    "installCommand": "claude plugins add flexport-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install flexport-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11362,7 +11362,7 @@
     "slug": "flyio-pack",
     "title": "Flyio Pack",
     "description": "Claude Code skill pack for Fly.io (18 skills)",
-    "installCommand": "claude plugins add flyio-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install flyio-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11382,7 +11382,7 @@
     "slug": "fondo-pack",
     "title": "Fondo Pack",
     "description": "Claude Code skill pack for Fondo (18 skills)",
-    "installCommand": "claude plugins add fondo-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install fondo-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11402,7 +11402,7 @@
     "slug": "framer-pack",
     "title": "Framer Pack",
     "description": "Claude Code skill pack for Framer (18 skills)",
-    "installCommand": "claude plugins add framer-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install framer-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11422,7 +11422,7 @@
     "slug": "glean-pack",
     "title": "Glean Pack",
     "description": "Claude Code skill pack for Glean (24 skills)",
-    "installCommand": "claude plugins add glean-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install glean-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11442,7 +11442,7 @@
     "slug": "grammarly-pack",
     "title": "Grammarly Pack",
     "description": "Claude Code skill pack for Grammarly (24 skills)",
-    "installCommand": "claude plugins add grammarly-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install grammarly-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11462,7 +11462,7 @@
     "slug": "hex-pack",
     "title": "Hex Pack",
     "description": "Claude Code skill pack for Hex (18 skills)",
-    "installCommand": "claude plugins add hex-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hex-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11482,7 +11482,7 @@
     "slug": "hootsuite-pack",
     "title": "Hootsuite Pack",
     "description": "Claude Code skill pack for Hootsuite (18 skills)",
-    "installCommand": "claude plugins add hootsuite-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hootsuite-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11502,7 +11502,7 @@
     "slug": "hubspot-pack",
     "title": "Hubspot Pack",
     "description": "Claude Code skill pack for HubSpot (30 skills)",
-    "installCommand": "claude plugins add hubspot-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hubspot-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11522,7 +11522,7 @@
     "slug": "intercom-pack",
     "title": "Intercom Pack",
     "description": "Claude Code skill pack for Intercom (24 skills)",
-    "installCommand": "claude plugins add intercom-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install intercom-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11542,7 +11542,7 @@
     "slug": "klaviyo-pack",
     "title": "Klaviyo Pack",
     "description": "Claude Code skill pack for Klaviyo (24 skills)",
-    "installCommand": "claude plugins add klaviyo-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install klaviyo-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11562,7 +11562,7 @@
     "slug": "linktree-pack",
     "title": "Linktree Pack",
     "description": "Claude Code skill pack for Linktree (18 skills)",
-    "installCommand": "claude plugins add linktree-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install linktree-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11582,7 +11582,7 @@
     "slug": "lucidchart-pack",
     "title": "Lucidchart Pack",
     "description": "Claude Code skill pack for Lucidchart (18 skills)",
-    "installCommand": "claude plugins add lucidchart-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install lucidchart-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11602,7 +11602,7 @@
     "slug": "mindtickle-pack",
     "title": "Mindtickle Pack",
     "description": "Claude Code skill pack for Mindtickle (18 skills)",
-    "installCommand": "claude plugins add mindtickle-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install mindtickle-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11622,7 +11622,7 @@
     "slug": "miro-pack",
     "title": "Miro Pack",
     "description": "Claude Code skill pack for Miro (24 skills)",
-    "installCommand": "claude plugins add miro-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install miro-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11642,7 +11642,7 @@
     "slug": "navan-pack",
     "title": "Navan Pack",
     "description": "Claude Code skill pack for Navan (24 skills)",
-    "installCommand": "claude plugins add navan-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install navan-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11662,7 +11662,7 @@
     "slug": "notion-pack",
     "title": "Notion Pack",
     "description": "Claude Code skill pack for Notion (30 skills)",
-    "installCommand": "claude plugins add notion-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install notion-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11682,7 +11682,7 @@
     "slug": "onenote-pack",
     "title": "Onenote Pack",
     "description": "Claude Code skill pack for OneNote (18 skills)",
-    "installCommand": "claude plugins add onenote-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install onenote-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11702,7 +11702,7 @@
     "slug": "oraclecloud-pack",
     "title": "Oraclecloud Pack",
     "description": "Claude Code skill pack for Oracle Cloud (24 skills)",
-    "installCommand": "claude plugins add oraclecloud-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install oraclecloud-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11722,7 +11722,7 @@
     "slug": "palantir-pack",
     "title": "Palantir Pack",
     "description": "Claude Code skill pack for Palantir (24 skills)",
-    "installCommand": "claude plugins add palantir-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install palantir-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11742,7 +11742,7 @@
     "slug": "persona-pack",
     "title": "Persona Pack",
     "description": "Claude Code skill pack for Persona (18 skills)",
-    "installCommand": "claude plugins add persona-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install persona-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11762,7 +11762,7 @@
     "slug": "podium-pack",
     "title": "Podium Pack",
     "description": "Claude Code skill pack for Podium (18 skills)",
-    "installCommand": "claude plugins add podium-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install podium-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11782,7 +11782,7 @@
     "slug": "procore-pack",
     "title": "Procore Pack",
     "description": "Claude Code skill pack for Procore (24 skills)",
-    "installCommand": "claude plugins add procore-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install procore-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11802,7 +11802,7 @@
     "slug": "quicknode-pack",
     "title": "Quicknode Pack",
     "description": "Claude Code skill pack for QuickNode (18 skills)",
-    "installCommand": "claude plugins add quicknode-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install quicknode-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "node"
@@ -11823,7 +11823,7 @@
     "slug": "ramp-pack",
     "title": "Ramp Pack",
     "description": "Claude Code skill pack for Ramp (24 skills)",
-    "installCommand": "claude plugins add ramp-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install ramp-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11843,7 +11843,7 @@
     "slug": "remofirst-pack",
     "title": "Remofirst Pack",
     "description": "Claude Code skill pack for RemoFirst (12 skills)",
-    "installCommand": "claude plugins add remofirst-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install remofirst-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11863,7 +11863,7 @@
     "slug": "runway-pack",
     "title": "Runway Pack",
     "description": "Claude Code skill pack for Runway (18 skills)",
-    "installCommand": "claude plugins add runway-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install runway-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11883,7 +11883,7 @@
     "slug": "salesforce-pack",
     "title": "Salesforce Pack",
     "description": "Claude Code skill pack for Salesforce (30 skills)",
-    "installCommand": "claude plugins add salesforce-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install salesforce-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11903,7 +11903,7 @@
     "slug": "salesloft-pack",
     "title": "Salesloft Pack",
     "description": "Claude Code skill pack for Salesloft (18 skills)",
-    "installCommand": "claude plugins add salesloft-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install salesloft-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11923,7 +11923,7 @@
     "slug": "serpapi-pack",
     "title": "Serpapi Pack",
     "description": "Claude Code skill pack for SerpApi (18 skills)",
-    "installCommand": "claude plugins add serpapi-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install serpapi-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "api"
@@ -11944,7 +11944,7 @@
     "slug": "shopify-pack",
     "title": "Shopify Pack",
     "description": "Claude Code skill pack for Shopify (30 skills)",
-    "installCommand": "claude plugins add shopify-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install shopify-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11964,7 +11964,7 @@
     "slug": "snowflake-pack",
     "title": "Snowflake Pack",
     "description": "Claude Code skill pack for Snowflake (30 skills)",
-    "installCommand": "claude plugins add snowflake-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install snowflake-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -11984,7 +11984,7 @@
     "slug": "stackblitz-pack",
     "title": "Stackblitz Pack",
     "description": "Claude Code skill pack for StackBlitz (18 skills)",
-    "installCommand": "claude plugins add stackblitz-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install stackblitz-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12004,7 +12004,7 @@
     "slug": "techsmith-pack",
     "title": "Techsmith Pack",
     "description": "Claude Code skill pack for TechSmith (18 skills)",
-    "installCommand": "claude plugins add techsmith-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install techsmith-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12024,7 +12024,7 @@
     "slug": "together-pack",
     "title": "Together Pack",
     "description": "Claude Code skill pack for Together AI (18 skills)",
-    "installCommand": "claude plugins add together-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install together-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs",
       "ai"
@@ -12045,7 +12045,7 @@
     "slug": "veeva-pack",
     "title": "Veeva Pack",
     "description": "Claude Code skill pack for Veeva (24 skills)",
-    "installCommand": "claude plugins add veeva-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install veeva-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12065,7 +12065,7 @@
     "slug": "webflow-pack",
     "title": "Webflow Pack",
     "description": "Claude Code skill pack for Webflow (24 skills)",
-    "installCommand": "claude plugins add webflow-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install webflow-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12085,7 +12085,7 @@
     "slug": "wispr-pack",
     "title": "Wispr Pack",
     "description": "Claude Code skill pack for Wispr (18 skills)",
-    "installCommand": "claude plugins add wispr-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install wispr-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12105,7 +12105,7 @@
     "slug": "workhuman-pack",
     "title": "Workhuman Pack",
     "description": "Claude Code skill pack for Workhuman (18 skills)",
-    "installCommand": "claude plugins add workhuman-pack@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install workhuman-pack@claude-code-plugins-plus-skills",
     "tags": [
       "saas-packs"
     ],
@@ -12125,7 +12125,7 @@
     "slug": "pm-ai-partner",
     "title": "Pm Ai Partner",
     "description": "12 PM-specific agent skills, 6 workflow commands, 3 automation hooks for Product Managers",
-    "installCommand": "claude plugins add pm-ai-partner@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install pm-ai-partner@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "automation",
@@ -12148,7 +12148,7 @@
     "slug": "validate-plugin",
     "title": "Validate Plugin",
     "description": "Validate Claude Code plugin structure against official Anthropic spec and Intent Solutions enterprise standard with 100-point grading.",
-    "installCommand": "claude plugins add validate-plugin@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install validate-plugin@claude-code-plugins-plus-skills",
     "tags": [
       "skill-enhancers",
       "ai"
@@ -12169,7 +12169,7 @@
     "slug": "executive-assistant-skills",
     "title": "Executive Assistant Skills",
     "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
-    "installCommand": "claude plugins add executive-assistant-skills@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install executive-assistant-skills@claude-code-plugins-plus-skills",
     "tags": [
       "business-tools",
       "ai"
@@ -12190,7 +12190,7 @@
     "slug": "box-cloud-filesystem",
     "title": "Box Cloud Filesystem",
     "description": "Transparent cloud filesystem for AI agents using Box CLI (@box/cli). Upload, download, search, share, and sync files to Box cloud storage with operational safety guardrails.",
-    "installCommand": "claude plugins add box-cloud-filesystem@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install box-cloud-filesystem@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "ai",
@@ -12212,8 +12212,8 @@
   {
     "slug": "pr-to-spec",
     "title": "Pr To Spec",
-    "description": "The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
-    "installCommand": "claude plugins add pr-to-spec@claude-code-plugins-plus-skills",
+    "description": "The flight envelope for agentic coding \u2014 convert PRs and local diffs into structured, agent-consumable specs with intent drift detection",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install pr-to-spec@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "agent"
@@ -12233,8 +12233,8 @@
   {
     "slug": "slack-channel",
     "title": "Slack Channel",
-    "description": "Two-way Slack channel for Claude Code — chat from Slack DMs and channels via Socket Mode",
-    "installCommand": "claude plugins add slack-channel@claude-code-plugins-plus-skills",
+    "description": "Two-way Slack channel for Claude Code \u2014 chat from Slack DMs and channels via Socket Mode",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install slack-channel@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "slack"
@@ -12254,8 +12254,8 @@
   {
     "slug": "x-bug-triage-plugin",
     "title": "X Bug Triage Plugin",
-    "description": "Closed-loop bug triage: X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
-    "installCommand": "claude plugins add x-bug-triage-plugin@claude-code-plugins-plus-skills",
+    "description": "Closed-loop bug triage: X complaints \u2192 clusters \u2192 repo evidence \u2192 owner routing \u2192 Slack review \u2192 filed issues",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install x-bug-triage-plugin@claude-code-plugins-plus-skills",
     "tags": [
       "mcp",
       "slack",
@@ -12277,7 +12277,7 @@
     "slug": "framecraft",
     "title": "Framecraft",
     "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
-    "installCommand": "claude plugins add framecraft@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install framecraft@claude-code-plugins-plus-skills",
     "tags": [
       "community"
     ],
@@ -12297,7 +12297,7 @@
     "slug": "tweetclaw",
     "title": "Tweetclaw",
     "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
-    "installCommand": "claude plugins add tweetclaw@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install tweetclaw@claude-code-plugins-plus-skills",
     "tags": [
       "devops",
       "automation",
@@ -12319,8 +12319,8 @@
   {
     "slug": "shipwright",
     "title": "Shipwright",
-    "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
-    "installCommand": "claude plugins add shipwright@claude-code-plugins-plus-skills",
+    "description": "Describe your app in plain English \u2014 Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install shipwright@claude-code-plugins-plus-skills",
     "tags": [
       "ai-agency",
       "ai"
@@ -12341,7 +12341,7 @@
     "slug": "hyperfocus",
     "title": "Hyperfocus",
     "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
-    "installCommand": "claude plugins add hyperfocus@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install hyperfocus@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "rest"
@@ -12361,8 +12361,8 @@
   {
     "slug": "plane",
     "title": "Plane",
-    "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
-    "installCommand": "claude plugins add plane@claude-code-plugins-plus-skills",
+    "description": "Plane is a team behavior observatory \u2014 synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install plane@claude-code-plugins-plus-skills",
     "tags": [
       "productivity",
       "api"
@@ -12382,8 +12382,8 @@
   {
     "slug": "local-tts",
     "title": "Local Tts",
-    "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
-    "installCommand": "claude plugins add local-tts@claude-code-plugins-plus-skills",
+    "description": "Offline text-to-speech via VoxCPM2 \u2014 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install local-tts@claude-code-plugins-plus-skills",
     "tags": [
       "ai-ml"
     ],
@@ -12403,7 +12403,7 @@
     "slug": "boycott-filter",
     "title": "Boycott Filter",
     "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
-    "installCommand": "claude plugins add boycott-filter@claude-code-plugins-plus-skills",
+    "installCommand": "/plugin marketplace add jeremylongshore/claude-code-plugins-plus-skills && /plugin install boycott-filter@claude-code-plugins-plus-skills",
     "tags": [
       "community",
       "ai",
@@ -12425,7 +12425,7 @@
     "slug": "marketing-skills",
     "title": "Marketing Skills",
     "description": "44 marketing skills across 7 pods: Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs.",
-    "installCommand": "claude plugins add marketing-skills@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install marketing-skills@claude-skills",
     "tags": [
       "marketing",
       "python"
@@ -12445,8 +12445,8 @@
   {
     "slug": "c-level-skills",
     "title": "C Level Skills",
-    "description": "28 C-level advisory skills: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive in…",
-    "installCommand": "claude plugins add c-level-skills@claude-skills",
+    "description": "28 C-level advisory skills: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive in\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install c-level-skills@claude-skills",
     "tags": [
       "leadership"
     ],
@@ -12465,8 +12465,8 @@
   {
     "slug": "engineering-advanced-skills",
     "title": "Engineering Advanced Skills",
-    "description": "44 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, migration architect, observability designer, dependency audi…",
-    "installCommand": "claude plugins add engineering-advanced-skills@claude-skills",
+    "description": "44 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, migration architect, observability designer, dependency audi\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install engineering-advanced-skills@claude-skills",
     "tags": [
       "development",
       "browser",
@@ -12489,8 +12489,8 @@
   {
     "slug": "engineering-skills",
     "title": "Engineering Skills",
-    "description": "36 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud archit…",
-    "installCommand": "claude plugins add engineering-skills@claude-skills",
+    "description": "36 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud archit\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install engineering-skills@claude-skills",
     "tags": [
       "development",
       "go",
@@ -12515,7 +12515,7 @@
     "slug": "ra-qm-skills",
     "title": "Ra Qm Skills",
     "description": "13 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, SOC 2 compliance.",
-    "installCommand": "claude plugins add ra-qm-skills@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install ra-qm-skills@claude-skills",
     "tags": [
       "compliance",
       "ai"
@@ -12535,8 +12535,8 @@
   {
     "slug": "product-skills",
     "title": "Product Skills",
-    "description": "15 product skills with 17 Python tools: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadm…",
-    "installCommand": "claude plugins add product-skills@claude-skills",
+    "description": "15 product skills with 17 Python tools: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadm\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install product-skills@claude-skills",
     "tags": [
       "product",
       "python"
@@ -12557,7 +12557,7 @@
     "slug": "pm-skills",
     "title": "Pm Skills",
     "description": "6 project management skills with 12 Python tools: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator.",
-    "installCommand": "claude plugins add pm-skills@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install pm-skills@claude-skills",
     "tags": [
       "project-management",
       "python",
@@ -12579,7 +12579,7 @@
     "slug": "business-growth-skills",
     "title": "Business Growth Skills",
     "description": "4 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer.",
-    "installCommand": "claude plugins add business-growth-skills@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install business-growth-skills@claude-skills",
     "tags": [
       "business-growth"
     ],
@@ -12599,7 +12599,7 @@
     "slug": "finance-skills",
     "title": "Finance Skills",
     "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, projections), and business investment advisor. 7 Python automation tools.",
-    "installCommand": "claude plugins add finance-skills@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install finance-skills@claude-skills",
     "tags": [
       "finance",
       "python",
@@ -12621,7 +12621,7 @@
     "slug": "pw",
     "title": "Pw",
     "description": "Production-grade Playwright testing toolkit. 9 skills, 3 agents, 55 templates, TestRail + BrowserStack MCP integrations. Generate tests, fix flaky failures, migrate from Cypress/Selenium.",
-    "installCommand": "claude plugins add pw@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install pw@claude-skills",
     "tags": [
       "development",
       "testing",
@@ -12645,7 +12645,7 @@
     "slug": "self-improving-agent",
     "title": "Self Improving Agent",
     "description": "Curate auto-memory, promote learnings to CLAUDE.md and rules, extract patterns into skills. Ships 5 slash commands (/si:review, /si:promote, /si:extract, /si:status, /si:remember) and 2 sub-agents (memory-analyst, skill-extractor).",
-    "installCommand": "claude plugins add self-improving-agent@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install self-improving-agent@claude-skills",
     "tags": [
       "development",
       "agent"
@@ -12665,8 +12665,8 @@
   {
     "slug": "autoresearch-agent",
     "title": "Autoresearch Agent",
-    "description": "Autonomous experiment loop — optimize any file by a measurable metric. 5 slash commands (/ar:setup, /ar:run, /ar:loop, /ar:status, /ar:resume), 8 built-in evaluators, configurable loop intervals (10min to monthly).",
-    "installCommand": "claude plugins add autoresearch-agent@claude-skills",
+    "description": "Autonomous experiment loop \u2014 optimize any file by a measurable metric. 5 slash commands (/ar:setup, /ar:run, /ar:loop, /ar:status, /ar:resume), 8 built-in evaluators, configurable loop intervals (10min to monthly).",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install autoresearch-agent@claude-skills",
     "tags": [
       "development",
       "agent"
@@ -12687,7 +12687,7 @@
     "slug": "google-workspace-cli",
     "title": "Google Workspace Cli",
     "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. 5 Python tools, 3 reference guides, 43 built-in recipes, 10 persona bundles.",
-    "installCommand": "claude plugins add google-workspace-cli@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install google-workspace-cli@claude-skills",
     "tags": [
       "development",
       "python",
@@ -12710,7 +12710,7 @@
     "slug": "code-to-prd",
     "title": "Code To Prd",
     "description": "Reverse-engineer any codebase into a complete PRD. Frontend (React, Vue, Angular, Next.js), backend (NestJS, Django, Express, FastAPI), and fullstack. 2 Python scripts (codebase_analyzer, prd_scaffolder), 2 reference guides, /code-to-prd slash command.",
-    "installCommand": "claude plugins add code-to-prd@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install code-to-prd@claude-skills",
     "tags": [
       "product",
       "python",
@@ -12735,8 +12735,8 @@
   {
     "slug": "agenthub",
     "title": "Agenthub",
-    "description": "Multi-agent collaboration — spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any task that benefits from diverse solutions. 7 slash commands (/hub:init, /hub:spawn, /hub:status, /hub:eval, /hub:merge, /hub:board, /hub:run), ag…",
-    "installCommand": "claude plugins add agenthub@claude-skills",
+    "description": "Multi-agent collaboration \u2014 spawn N parallel subagents that compete on code optimization, content drafts, research approaches, or any task that benefits from diverse solutions. 7 slash commands (/hub:init, /hub:spawn, /hub:status, /hub:eval, /hub:merge, /hub:board, /hub:run), ag\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install agenthub@claude-skills",
     "tags": [
       "development",
       "agent"
@@ -12757,7 +12757,7 @@
     "slug": "a11y-audit",
     "title": "A11y Audit",
     "description": "WCAG 2.2 accessibility audit and fix for React, Next.js, Vue, Angular, Svelte, and HTML. Static scanner detecting 20+ violation types, contrast checker with suggest mode, framework-specific fix patterns, /a11y-audit slash command.",
-    "installCommand": "claude plugins add a11y-audit@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install a11y-audit@claude-skills",
     "tags": [
       "development",
       "react",
@@ -12779,7 +12779,7 @@
     "slug": "executive-mentor",
     "title": "Executive Mentor",
     "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for board meetings, navigates hard calls, runs postmortems. 5 sub-skills with slash commands.",
-    "installCommand": "claude plugins add executive-mentor@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install executive-mentor@claude-skills",
     "tags": [
       "leadership"
     ],
@@ -12798,8 +12798,8 @@
   {
     "slug": "docker-development",
     "title": "Docker Development",
-    "description": "Docker and container development — Dockerfile optimization, docker-compose orchestration, multi-stage builds, security hardening, and CI/CD container pipelines.",
-    "installCommand": "claude plugins add docker-development@claude-skills",
+    "description": "Docker and container development \u2014 Dockerfile optimization, docker-compose orchestration, multi-stage builds, security hardening, and CI/CD container pipelines.",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install docker-development@claude-skills",
     "tags": [
       "development",
       "docker",
@@ -12821,8 +12821,8 @@
   {
     "slug": "helm-chart-builder",
     "title": "Helm Chart Builder",
-    "description": "Helm chart development — chart scaffolding, values design, template patterns, dependency management, and Kubernetes deployment strategies.",
-    "installCommand": "claude plugins add helm-chart-builder@claude-skills",
+    "description": "Helm chart development \u2014 chart scaffolding, values design, template patterns, dependency management, and Kubernetes deployment strategies.",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install helm-chart-builder@claude-skills",
     "tags": [
       "development",
       "kubernetes",
@@ -12843,8 +12843,8 @@
   {
     "slug": "terraform-patterns",
     "title": "Terraform Patterns",
-    "description": "Terraform infrastructure-as-code — module design patterns, state management, provider configuration, CI/CD integration, and multi-environment strategies.",
-    "installCommand": "claude plugins add terraform-patterns@claude-skills",
+    "description": "Terraform infrastructure-as-code \u2014 module design patterns, state management, provider configuration, CI/CD integration, and multi-environment strategies.",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install terraform-patterns@claude-skills",
     "tags": [
       "development"
     ],
@@ -12863,8 +12863,8 @@
   {
     "slug": "research-summarizer",
     "title": "Research Summarizer",
-    "description": "Structured research summarization — summarize academic papers, market research, user interviews, and competitive analysis into actionable insights.",
-    "installCommand": "claude plugins add research-summarizer@claude-skills",
+    "description": "Structured research summarization \u2014 summarize academic papers, market research, user interviews, and competitive analysis into actionable insights.",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install research-summarizer@claude-skills",
     "tags": [
       "product"
     ],
@@ -12883,8 +12883,8 @@
   {
     "slug": "code-tour",
     "title": "Code Tour",
-    "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. 10 developer personas, all CodeTour step types, SMIG description formula.",
-    "installCommand": "claude plugins add code-tour@claude-skills",
+    "description": "Create CodeTour .tour files \u2014 persona-targeted, step-by-step walkthroughs that link to real files and line numbers. 10 developer personas, all CodeTour step types, SMIG description formula.",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install code-tour@claude-skills",
     "tags": [
       "development"
     ],
@@ -12904,7 +12904,7 @@
     "slug": "demo-video",
     "title": "Demo Video",
     "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts with story structure, scene design system, and narration guidance.",
-    "installCommand": "claude plugins add demo-video@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install demo-video@claude-skills",
     "tags": [
       "development"
     ],
@@ -12924,7 +12924,7 @@
     "slug": "data-quality-auditor",
     "title": "Data Quality Auditor",
     "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
-    "installCommand": "claude plugins add data-quality-auditor@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install data-quality-auditor@claude-skills",
     "tags": [
       "development",
       "python"
@@ -12945,7 +12945,7 @@
     "slug": "statistical-analyst",
     "title": "Statistical Analyst",
     "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools: Z-test/t-test/chi-square with effect sizes, sample size calculator with power tradeoffs, and Wilson score confidence intervals.",
-    "installCommand": "claude plugins add statistical-analyst@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install statistical-analyst@claude-skills",
     "tags": [
       "development",
       "python",
@@ -12967,7 +12967,7 @@
     "slug": "apple-hig-expert",
     "title": "Apple Hig Expert",
     "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets and contrast.",
-    "installCommand": "claude plugins add apple-hig-expert@claude-skills",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install apple-hig-expert@claude-skills",
     "tags": [
       "design",
       "python"
@@ -12987,8 +12987,8 @@
   {
     "slug": "llm-wiki",
     "title": "Llm Wiki",
-    "description": "A second brain for Claude Code + Obsidian inspired by Karpathy's LLM Wiki gist. Turn any LLM CLI into a disciplined wiki maintainer: incrementally ingest sources into a persistent, interlinked markdown vault; update entity/concept/source pages; flag contradictions; maintain inde…",
-    "installCommand": "claude plugins add llm-wiki@claude-skills",
+    "description": "A second brain for Claude Code + Obsidian inspired by Karpathy's LLM Wiki gist. Turn any LLM CLI into a disciplined wiki maintainer: incrementally ingest sources into a persistent, interlinked markdown vault; update entity/concept/source pages; flag contradictions; maintain inde\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install llm-wiki@claude-skills",
     "tags": [
       "knowledge",
       "ai",
@@ -13009,8 +13009,8 @@
   {
     "slug": "karpathy-coder",
     "title": "Karpathy Coder",
-    "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, simplify, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check command, …",
-    "installCommand": "claude plugins add karpathy-coder@claude-skills",
+    "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, simplify, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check command, \u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install karpathy-coder@claude-skills",
     "tags": [
       "development",
       "python",
@@ -13032,8 +13032,8 @@
   {
     "slug": "agile-product-owner",
     "title": "Agile Product Owner",
-    "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weig…",
-    "installCommand": "claude plugins add agile-product-owner@claude-skills",
+    "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weig\u2026",
+    "installCommand": "/plugin marketplace add alirezarezvani/claude-skills && /plugin install agile-product-owner@claude-skills",
     "tags": [
       "product"
     ],
@@ -13053,7 +13053,7 @@
     "slug": "pm-product-discovery",
     "title": "Pm Product Discovery",
     "description": "Product discovery skills for PMs: ideation, experiments, assumption testing, feature prioritization, and customer interview synthesis.",
-    "installCommand": "claude plugins add pm-product-discovery@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-product-discovery@pm-skills",
     "tags": [
       "product-management",
       "testing"
@@ -13074,7 +13074,7 @@
     "slug": "pm-product-strategy",
     "title": "Pm Product Strategy",
     "description": "Product strategy skills for PMs: vision, strategy canvas, value propositions, lean canvas, business model canvas, SWOT, PESTLE, Ansoff Matrix, Porter's Five Forces, and monetization.",
-    "installCommand": "claude plugins add pm-product-strategy@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-product-strategy@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13094,7 +13094,7 @@
     "slug": "pm-execution",
     "title": "Pm Execution",
     "description": "Execution and product management skills: PRDs, OKRs, roadmaps, sprints, pre-mortems, stakeholder maps, user stories, prioritization frameworks, and more.",
-    "installCommand": "claude plugins add pm-execution@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-execution@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13114,7 +13114,7 @@
     "slug": "pm-market-research",
     "title": "Pm Market Research",
     "description": "Market research skills for PMs: user personas, market segmentation, sentiment analysis, and competitive analysis.",
-    "installCommand": "claude plugins add pm-market-research@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-market-research@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13134,7 +13134,7 @@
     "slug": "pm-data-analytics",
     "title": "Pm Data Analytics",
     "description": "Data analytics skills for PMs: SQL query generation and cohort analysis. Analyze user data, generate queries, and identify retention patterns.",
-    "installCommand": "claude plugins add pm-data-analytics@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-data-analytics@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13154,7 +13154,7 @@
     "slug": "pm-go-to-market",
     "title": "Pm Go To Market",
     "description": "Go-to-market skills for PMs: GTM strategy, growth loops, GTM motions, beachhead segments, and ideal customer profiles.",
-    "installCommand": "claude plugins add pm-go-to-market@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-go-to-market@pm-skills",
     "tags": [
       "product-management",
       "go"
@@ -13175,7 +13175,7 @@
     "slug": "pm-marketing-growth",
     "title": "Pm Marketing Growth",
     "description": "Product marketing and growth skills: marketing ideas, value proposition statements, North Star metrics, product naming, and positioning.",
-    "installCommand": "claude plugins add pm-marketing-growth@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-marketing-growth@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13195,7 +13195,7 @@
     "slug": "pm-toolkit",
     "title": "Pm Toolkit",
     "description": "PM utility skills: resume review, NDA drafting, privacy policy generation, and grammar/flow checking. Essential tools for product managers beyond core product work.",
-    "installCommand": "claude plugins add pm-toolkit@pm-skills",
+    "installCommand": "/plugin marketplace add phuryn/pm-skills && /plugin install pm-toolkit@pm-skills",
     "tags": [
       "product-management"
     ],
@@ -13214,8 +13214,8 @@
   {
     "slug": "documentation-standards",
     "title": "Documentation Standards",
-    "description": "HADS (Human-AI Document Standard) — semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
-    "installCommand": "claude plugins add documentation-standards@agents",
+    "description": "HADS (Human-AI Document Standard) \u2014 semantic tagging convention for writing docs that work efficiently for both humans and AI models. Reduces token consumption by separating machine-critical facts from human context.",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install documentation-standards@agents",
     "tags": [
       "documentation",
       "ai"
@@ -13236,7 +13236,7 @@
     "slug": "code-documentation",
     "title": "Code Documentation",
     "description": "Documentation generation, code explanation, and technical writing with automated doc generation and tutorial creation",
-    "installCommand": "claude plugins add code-documentation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install code-documentation@agents",
     "tags": [
       "documentation"
     ],
@@ -13256,7 +13256,7 @@
     "slug": "debugging-toolkit",
     "title": "Debugging Toolkit",
     "description": "Interactive debugging, developer experience optimization, and smart debugging workflows",
-    "installCommand": "claude plugins add debugging-toolkit@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install debugging-toolkit@agents",
     "tags": [
       "development"
     ],
@@ -13276,7 +13276,7 @@
     "slug": "git-pr-workflows",
     "title": "Git Pr Workflows",
     "description": "Git workflow automation, pull request enhancement, and team onboarding processes",
-    "installCommand": "claude plugins add git-pr-workflows@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install git-pr-workflows@agents",
     "tags": [
       "workflows",
       "automation"
@@ -13297,7 +13297,7 @@
     "slug": "backend-development",
     "title": "Backend Development",
     "description": "Backend API design, GraphQL architecture, workflow orchestration with Temporal, and test-driven backend development",
-    "installCommand": "claude plugins add backend-development@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install backend-development@agents",
     "tags": [
       "development",
       "api",
@@ -13319,7 +13319,7 @@
     "slug": "frontend-mobile-development",
     "title": "Frontend Mobile Development",
     "description": "Frontend UI development and mobile application implementation across platforms",
-    "installCommand": "claude plugins add frontend-mobile-development@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install frontend-mobile-development@agents",
     "tags": [
       "development"
     ],
@@ -13339,7 +13339,7 @@
     "slug": "full-stack-orchestration",
     "title": "Full Stack Orchestration",
     "description": "End-to-end feature orchestration with testing, security, performance, and deployment",
-    "installCommand": "claude plugins add full-stack-orchestration@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install full-stack-orchestration@agents",
     "tags": [
       "workflows",
       "security",
@@ -13363,7 +13363,7 @@
     "slug": "unit-testing",
     "title": "Unit Testing",
     "description": "Unit and integration test automation for Python and JavaScript with debugging support",
-    "installCommand": "claude plugins add unit-testing@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install unit-testing@agents",
     "tags": [
       "testing",
       "python",
@@ -13386,7 +13386,7 @@
     "slug": "tdd-workflows",
     "title": "Tdd Workflows",
     "description": "Test-driven development methodology with red-green-refactor cycles and code review",
-    "installCommand": "claude plugins add tdd-workflows@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install tdd-workflows@agents",
     "tags": [
       "workflows"
     ],
@@ -13406,7 +13406,7 @@
     "slug": "code-refactoring",
     "title": "Code Refactoring",
     "description": "Code cleanup, refactoring automation, and technical debt management with context restoration",
-    "installCommand": "claude plugins add code-refactoring@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install code-refactoring@agents",
     "tags": [
       "utilities",
       "automation",
@@ -13428,7 +13428,7 @@
     "slug": "dependency-management",
     "title": "Dependency Management",
     "description": "Dependency auditing, version management, and security vulnerability scanning",
-    "installCommand": "claude plugins add dependency-management@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install dependency-management@agents",
     "tags": [
       "utilities",
       "security"
@@ -13449,7 +13449,7 @@
     "slug": "error-debugging",
     "title": "Error Debugging",
     "description": "Error analysis, trace debugging, and multi-agent problem diagnosis",
-    "installCommand": "claude plugins add error-debugging@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install error-debugging@agents",
     "tags": [
       "utilities",
       "agent"
@@ -13470,7 +13470,7 @@
     "slug": "team-collaboration",
     "title": "Team Collaboration",
     "description": "Team workflows, issue management, standup automation, and developer experience optimization",
-    "installCommand": "claude plugins add team-collaboration@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install team-collaboration@agents",
     "tags": [
       "utilities",
       "automation"
@@ -13491,7 +13491,7 @@
     "slug": "llm-application-dev",
     "title": "Llm Application Dev",
     "description": "LLM application development with LangGraph, RAG systems, vector search, and AI agent architectures for Claude 4.6 and GPT-5.4",
-    "installCommand": "claude plugins add llm-application-dev@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install llm-application-dev@agents",
     "tags": [
       "ai-ml",
       "ai",
@@ -13515,7 +13515,7 @@
     "slug": "agent-orchestration",
     "title": "Agent Orchestration",
     "description": "Multi-agent system optimization, agent improvement workflows, and context management",
-    "installCommand": "claude plugins add agent-orchestration@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install agent-orchestration@agents",
     "tags": [
       "ai-ml",
       "agent"
@@ -13536,7 +13536,7 @@
     "slug": "context-management",
     "title": "Context Management",
     "description": "Context persistence, restoration, and long-running conversation management",
-    "installCommand": "claude plugins add context-management@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install context-management@agents",
     "tags": [
       "ai-ml",
       "rest"
@@ -13557,7 +13557,7 @@
     "slug": "machine-learning-ops",
     "title": "Machine Learning Ops",
     "description": "ML model training pipelines, hyperparameter tuning, model deployment automation, experiment tracking, and MLOps workflows",
-    "installCommand": "claude plugins add machine-learning-ops@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install machine-learning-ops@agents",
     "tags": [
       "ai-ml",
       "deployment",
@@ -13580,7 +13580,7 @@
     "slug": "incident-response",
     "title": "Incident Response",
     "description": "Production incident management, triage workflows, and automated incident resolution",
-    "installCommand": "claude plugins add incident-response@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install incident-response@agents",
     "tags": [
       "operations"
     ],
@@ -13600,7 +13600,7 @@
     "slug": "error-diagnostics",
     "title": "Error Diagnostics",
     "description": "Error tracing, root cause analysis, and smart debugging for production systems",
-    "installCommand": "claude plugins add error-diagnostics@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install error-diagnostics@agents",
     "tags": [
       "operations"
     ],
@@ -13620,7 +13620,7 @@
     "slug": "distributed-debugging",
     "title": "Distributed Debugging",
     "description": "Distributed system tracing and debugging across microservices",
-    "installCommand": "claude plugins add distributed-debugging@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install distributed-debugging@agents",
     "tags": [
       "operations"
     ],
@@ -13640,7 +13640,7 @@
     "slug": "observability-monitoring",
     "title": "Observability Monitoring",
     "description": "Metrics collection, logging infrastructure, distributed tracing, SLO implementation, and monitoring dashboards",
-    "installCommand": "claude plugins add observability-monitoring@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install observability-monitoring@agents",
     "tags": [
       "operations",
       "monitoring"
@@ -13661,7 +13661,7 @@
     "slug": "deployment-strategies",
     "title": "Deployment Strategies",
     "description": "Deployment patterns, rollback automation, and infrastructure templates",
-    "installCommand": "claude plugins add deployment-strategies@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install deployment-strategies@agents",
     "tags": [
       "infrastructure",
       "deployment",
@@ -13683,7 +13683,7 @@
     "slug": "deployment-validation",
     "title": "Deployment Validation",
     "description": "Pre-deployment checks, configuration validation, and deployment readiness assessment",
-    "installCommand": "claude plugins add deployment-validation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install deployment-validation@agents",
     "tags": [
       "infrastructure",
       "deployment"
@@ -13704,7 +13704,7 @@
     "slug": "kubernetes-operations",
     "title": "Kubernetes Operations",
     "description": "Kubernetes manifest generation, networking configuration, security policies, observability setup, GitOps workflows, and auto-scaling",
-    "installCommand": "claude plugins add kubernetes-operations@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install kubernetes-operations@agents",
     "tags": [
       "infrastructure",
       "kubernetes",
@@ -13726,7 +13726,7 @@
     "slug": "cloud-infrastructure",
     "title": "Cloud Infrastructure",
     "description": "Cloud architecture design for AWS/Azure/GCP/OCI, Kubernetes cluster configuration, Terraform infrastructure-as-code, hybrid cloud networking, and multi-cloud cost optimization",
-    "installCommand": "claude plugins add cloud-infrastructure@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install cloud-infrastructure@agents",
     "tags": [
       "infrastructure",
       "aws",
@@ -13750,7 +13750,7 @@
     "slug": "cicd-automation",
     "title": "Cicd Automation",
     "description": "CI/CD pipeline configuration, GitHub Actions/GitLab CI workflow setup, and automated deployment pipeline orchestration",
-    "installCommand": "claude plugins add cicd-automation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install cicd-automation@agents",
     "tags": [
       "infrastructure",
       "github",
@@ -13774,7 +13774,7 @@
     "slug": "application-performance",
     "title": "Application Performance",
     "description": "Application profiling, performance optimization, and observability for frontend and backend systems",
-    "installCommand": "claude plugins add application-performance@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install application-performance@agents",
     "tags": [
       "performance"
     ],
@@ -13794,7 +13794,7 @@
     "slug": "database-cloud-optimization",
     "title": "Database Cloud Optimization",
     "description": "Database query optimization, cloud cost optimization, and scalability improvements",
-    "installCommand": "claude plugins add database-cloud-optimization@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install database-cloud-optimization@agents",
     "tags": [
       "performance"
     ],
@@ -13814,7 +13814,7 @@
     "slug": "comprehensive-review",
     "title": "Comprehensive Review",
     "description": "Multi-perspective code analysis covering architecture, security, and best practices",
-    "installCommand": "claude plugins add comprehensive-review@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install comprehensive-review@agents",
     "tags": [
       "quality",
       "security"
@@ -13835,7 +13835,7 @@
     "slug": "performance-testing-review",
     "title": "Performance Testing Review",
     "description": "Performance analysis, test coverage review, and AI-powered code quality assessment",
-    "installCommand": "claude plugins add performance-testing-review@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install performance-testing-review@agents",
     "tags": [
       "quality",
       "testing",
@@ -13859,7 +13859,7 @@
     "slug": "framework-migration",
     "title": "Framework Migration",
     "description": "Framework updates, migration planning, and architectural transformation workflows",
-    "installCommand": "claude plugins add framework-migration@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install framework-migration@agents",
     "tags": [
       "modernization"
     ],
@@ -13879,7 +13879,7 @@
     "slug": "codebase-cleanup",
     "title": "Codebase Cleanup",
     "description": "Technical debt reduction, dependency updates, and code refactoring automation",
-    "installCommand": "claude plugins add codebase-cleanup@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install codebase-cleanup@agents",
     "tags": [
       "modernization",
       "automation"
@@ -13900,7 +13900,7 @@
     "slug": "database-design",
     "title": "Database Design",
     "description": "Database architecture, schema design, and SQL optimization for production systems",
-    "installCommand": "claude plugins add database-design@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install database-design@agents",
     "tags": [
       "database"
     ],
@@ -13920,7 +13920,7 @@
     "slug": "database-migrations",
     "title": "Database Migrations",
     "description": "Database migration automation, observability, and cross-database migration strategies",
-    "installCommand": "claude plugins add database-migrations@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install database-migrations@agents",
     "tags": [
       "database",
       "automation"
@@ -13941,7 +13941,7 @@
     "slug": "security-scanning",
     "title": "Security Scanning",
     "description": "SAST analysis, dependency vulnerability scanning, OWASP Top 10 compliance, container security scanning, and automated security hardening",
-    "installCommand": "claude plugins add security-scanning@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install security-scanning@agents",
     "tags": [
       "security",
       "ai"
@@ -13962,7 +13962,7 @@
     "slug": "security-compliance",
     "title": "Security Compliance",
     "description": "SOC2, HIPAA, and GDPR compliance validation, secrets scanning, compliance checklists, and regulatory documentation",
-    "installCommand": "claude plugins add security-compliance@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install security-compliance@agents",
     "tags": [
       "security"
     ],
@@ -13982,7 +13982,7 @@
     "slug": "backend-api-security",
     "title": "Backend Api Security",
     "description": "API security hardening, authentication implementation, authorization patterns, rate limiting, and input validation",
-    "installCommand": "claude plugins add backend-api-security@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install backend-api-security@agents",
     "tags": [
       "security",
       "api"
@@ -14003,7 +14003,7 @@
     "slug": "frontend-mobile-security",
     "title": "Frontend Mobile Security",
     "description": "XSS prevention, CSRF protection, content security policies, mobile app security, and secure storage patterns",
-    "installCommand": "claude plugins add frontend-mobile-security@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install frontend-mobile-security@agents",
     "tags": [
       "security",
       "rag"
@@ -14024,7 +14024,7 @@
     "slug": "data-validation-suite",
     "title": "Data Validation Suite",
     "description": "Schema validation, data quality monitoring, streaming validation pipelines, and input validation for backend APIs",
-    "installCommand": "claude plugins add data-validation-suite@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install data-validation-suite@agents",
     "tags": [
       "data",
       "monitoring",
@@ -14046,7 +14046,7 @@
     "slug": "api-scaffolding",
     "title": "Api Scaffolding",
     "description": "REST and GraphQL API scaffolding, framework selection, backend architecture, and API generation",
-    "installCommand": "claude plugins add api-scaffolding@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install api-scaffolding@agents",
     "tags": [
       "api",
       "graphql",
@@ -14068,7 +14068,7 @@
     "slug": "api-testing-observability",
     "title": "Api Testing Observability",
     "description": "API testing automation, request mocking, OpenAPI documentation generation, observability setup, and monitoring",
-    "installCommand": "claude plugins add api-testing-observability@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install api-testing-observability@agents",
     "tags": [
       "api",
       "testing",
@@ -14091,7 +14091,7 @@
     "slug": "seo-content-creation",
     "title": "Seo Content Creation",
     "description": "SEO content writing, planning, and quality auditing with E-E-A-T optimization",
-    "installCommand": "claude plugins add seo-content-creation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install seo-content-creation@agents",
     "tags": [
       "marketing"
     ],
@@ -14111,7 +14111,7 @@
     "slug": "seo-technical-optimization",
     "title": "Seo Technical Optimization",
     "description": "Technical SEO optimization including meta tags, keywords, structure, and featured snippets",
-    "installCommand": "claude plugins add seo-technical-optimization@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install seo-technical-optimization@agents",
     "tags": [
       "marketing"
     ],
@@ -14131,7 +14131,7 @@
     "slug": "seo-analysis-monitoring",
     "title": "Seo Analysis Monitoring",
     "description": "Content freshness analysis, cannibalization detection, and authority building for SEO",
-    "installCommand": "claude plugins add seo-analysis-monitoring@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install seo-analysis-monitoring@agents",
     "tags": [
       "marketing",
       "monitoring"
@@ -14152,7 +14152,7 @@
     "slug": "documentation-generation",
     "title": "Documentation Generation",
     "description": "OpenAPI specification generation, Mermaid diagram creation, tutorial writing, API reference documentation",
-    "installCommand": "claude plugins add documentation-generation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install documentation-generation@agents",
     "tags": [
       "documentation",
       "api",
@@ -14174,7 +14174,7 @@
     "slug": "c4-architecture",
     "title": "C4 Architecture",
     "description": "Comprehensive C4 architecture documentation workflow with bottom-up code analysis, component synthesis, container mapping, and context diagram generation",
-    "installCommand": "claude plugins add c4-architecture@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install c4-architecture@agents",
     "tags": [
       "documentation",
       "ai"
@@ -14195,7 +14195,7 @@
     "slug": "multi-platform-apps",
     "title": "Multi Platform Apps",
     "description": "Cross-platform application development coordinating web, iOS, Android, and desktop implementations",
-    "installCommand": "claude plugins add multi-platform-apps@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install multi-platform-apps@agents",
     "tags": [
       "development"
     ],
@@ -14215,7 +14215,7 @@
     "slug": "business-analytics",
     "title": "Business Analytics",
     "description": "Business metrics analysis, KPI tracking, financial reporting, and data-driven decision making",
-    "installCommand": "claude plugins add business-analytics@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install business-analytics@agents",
     "tags": [
       "business"
     ],
@@ -14235,7 +14235,7 @@
     "slug": "startup-business-analyst",
     "title": "Startup Business Analyst",
     "description": "Comprehensive startup business analysis with market sizing (TAM/SAM/SOM), financial modeling, team planning, and strategic research for early-stage companies",
-    "installCommand": "claude plugins add startup-business-analyst@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install startup-business-analyst@agents",
     "tags": [
       "business"
     ],
@@ -14255,7 +14255,7 @@
     "slug": "hr-legal-compliance",
     "title": "Hr Legal Compliance",
     "description": "HR policy documentation, legal compliance templates (GDPR/SOC2/HIPAA), employment contracts, and regulatory documentation",
-    "installCommand": "claude plugins add hr-legal-compliance@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install hr-legal-compliance@agents",
     "tags": [
       "business"
     ],
@@ -14275,7 +14275,7 @@
     "slug": "customer-sales-automation",
     "title": "Customer Sales Automation",
     "description": "Customer support workflow automation, sales pipeline management, email campaigns, and CRM integration",
-    "installCommand": "claude plugins add customer-sales-automation@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install customer-sales-automation@agents",
     "tags": [
       "business",
       "automation",
@@ -14297,7 +14297,7 @@
     "slug": "content-marketing",
     "title": "Content Marketing",
     "description": "Content marketing strategy, web research, and information synthesis for marketing operations",
-    "installCommand": "claude plugins add content-marketing@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install content-marketing@agents",
     "tags": [
       "marketing"
     ],
@@ -14317,7 +14317,7 @@
     "slug": "blockchain-web3",
     "title": "Blockchain Web3",
     "description": "Smart contract development with Solidity, DeFi protocol implementation, NFT platforms, and Web3 application architecture",
-    "installCommand": "claude plugins add blockchain-web3@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install blockchain-web3@agents",
     "tags": [
       "blockchain",
       "ai"
@@ -14338,7 +14338,7 @@
     "slug": "quantitative-trading",
     "title": "Quantitative Trading",
     "description": "Quantitative analysis, algorithmic trading strategies, financial modeling, portfolio risk management, and backtesting",
-    "installCommand": "claude plugins add quantitative-trading@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install quantitative-trading@agents",
     "tags": [
       "finance",
       "go",
@@ -14360,7 +14360,7 @@
     "slug": "payment-processing",
     "title": "Payment Processing",
     "description": "Payment gateway integration with Stripe, PayPal, checkout flow implementation, subscription billing, and PCI compliance",
-    "installCommand": "claude plugins add payment-processing@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install payment-processing@agents",
     "tags": [
       "payments"
     ],
@@ -14380,7 +14380,7 @@
     "slug": "game-development",
     "title": "Game Development",
     "description": "Unity game development with C# scripting, Minecraft server plugin development with Bukkit/Spigot APIs",
-    "installCommand": "claude plugins add game-development@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install game-development@agents",
     "tags": [
       "gaming",
       "go",
@@ -14402,7 +14402,7 @@
     "slug": "accessibility-compliance",
     "title": "Accessibility Compliance",
     "description": "WCAG accessibility auditing, compliance validation, UI testing for screen readers, keyboard navigation, and inclusive design",
-    "installCommand": "claude plugins add accessibility-compliance@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install accessibility-compliance@agents",
     "tags": [
       "accessibility",
       "testing"
@@ -14423,7 +14423,7 @@
     "slug": "python-development",
     "title": "Python Development",
     "description": "Modern Python development with Python 3.12+, Django, FastAPI, async patterns, and production best practices",
-    "installCommand": "claude plugins add python-development@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install python-development@agents",
     "tags": [
       "languages",
       "python",
@@ -14447,7 +14447,7 @@
     "slug": "javascript-typescript",
     "title": "Javascript Typescript",
     "description": "JavaScript and TypeScript development with ES6+, Node.js, React, and modern web frameworks",
-    "installCommand": "claude plugins add javascript-typescript@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install javascript-typescript@agents",
     "tags": [
       "languages",
       "typescript",
@@ -14471,7 +14471,7 @@
     "slug": "systems-programming",
     "title": "Systems Programming",
     "description": "Systems programming with Rust, Go, C, and C++ for performance-critical and low-level development",
-    "installCommand": "claude plugins add systems-programming@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install systems-programming@agents",
     "tags": [
       "languages",
       "rust",
@@ -14494,7 +14494,7 @@
     "slug": "jvm-languages",
     "title": "Jvm Languages",
     "description": "JVM language development including Java, Scala, and C# with enterprise patterns and frameworks",
-    "installCommand": "claude plugins add jvm-languages@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install jvm-languages@agents",
     "tags": [
       "languages"
     ],
@@ -14514,7 +14514,7 @@
     "slug": "web-scripting",
     "title": "Web Scripting",
     "description": "Web scripting with PHP and Ruby for web applications, CMS development, and backend services",
-    "installCommand": "claude plugins add web-scripting@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install web-scripting@agents",
     "tags": [
       "languages"
     ],
@@ -14534,7 +14534,7 @@
     "slug": "functional-programming",
     "title": "Functional Programming",
     "description": "Functional programming with Elixir, OTP patterns, Phoenix framework, and distributed systems",
-    "installCommand": "claude plugins add functional-programming@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install functional-programming@agents",
     "tags": [
       "languages"
     ],
@@ -14554,7 +14554,7 @@
     "slug": "julia-development",
     "title": "Julia Development",
     "description": "Modern Julia development with Julia 1.10+, package management, scientific computing, high-performance numerical code, and production best practices",
-    "installCommand": "claude plugins add julia-development@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install julia-development@agents",
     "tags": [
       "languages",
       "performance"
@@ -14575,7 +14575,7 @@
     "slug": "arm-cortex-microcontrollers",
     "title": "Arm Cortex Microcontrollers",
     "description": "ARM Cortex-M firmware development for Teensy, STM32, nRF52, and SAMD with peripheral drivers and memory safety patterns",
-    "installCommand": "claude plugins add arm-cortex-microcontrollers@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install arm-cortex-microcontrollers@agents",
     "tags": [
       "languages"
     ],
@@ -14595,7 +14595,7 @@
     "slug": "shell-scripting",
     "title": "Shell Scripting",
     "description": "Production-grade Bash scripting with defensive programming, POSIX compliance, and comprehensive testing",
-    "installCommand": "claude plugins add shell-scripting@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install shell-scripting@agents",
     "tags": [
       "languages",
       "testing"
@@ -14616,7 +14616,7 @@
     "slug": "developer-essentials",
     "title": "Developer Essentials",
     "description": "Essential developer skills including Git workflows, SQL optimization, error handling, code review, E2E testing, authentication, debugging, and monorepo management",
-    "installCommand": "claude plugins add developer-essentials@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install developer-essentials@agents",
     "tags": [
       "development",
       "testing"
@@ -14637,12 +14637,12 @@
     "slug": "reverse-engineering",
     "title": "Reverse Engineering",
     "description": "Binary reverse engineering, malware analysis, firmware security, and software protection research for authorized security research, CTF competitions, and defensive security",
-    "installCommand": "claude plugins add reverse-engineering@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install reverse-engineering@agents",
     "tags": [
       "security"
     ],
     "author": {
-      "name": "Dávid Balatoni",
+      "name": "D\u00e1vid Balatoni",
       "url": "https://github.com/wshobson/agents"
     },
     "repoUrl": "https://github.com/wshobson/agents",
@@ -14656,8 +14656,8 @@
   {
     "slug": "conductor",
     "title": "Conductor",
-    "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context → Spec & Plan → Implement",
-    "installCommand": "claude plugins add conductor@agents",
+    "description": "Context-Driven Development plugin that transforms Claude Code into a project management tool with structured workflow: Context \u2192 Spec & Plan \u2192 Implement",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install conductor@agents",
     "tags": [
       "workflows"
     ],
@@ -14677,7 +14677,7 @@
     "slug": "ui-design",
     "title": "Ui Design",
     "description": "Comprehensive UI/UX design plugin for mobile (iOS, Android, React Native) and web applications with design systems, accessibility, and modern patterns",
-    "installCommand": "claude plugins add ui-design@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install ui-design@agents",
     "tags": [
       "development",
       "react"
@@ -14698,7 +14698,7 @@
     "slug": "agent-teams",
     "title": "Agent Teams",
     "description": "Orchestrate multi-agent teams for parallel code review, hypothesis-driven debugging, and coordinated feature development using Claude Code's Agent Teams",
-    "installCommand": "claude plugins add agent-teams@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install agent-teams@agents",
     "tags": [
       "workflows",
       "agent"
@@ -14719,7 +14719,7 @@
     "slug": "dotnet-contribution",
     "title": "Dotnet Contribution",
     "description": "Comprehensive .NET backend development with C#, ASP.NET Core, Entity Framework Core, and Dapper for production-grade applications",
-    "installCommand": "claude plugins add dotnet-contribution@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install dotnet-contribution@agents",
     "tags": [
       "languages"
     ],
@@ -14739,7 +14739,7 @@
     "slug": "meigen-ai-design",
     "title": "Meigen Ai Design",
     "description": "AI image generation with creative workflow orchestration, prompt engineering, and curated inspiration library via MCP server",
-    "installCommand": "claude plugins add meigen-ai-design@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install meigen-ai-design@agents",
     "tags": [
       "creative",
       "ai"
@@ -14760,7 +14760,7 @@
     "slug": "brand-landingpage",
     "title": "Brand Landingpage",
     "description": "Guides developers from brand discovery through iterative design to deployment-ready HTML via Stitch.",
-    "installCommand": "claude plugins add brand-landingpage@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install brand-landingpage@agents",
     "tags": [
       "creative",
       "deployment"
@@ -14781,7 +14781,7 @@
     "slug": "plugin-eval",
     "title": "Plugin Eval",
     "description": "Three-layer quality evaluation framework for Claude Code plugins with Elo ranking",
-    "installCommand": "claude plugins add plugin-eval@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install plugin-eval@agents",
     "tags": [
       "quality"
     ],
@@ -14801,7 +14801,7 @@
     "slug": "block-no-verify",
     "title": "Block No Verify",
     "description": "PreToolUse hook that prevents AI agents from using --no-verify, --no-gpg-sign, and other bypass flags that skip git hooks",
-    "installCommand": "claude plugins add block-no-verify@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install block-no-verify@agents",
     "tags": [
       "security",
       "ai",
@@ -14822,8 +14822,8 @@
   {
     "slug": "qa-orchestra",
     "title": "Qa Orchestra",
-    "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle — orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Sta…",
-    "installCommand": "claude plugins add qa-orchestra@agents",
+    "description": "Multi-agent QA toolkit with 10 specialized agents covering the full QA lifecycle \u2014 orchestrator, environment-manager, functional-reviewer, test-scenario-designer, browser-validator, automation-writer, manual-validator, bug-reporter, release-analyzer, and smart-test-selector. Sta\u2026",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install qa-orchestra@agents",
     "tags": [
       "testing",
       "browser",
@@ -14845,8 +14845,8 @@
   {
     "slug": "protect-mcp",
     "title": "Protect Mcp",
-    "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin — decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
-    "installCommand": "claude plugins add protect-mcp@agents",
+    "description": "Cedar policy enforcement + Ed25519 signed receipts for every Claude Code tool call. First cryptographic governance plugin \u2014 decisions are policy-gated before they run and every decision produces a tamper-evident receipt verifiable offline.",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install protect-mcp@agents",
     "tags": [
       "governance",
       "go"
@@ -14867,7 +14867,7 @@
     "slug": "signed-audit-trails",
     "title": "Signed Audit Trails",
     "description": "Teaching skill: cookbook-style walkthrough for signed audit trails on every Claude Code tool call. Cedar policy, Ed25519 receipts, offline verification, CI/CD integration, SLSA composition. Pairs with the protect-mcp runtime plugin.",
-    "installCommand": "claude plugins add signed-audit-trails@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install signed-audit-trails@agents",
     "tags": [
       "governance",
       "ai"
@@ -14888,7 +14888,7 @@
     "slug": "review-agent-governance",
     "title": "Review Agent Governance",
     "description": "Require a human approval signal before an AI agent can post PR reviews, comments, merges, or writes to CI configuration. Joins protect-mcp and signed-audit-trails in the governance category; composes with protect-mcp for runtime enforcement.",
-    "installCommand": "claude plugins add review-agent-governance@agents",
+    "installCommand": "/plugin marketplace add wshobson/agents && /plugin install review-agent-governance@agents",
     "tags": [
       "governance",
       "go",
@@ -14911,7 +14911,7 @@
     "slug": "connect-apps",
     "title": "Connect Apps",
     "description": "Connect Claude to 500+ apps - Gmail, Slack, GitHub, Notion, and more",
-    "installCommand": "claude plugins add connect-apps@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install connect-apps@awesome-claude-plugins",
     "tags": [
       "integrations",
       "github",
@@ -14934,7 +14934,7 @@
     "slug": "artifacts-builder",
     "title": "Artifacts Builder",
     "description": "Build complex HTML artifacts with React, Tailwind CSS, and shadcn/ui",
-    "installCommand": "claude plugins add artifacts-builder@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install artifacts-builder@awesome-claude-plugins",
     "tags": [
       "frontend",
       "react",
@@ -14956,7 +14956,7 @@
     "slug": "theme-factory",
     "title": "Theme Factory",
     "description": "10 professional themes for slides, docs, reports, and landing pages",
-    "installCommand": "claude plugins add theme-factory@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install theme-factory@awesome-claude-plugins",
     "tags": [
       "frontend"
     ],
@@ -14976,7 +14976,7 @@
     "slug": "canvas-design",
     "title": "Canvas Design",
     "description": "Create museum-quality visual art in PNG and PDF formats",
-    "installCommand": "claude plugins add canvas-design@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install canvas-design@awesome-claude-plugins",
     "tags": [
       "frontend"
     ],
@@ -14996,7 +14996,7 @@
     "slug": "senior-frontend",
     "title": "Senior Frontend",
     "description": "React/Next.js/TypeScript patterns with bundle analysis and optimization",
-    "installCommand": "claude plugins add senior-frontend@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install senior-frontend@awesome-claude-plugins",
     "tags": [
       "frontend",
       "typescript",
@@ -15018,7 +15018,7 @@
     "slug": "frontend-developer",
     "title": "Frontend Developer",
     "description": "Frontend development specialist agent",
-    "installCommand": "claude plugins add frontend-developer@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install frontend-developer@awesome-claude-plugins",
     "tags": [
       "frontend",
       "agent"
@@ -15039,7 +15039,7 @@
     "slug": "commit",
     "title": "Commit",
     "description": "Smart git commits using conventional commit format",
-    "installCommand": "claude plugins add commit@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install commit@awesome-claude-plugins",
     "tags": [
       "git"
     ],
@@ -15059,7 +15059,7 @@
     "slug": "create-pr",
     "title": "Create Pr",
     "description": "Automates pull request creation with proper templates",
-    "installCommand": "claude plugins add create-pr@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install create-pr@awesome-claude-plugins",
     "tags": [
       "git"
     ],
@@ -15079,7 +15079,7 @@
     "slug": "pr-review",
     "title": "Pr Review",
     "description": "Comprehensive PR reviews with detailed feedback",
-    "installCommand": "claude plugins add pr-review@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install pr-review@awesome-claude-plugins",
     "tags": [
       "git",
       "ai"
@@ -15100,7 +15100,7 @@
     "slug": "changelog-generator",
     "title": "Changelog Generator",
     "description": "Transform git commits into user-friendly changelogs",
-    "installCommand": "claude plugins add changelog-generator@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install changelog-generator@awesome-claude-plugins",
     "tags": [
       "git"
     ],
@@ -15120,7 +15120,7 @@
     "slug": "ship",
     "title": "Ship",
     "description": "Complete PR workflow from commit to production",
-    "installCommand": "claude plugins add ship@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install ship@awesome-claude-plugins",
     "tags": [
       "git"
     ],
@@ -15140,7 +15140,7 @@
     "slug": "test-writer-fixer",
     "title": "Test Writer Fixer",
     "description": "Automatically write and fix unit tests",
-    "installCommand": "claude plugins add test-writer-fixer@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install test-writer-fixer@awesome-claude-plugins",
     "tags": [
       "quality"
     ],
@@ -15160,7 +15160,7 @@
     "slug": "debugger",
     "title": "Debugger",
     "description": "Advanced debugging assistant",
-    "installCommand": "claude plugins add debugger@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install debugger@awesome-claude-plugins",
     "tags": [
       "quality"
     ],
@@ -15180,7 +15180,7 @@
     "slug": "bug-fix",
     "title": "Bug Fix",
     "description": "Analyzes and fixes bugs in your codebase",
-    "installCommand": "claude plugins add bug-fix@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install bug-fix@awesome-claude-plugins",
     "tags": [
       "quality"
     ],
@@ -15200,7 +15200,7 @@
     "slug": "backend-architect",
     "title": "Backend Architect",
     "description": "Backend architecture patterns and system design",
-    "installCommand": "claude plugins add backend-architect@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install backend-architect@awesome-claude-plugins",
     "tags": [
       "backend"
     ],
@@ -15220,7 +15220,7 @@
     "slug": "mcp-builder",
     "title": "Mcp Builder",
     "description": "Build high-quality MCP servers for LLM integrations",
-    "installCommand": "claude plugins add mcp-builder@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install mcp-builder@awesome-claude-plugins",
     "tags": [
       "backend",
       "llm"
@@ -15241,7 +15241,7 @@
     "slug": "perf",
     "title": "Perf",
     "description": "Performance analysis and optimization",
-    "installCommand": "claude plugins add perf@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install perf@awesome-claude-plugins",
     "tags": [
       "devops",
       "performance"
@@ -15262,7 +15262,7 @@
     "slug": "audit-project",
     "title": "Audit Project",
     "description": "Full project audit for quality and issues",
-    "installCommand": "claude plugins add audit-project@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install audit-project@awesome-claude-plugins",
     "tags": [
       "devops"
     ],
@@ -15282,7 +15282,7 @@
     "slug": "documentation-generator",
     "title": "Documentation Generator",
     "description": "Generate comprehensive documentation from code",
-    "installCommand": "claude plugins add documentation-generator@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install documentation-generator@awesome-claude-plugins",
     "tags": [
       "docs"
     ],
@@ -15302,7 +15302,7 @@
     "slug": "developer-growth-analysis",
     "title": "Developer Growth Analysis",
     "description": "Analyze coding patterns and get personalized learning resources",
-    "installCommand": "claude plugins add developer-growth-analysis@awesome-claude-plugins",
+    "installCommand": "/plugin marketplace add ComposioHQ/awesome-claude-plugins && /plugin install developer-growth-analysis@awesome-claude-plugins",
     "tags": [
       "productivity"
     ],
@@ -15322,7 +15322,7 @@
     "slug": "abstract",
     "title": "Abstract",
     "description": "Skill authoring, hook development, evaluation frameworks, and escalation governance for the Claude Code plugin ecosystem",
-    "installCommand": "claude plugins add abstract@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install abstract@claude-night-market",
     "tags": [
       "go"
     ],
@@ -15341,7 +15341,7 @@
     "slug": "attune",
     "title": "Attune",
     "description": "Full-cycle project development: brainstorm, specify, plan, initialize, execute, and polish with war-room deliberation for strategic decisions",
-    "installCommand": "claude plugins add attune@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install attune@claude-night-market",
     "tags": [
       "ai"
     ],
@@ -15360,7 +15360,7 @@
     "slug": "archetypes",
     "title": "Archetypes",
     "description": "Architecture paradigm selection and implementation planning: 14 paradigms from functional-core to hexagonal to microservices",
-    "installCommand": "claude plugins add archetypes@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install archetypes@claude-night-market",
     "tags": [
       "go"
     ],
@@ -15379,7 +15379,7 @@
     "slug": "cartograph",
     "title": "Cartograph",
     "description": "Codebase visualization: architecture, data flow, dependency, call chains, community detection, and class diagrams via Mermaid Chart MCP",
-    "installCommand": "claude plugins add cartograph@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install cartograph@claude-night-market",
     "tags": [
       "ai"
     ],
@@ -15398,7 +15398,7 @@
     "slug": "conjure",
     "title": "Conjure",
     "description": "Delegate tasks to external LLMs (Gemini, Qwen) with cheapest-capable model selection while retaining strategic oversight",
-    "installCommand": "claude plugins add conjure@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install conjure@claude-night-market",
     "tags": [
       "ai",
       "llm"
@@ -15418,7 +15418,7 @@
     "slug": "conserve",
     "title": "Conserve",
     "description": "Context optimization, bloat detection, CPU/GPU monitoring, and token conservation for efficient Claude Code sessions",
-    "installCommand": "claude plugins add conserve@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install conserve@claude-night-market",
     "tags": [
       "monitoring"
     ],
@@ -15437,7 +15437,7 @@
     "slug": "imbue",
     "title": "Imbue",
     "description": "TDD enforcement, proof-of-work validation, scope guarding, rigorous reasoning, and research-enriched feature review with RICE/WSJF/Kano scoring",
-    "installCommand": "claude plugins add imbue@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install imbue@claude-night-market",
     "tags": [
       "go"
     ],
@@ -15456,7 +15456,7 @@
     "slug": "leyline",
     "title": "Leyline",
     "description": "Foundation infrastructure: auth flows, quota management, error patterns, markdown formatting, trust verification, and injection detection",
-    "installCommand": "claude plugins add leyline@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install leyline@claude-night-market",
     "tags": [
       "rust"
     ],
@@ -15475,7 +15475,7 @@
     "slug": "memory-palace",
     "title": "Memory Palace",
     "description": "Spatial knowledge organization with memory palace techniques: build, navigate, and maintain virtual memory structures with PR review capture",
-    "installCommand": "claude plugins add memory-palace@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install memory-palace@claude-night-market",
     "tags": [
       "ai"
     ],
@@ -15494,7 +15494,7 @@
     "slug": "minister",
     "title": "Minister",
     "description": "GitHub issue management, label taxonomy, and initiative tracking: turns repositories, issues, and projects into status dashboards",
-    "installCommand": "claude plugins add minister@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install minister@claude-night-market",
     "tags": [
       "github"
     ],
@@ -15513,7 +15513,7 @@
     "slug": "parseltongue",
     "title": "Parseltongue",
     "description": "Python development suite: testing, performance optimization, async patterns, and packaging guidance",
-    "installCommand": "claude plugins add parseltongue@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install parseltongue@claude-night-market",
     "tags": [
       "python",
       "testing",
@@ -15534,7 +15534,7 @@
     "slug": "pensive",
     "title": "Pensive",
     "description": "Multi-discipline code review: architecture, bugs, APIs, blast radius analysis, security, tests, Makefiles, and NASA Power of 10 analysis",
-    "installCommand": "claude plugins add pensive@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install pensive@claude-night-market",
     "tags": [
       "security",
       "api"
@@ -15554,7 +15554,7 @@
     "slug": "phantom",
     "title": "Phantom",
     "description": "Computer use toolkit for driving desktop environments through Claude's vision and action API with screenshot capture, mouse/keyboard control, and an autonomous agent loop",
-    "installCommand": "claude plugins add phantom@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install phantom@claude-night-market",
     "tags": [
       "api",
       "agent"
@@ -15574,7 +15574,7 @@
     "slug": "sanctum",
     "title": "Sanctum",
     "description": "Git workflows: commit messages, PR preparation, documentation updates, version management, sessions, and deferred-item capture",
-    "installCommand": "claude plugins add sanctum@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install sanctum@claude-night-market",
     "tags": [],
     "author": {
       "name": "athola",
@@ -15591,7 +15591,7 @@
     "slug": "scribe",
     "title": "Scribe",
     "description": "Documentation review, cleanup, and generation with AI slop detection, style learning, and human-quality writing enforcement",
-    "installCommand": "claude plugins add scribe@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install scribe@claude-night-market",
     "tags": [
       "ai"
     ],
@@ -15610,7 +15610,7 @@
     "slug": "scry",
     "title": "Scry",
     "description": "Media generation: terminal recordings (VHS), browser recordings (Playwright), GIF processing, and media composition",
-    "installCommand": "claude plugins add scry@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install scry@claude-night-market",
     "tags": [
       "browser"
     ],
@@ -15629,7 +15629,7 @@
     "slug": "spec-kit",
     "title": "Spec Kit",
     "description": "Specification-driven development: structured specs, implementation planning, and task orchestration for systematic feature delivery",
-    "installCommand": "claude plugins add spec-kit@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install spec-kit@claude-night-market",
     "tags": [],
     "author": {
       "name": "athola",
@@ -15646,7 +15646,7 @@
     "slug": "egregore",
     "title": "Egregore",
     "description": "Autonomous agent orchestrator: parallel worktree execution, agent specialization, cross-item learning, and crash recovery",
-    "installCommand": "claude plugins add egregore@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install egregore@claude-night-market",
     "tags": [
       "go",
       "agent"
@@ -15666,7 +15666,7 @@
     "slug": "gauntlet",
     "title": "Gauntlet",
     "description": "Codebase learning through knowledge extraction, code knowledge graph, adaptive challenges, and spaced repetition for developer onboarding and fluency",
-    "installCommand": "claude plugins add gauntlet@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install gauntlet@claude-night-market",
     "tags": [],
     "author": {
       "name": "athola",
@@ -15683,7 +15683,7 @@
     "slug": "herald",
     "title": "Herald",
     "description": "Standalone notification system: GitHub issue alerts and webhook support for Slack, Discord, and generic endpoints.",
-    "installCommand": "claude plugins add herald@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install herald@claude-night-market",
     "tags": [
       "github",
       "slack",
@@ -15704,7 +15704,7 @@
     "slug": "oracle",
     "title": "Oracle",
     "description": "ONNX Runtime inference daemon for ML-enhanced plugin capabilities with local model inference over HTTP and opt-in activation",
-    "installCommand": "claude plugins add oracle@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install oracle@claude-night-market",
     "tags": [],
     "author": {
       "name": "athola",
@@ -15721,7 +15721,7 @@
     "slug": "tome",
     "title": "Tome",
     "description": "Multi-source research: code archaeology, community discourse (HN, Reddit), academic literature (arXiv, Semantic Scholar), and TRIZ cross-domain analysis",
-    "installCommand": "claude plugins add tome@claude-night-market",
+    "installCommand": "/plugin marketplace add athola/claude-night-market && /plugin install tome@claude-night-market",
     "tags": [
       "ai"
     ],
@@ -15740,7 +15740,7 @@
     "slug": "access-control-rbac",
     "title": "Access Control Rbac",
     "description": "Role-based access control (RBAC) with permissions and policies. Use for admin dashboards, enterprise access, multi-tenant apps, fine-grained authorization, or encountering permission hierarchies, role inheritance, policy conflicts.",
-    "installCommand": "claude plugins add access-control-rbac@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install access-control-rbac@claude-skills",
     "tags": [
       "security",
       "ai"
@@ -15761,7 +15761,7 @@
     "slug": "aceternity-ui",
     "title": "Aceternity Ui",
     "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
-    "installCommand": "claude plugins add aceternity-ui@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install aceternity-ui@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -15783,7 +15783,7 @@
     "slug": "ai-elements-chatbot",
     "title": "Ai Elements Chatbot",
     "description": "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.",
-    "installCommand": "claude plugins add ai-elements-chatbot@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ai-elements-chatbot@claude-skills",
     "tags": [
       "ai"
     ],
@@ -15803,7 +15803,7 @@
     "slug": "ai-sdk-core",
     "title": "Ai Sdk Core",
     "description": "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.",
-    "installCommand": "claude plugins add ai-sdk-core@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ai-sdk-core@claude-skills",
     "tags": [
       "ai",
       "vercel",
@@ -15826,7 +15826,7 @@
     "slug": "ai-sdk-ui",
     "title": "Ai Sdk Ui",
     "description": "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.",
-    "installCommand": "claude plugins add ai-sdk-ui@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ai-sdk-ui@claude-skills",
     "tags": [
       "ai",
       "react",
@@ -15848,7 +15848,7 @@
     "slug": "api-authentication",
     "title": "Api Authentication",
     "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
-    "installCommand": "claude plugins add api-authentication@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-authentication@claude-skills",
     "tags": [
       "auth",
       "security",
@@ -15870,7 +15870,7 @@
     "slug": "api-changelog-versioning",
     "title": "Api Changelog Versioning",
     "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
-    "installCommand": "claude plugins add api-changelog-versioning@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-changelog-versioning@claude-skills",
     "tags": [
       "api"
     ],
@@ -15890,7 +15890,7 @@
     "slug": "api-contract-testing",
     "title": "Api Contract Testing",
     "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
-    "installCommand": "claude plugins add api-contract-testing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-contract-testing@claude-skills",
     "tags": [
       "api",
       "testing"
@@ -15911,7 +15911,7 @@
     "slug": "api-design-principles",
     "title": "Api Design Principles",
     "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
-    "installCommand": "claude plugins add api-design-principles@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-design-principles@claude-skills",
     "tags": [
       "api",
       "graphql",
@@ -15934,7 +15934,7 @@
     "slug": "api-error-handling",
     "title": "Api Error Handling",
     "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
-    "installCommand": "claude plugins add api-error-handling@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-error-handling@claude-skills",
     "tags": [
       "api",
       "monitoring"
@@ -15955,7 +15955,7 @@
     "slug": "api-filtering-sorting",
     "title": "Api Filtering Sorting",
     "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
-    "installCommand": "claude plugins add api-filtering-sorting@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-filtering-sorting@claude-skills",
     "tags": [
       "api",
       "security"
@@ -15976,7 +15976,7 @@
     "slug": "api-gateway-configuration",
     "title": "Api Gateway Configuration",
     "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
-    "installCommand": "claude plugins add api-gateway-configuration@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-gateway-configuration@claude-skills",
     "tags": [
       "api",
       "aws"
@@ -15997,7 +15997,7 @@
     "slug": "api-pagination",
     "title": "Api Pagination",
     "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
-    "installCommand": "claude plugins add api-pagination@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-pagination@claude-skills",
     "tags": [
       "api"
     ],
@@ -16017,7 +16017,7 @@
     "slug": "api-rate-limiting",
     "title": "Api Rate Limiting",
     "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
-    "installCommand": "claude plugins add api-rate-limiting@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-rate-limiting@claude-skills",
     "tags": [
       "api",
       "go",
@@ -16040,7 +16040,7 @@
     "slug": "api-reference-documentation",
     "title": "Api Reference Documentation",
     "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
-    "installCommand": "claude plugins add api-reference-documentation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-reference-documentation@claude-skills",
     "tags": [
       "api",
       "rest"
@@ -16061,7 +16061,7 @@
     "slug": "api-response-optimization",
     "title": "Api Response Optimization",
     "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
-    "installCommand": "claude plugins add api-response-optimization@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-response-optimization@claude-skills",
     "tags": [
       "api",
       "performance"
@@ -16082,7 +16082,7 @@
     "slug": "api-security-hardening",
     "title": "Api Security Hardening",
     "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
-    "installCommand": "claude plugins add api-security-hardening@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-security-hardening@claude-skills",
     "tags": [
       "api",
       "security",
@@ -16104,7 +16104,7 @@
     "slug": "api-testing",
     "title": "Api Testing",
     "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
-    "installCommand": "claude plugins add api-testing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-testing@claude-skills",
     "tags": [
       "api",
       "python",
@@ -16129,7 +16129,7 @@
     "slug": "api-versioning-strategy",
     "title": "Api Versioning Strategy",
     "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
-    "installCommand": "claude plugins add api-versioning-strategy@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install api-versioning-strategy@claude-skills",
     "tags": [
       "api"
     ],
@@ -16149,7 +16149,7 @@
     "slug": "app-store-deployment",
     "title": "App Store Deployment",
     "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
-    "installCommand": "claude plugins add app-store-deployment@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install app-store-deployment@claude-skills",
     "tags": [
       "mobile",
       "go",
@@ -16172,7 +16172,7 @@
     "slug": "architecture-patterns",
     "title": "Architecture Patterns",
     "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
-    "installCommand": "claude plugins add architecture-patterns@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install architecture-patterns@claude-skills",
     "tags": [
       "architecture",
       "go",
@@ -16194,7 +16194,7 @@
     "slug": "auto-animate",
     "title": "Auto Animate",
     "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
-    "installCommand": "claude plugins add auto-animate@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install auto-animate@claude-skills",
     "tags": [
       "frontend",
       "react"
@@ -16215,7 +16215,7 @@
     "slug": "base-ui-react",
     "title": "Base Ui React",
     "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
-    "installCommand": "claude plugins add base-ui-react@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install base-ui-react@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -16237,7 +16237,7 @@
     "slug": "better-auth",
     "title": "Better Auth",
     "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-    "installCommand": "claude plugins add better-auth@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install better-auth@claude-skills",
     "tags": [
       "auth",
       "typescript",
@@ -16259,7 +16259,7 @@
     "slug": "better-chatbot",
     "title": "Better Chatbot",
     "description": "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.",
-    "installCommand": "claude plugins add better-chatbot@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install better-chatbot@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -16279,7 +16279,7 @@
     "slug": "better-chatbot-patterns",
     "title": "Better Chatbot Patterns",
     "description": "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.",
-    "installCommand": "claude plugins add better-chatbot-patterns@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install better-chatbot-patterns@claude-skills",
     "tags": [
       "tooling",
       "deployment",
@@ -16301,7 +16301,7 @@
     "slug": "bun",
     "title": "Bun",
     "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
-    "installCommand": "claude plugins add bun@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install bun@claude-skills",
     "tags": [
       "tooling",
       "node",
@@ -16324,7 +16324,7 @@
     "slug": "chrome-devtools",
     "title": "Chrome Devtools",
     "description": "Browser automation with Puppeteer CLI scripts. Use for screenshots, performance analysis, network monitoring, web scraping, form automation, or encountering JavaScript debugging, browser automation errors.",
-    "installCommand": "claude plugins add chrome-devtools@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install chrome-devtools@claude-skills",
     "tags": [
       "tooling",
       "javascript",
@@ -16351,7 +16351,7 @@
     "slug": "claude-agent-sdk",
     "title": "Claude Agent Sdk",
     "description": "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.",
-    "installCommand": "claude plugins add claude-agent-sdk@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install claude-agent-sdk@claude-skills",
     "tags": [
       "ai",
       "agent"
@@ -16372,7 +16372,7 @@
     "slug": "claude-api",
     "title": "Claude Api",
     "description": "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.",
-    "installCommand": "claude plugins add claude-api@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install claude-api@claude-skills",
     "tags": [
       "ai",
       "api"
@@ -16393,7 +16393,7 @@
     "slug": "claude-code-bash-patterns",
     "title": "Claude Code Bash Patterns",
     "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
-    "installCommand": "claude plugins add claude-code-bash-patterns@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install claude-code-bash-patterns@claude-skills",
     "tags": [
       "tooling",
       "security",
@@ -16416,7 +16416,7 @@
     "slug": "claude-hook-writer",
     "title": "Claude Hook Writer",
     "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
-    "installCommand": "claude plugins add claude-hook-writer@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install claude-hook-writer@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -16436,7 +16436,7 @@
     "slug": "cloudflare-agents",
     "title": "Cloudflare Agents",
     "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
-    "installCommand": "claude plugins add cloudflare-agents@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-agents@claude-skills",
     "tags": [
       "cloudflare",
       "ai",
@@ -16459,7 +16459,7 @@
     "slug": "cloudflare-browser-rendering",
     "title": "Cloudflare Browser Rendering",
     "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
-    "installCommand": "claude plugins add cloudflare-browser-rendering@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-browser-rendering@claude-skills",
     "tags": [
       "cloudflare",
       "browser",
@@ -16482,7 +16482,7 @@
     "slug": "cloudflare-cron-triggers",
     "title": "Cloudflare Cron Triggers",
     "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
-    "installCommand": "claude plugins add cloudflare-cron-triggers@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-cron-triggers@claude-skills",
     "tags": [
       "cloudflare"
     ],
@@ -16502,7 +16502,7 @@
     "slug": "cloudflare-d1",
     "title": "Cloudflare D1",
     "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
-    "installCommand": "claude plugins add cloudflare-d1@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-d1@claude-skills",
     "tags": [
       "cloudflare",
       "sqlite"
@@ -16523,7 +16523,7 @@
     "slug": "cloudflare-durable-objects",
     "title": "Cloudflare Durable Objects",
     "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
-    "installCommand": "claude plugins add cloudflare-durable-objects@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-durable-objects@claude-skills",
     "tags": [
       "cloudflare"
     ],
@@ -16543,7 +16543,7 @@
     "slug": "cloudflare-email-routing",
     "title": "Cloudflare Email Routing",
     "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
-    "installCommand": "claude plugins add cloudflare-email-routing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-email-routing@claude-skills",
     "tags": [
       "cloudflare",
       "ai"
@@ -16564,7 +16564,7 @@
     "slug": "cloudflare-hyperdrive",
     "title": "Cloudflare Hyperdrive",
     "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
-    "installCommand": "claude plugins add cloudflare-hyperdrive@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-hyperdrive@claude-skills",
     "tags": [
       "cloudflare",
       "postgres",
@@ -16585,8 +16585,8 @@
   {
     "slug": "cloudflare-images",
     "title": "Cloudflare Images",
-    "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"co…",
-    "installCommand": "claude plugins add cloudflare-images@claude-skills",
+    "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"co\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-images@claude-skills",
     "tags": [
       "cloudflare"
     ],
@@ -16606,7 +16606,7 @@
     "slug": "cloudflare-kv",
     "title": "Cloudflare Kv",
     "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
-    "installCommand": "claude plugins add cloudflare-kv@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-kv@claude-skills",
     "tags": [
       "cloudflare",
       "rag"
@@ -16626,8 +16626,8 @@
   {
     "slug": "cloudflare-manager",
     "title": "Cloudflare Manager",
-    "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtim…",
-    "installCommand": "claude plugins add cloudflare-manager@claude-skills",
+    "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtim\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-manager@claude-skills",
     "tags": [
       "cloudflare",
       "api",
@@ -16650,7 +16650,7 @@
     "slug": "cloudflare-mcp-server",
     "title": "Cloudflare Mcp Server",
     "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
-    "installCommand": "claude plugins add cloudflare-mcp-server@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-mcp-server@claude-skills",
     "tags": [
       "cloudflare"
     ],
@@ -16670,7 +16670,7 @@
     "slug": "cloudflare-nextjs",
     "title": "Cloudflare Nextjs",
     "description": "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.",
-    "installCommand": "claude plugins add cloudflare-nextjs@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-nextjs@claude-skills",
     "tags": [
       "cloudflare",
       "nextjs"
@@ -16690,8 +16690,8 @@
   {
     "slug": "cloudflare-queues",
     "title": "Cloudflare Queues",
-    "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\"…",
-    "installCommand": "claude plugins add cloudflare-queues@claude-skills",
+    "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\"\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-queues@claude-skills",
     "tags": [
       "cloudflare"
     ],
@@ -16711,7 +16711,7 @@
     "slug": "cloudflare-r2",
     "title": "Cloudflare R2",
     "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
-    "installCommand": "claude plugins add cloudflare-r2@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-r2@claude-skills",
     "tags": [
       "cloudflare",
       "automation",
@@ -16734,7 +16734,7 @@
     "slug": "cloudflare-sandbox",
     "title": "Cloudflare Sandbox",
     "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
-    "installCommand": "claude plugins add cloudflare-sandbox@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-sandbox@claude-skills",
     "tags": [
       "cloudflare",
       "python",
@@ -16758,7 +16758,7 @@
     "slug": "cloudflare-turnstile",
     "title": "Cloudflare Turnstile",
     "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
-    "installCommand": "claude plugins add cloudflare-turnstile@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-turnstile@claude-skills",
     "tags": [
       "cloudflare",
       "security",
@@ -16781,7 +16781,7 @@
     "slug": "cloudflare-vectorize",
     "title": "Cloudflare Vectorize",
     "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
-    "installCommand": "claude plugins add cloudflare-vectorize@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-vectorize@claude-skills",
     "tags": [
       "cloudflare",
       "embedding",
@@ -16803,7 +16803,7 @@
     "slug": "cloudflare-workers",
     "title": "Cloudflare Workers",
     "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
-    "installCommand": "claude plugins add cloudflare-workers@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-workers@claude-skills",
     "tags": [
       "cloudflare",
       "security",
@@ -16828,7 +16828,7 @@
     "slug": "cloudflare-workers-ai",
     "title": "Cloudflare Workers Ai",
     "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
-    "installCommand": "claude plugins add cloudflare-workers-ai@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-workers-ai@claude-skills",
     "tags": [
       "cloudflare",
       "ai",
@@ -16851,7 +16851,7 @@
     "slug": "cloudflare-workflows",
     "title": "Cloudflare Workflows",
     "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
-    "installCommand": "claude plugins add cloudflare-workflows@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-workflows@claude-skills",
     "tags": [
       "cloudflare",
       "ai"
@@ -16872,7 +16872,7 @@
     "slug": "cloudflare-zero-trust-access",
     "title": "Cloudflare Zero Trust Access",
     "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
-    "installCommand": "claude plugins add cloudflare-zero-trust-access@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install cloudflare-zero-trust-access@claude-skills",
     "tags": [
       "cloudflare",
       "rust"
@@ -16892,8 +16892,8 @@
   {
     "slug": "content-collections",
     "title": "Content Collections",
-    "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation error…",
-    "installCommand": "claude plugins add content-collections@claude-skills",
+    "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation error\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install content-collections@claude-skills",
     "tags": [
       "cms",
       "typescript",
@@ -16915,7 +16915,7 @@
     "slug": "csrf-protection",
     "title": "Csrf Protection",
     "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
-    "installCommand": "claude plugins add csrf-protection@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install csrf-protection@claude-skills",
     "tags": [
       "security"
     ],
@@ -16935,7 +16935,7 @@
     "slug": "database-schema-design",
     "title": "Database Schema Design",
     "description": "Database schema design for PostgreSQL/MySQL with normalization, relationships, constraints. Use for new databases, schema reviews, migrations, or encountering missing PKs/FKs, wrong data types, premature denormalization, EAV anti-pattern.",
-    "installCommand": "claude plugins add database-schema-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install database-schema-design@claude-skills",
     "tags": [
       "database",
       "postgres",
@@ -16958,7 +16958,7 @@
     "slug": "database-sharding",
     "title": "Database Sharding",
     "description": "Database sharding for PostgreSQL/MySQL with hash/range/directory strategies. Use for horizontal scaling, multi-tenant isolation, billions of records, or encountering wrong shard keys, hotspots, cross-shard transactions, rebalancing issues.",
-    "installCommand": "claude plugins add database-sharding@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install database-sharding@claude-skills",
     "tags": [
       "database",
       "postgres",
@@ -16980,7 +16980,7 @@
     "slug": "defense-in-depth-validation",
     "title": "Defense In Depth Validation",
     "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
-    "installCommand": "claude plugins add defense-in-depth-validation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install defense-in-depth-validation@claude-skills",
     "tags": [
       "security",
       "ai"
@@ -17001,7 +17001,7 @@
     "slug": "dependency-upgrade",
     "title": "Dependency Upgrade",
     "description": "Secure dependency upgrades with supply chain protection, cooldown periods, post-install script hardening, lockfile validation, and staged rollout across npm, Bun, pnpm, and Yarn. Use when upgrading dependencies, configuring security policies, or preventing supply chain attacks.",
-    "installCommand": "claude plugins add dependency-upgrade@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install dependency-upgrade@claude-skills",
     "tags": [
       "tooling",
       "security",
@@ -17023,7 +17023,7 @@
     "slug": "design-review",
     "title": "Design Review",
     "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
-    "installCommand": "claude plugins add design-review@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install design-review@claude-skills",
     "tags": [
       "design",
       "testing"
@@ -17044,7 +17044,7 @@
     "slug": "design-system-creation",
     "title": "Design System Creation",
     "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
-    "installCommand": "claude plugins add design-system-creation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install design-system-creation@claude-skills",
     "tags": [
       "design"
     ],
@@ -17063,8 +17063,8 @@
   {
     "slug": "drizzle-orm-d1",
     "title": "Drizzle Orm D1",
-    "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transac…",
-    "installCommand": "claude plugins add drizzle-orm-d1@claude-skills",
+    "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transac\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install drizzle-orm-d1@claude-skills",
     "tags": [
       "database",
       "cloudflare",
@@ -17086,7 +17086,7 @@
     "slug": "elevenlabs-agents",
     "title": "Elevenlabs Agents",
     "description": "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.",
-    "installCommand": "claude plugins add elevenlabs-agents@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install elevenlabs-agents@claude-skills",
     "tags": [
       "ai",
       "swift",
@@ -17110,7 +17110,7 @@
     "slug": "fastmcp",
     "title": "Fastmcp",
     "description": "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.",
-    "installCommand": "claude plugins add fastmcp@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install fastmcp@claude-skills",
     "tags": [
       "tooling",
       "python",
@@ -17134,7 +17134,7 @@
     "slug": "firecrawl-scraper",
     "title": "Firecrawl Scraper",
     "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
-    "installCommand": "claude plugins add firecrawl-scraper@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install firecrawl-scraper@claude-skills",
     "tags": [
       "web",
       "javascript",
@@ -17158,7 +17158,7 @@
     "slug": "gemini-cli",
     "title": "Gemini Cli",
     "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
-    "installCommand": "claude plugins add gemini-cli@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install gemini-cli@claude-skills",
     "tags": [
       "ai",
       "go",
@@ -17181,7 +17181,7 @@
     "slug": "github-project-automation",
     "title": "Github Project Automation",
     "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
-    "installCommand": "claude plugins add github-project-automation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install github-project-automation@claude-skills",
     "tags": [
       "tooling",
       "github",
@@ -17204,7 +17204,7 @@
     "slug": "google-gemini-api",
     "title": "Google Gemini Api",
     "description": "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.",
-    "installCommand": "claude plugins add google-gemini-api@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install google-gemini-api@claude-skills",
     "tags": [
       "ai",
       "go",
@@ -17226,7 +17226,7 @@
     "slug": "google-gemini-embeddings",
     "title": "Google Gemini Embeddings",
     "description": "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.",
-    "installCommand": "claude plugins add google-gemini-embeddings@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install google-gemini-embeddings@claude-skills",
     "tags": [
       "ai",
       "go",
@@ -17250,7 +17250,7 @@
     "slug": "google-gemini-file-search",
     "title": "Google Gemini File Search",
     "description": "Google Gemini File Search for managed RAG with 100+ file formats. Use for document Q&A, knowledge bases, or encountering immutability errors, quota issues, polling failures. Supports Gemini 3 Pro/Flash (Gemini 2.5 legacy).",
-    "installCommand": "claude plugins add google-gemini-file-search@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install google-gemini-file-search@claude-skills",
     "tags": [
       "ai",
       "go",
@@ -17272,7 +17272,7 @@
     "slug": "graphql-implementation",
     "title": "Graphql Implementation",
     "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
-    "installCommand": "claude plugins add graphql-implementation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install graphql-implementation@claude-skills",
     "tags": [
       "api",
       "performance",
@@ -17295,7 +17295,7 @@
     "slug": "health-check-endpoints",
     "title": "Health Check Endpoints",
     "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
-    "installCommand": "claude plugins add health-check-endpoints@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install health-check-endpoints@claude-skills",
     "tags": [
       "architecture",
       "kubernetes",
@@ -17318,7 +17318,7 @@
     "slug": "hono-routing",
     "title": "Hono Routing",
     "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
-    "installCommand": "claude plugins add hono-routing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install hono-routing@claude-skills",
     "tags": [
       "web",
       "api"
@@ -17339,7 +17339,7 @@
     "slug": "hugo",
     "title": "Hugo",
     "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
-    "installCommand": "claude plugins add hugo@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install hugo@claude-skills",
     "tags": [
       "cms",
       "go",
@@ -17363,7 +17363,7 @@
     "slug": "idempotency-handling",
     "title": "Idempotency Handling",
     "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
-    "installCommand": "claude plugins add idempotency-handling@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install idempotency-handling@claude-skills",
     "tags": [
       "tooling",
       "redis",
@@ -17386,7 +17386,7 @@
     "slug": "image-optimization",
     "title": "Image Optimization",
     "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
-    "installCommand": "claude plugins add image-optimization@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install image-optimization@claude-skills",
     "tags": [
       "web",
       "performance",
@@ -17408,7 +17408,7 @@
     "slug": "inspira-ui",
     "title": "Inspira Ui",
     "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
-    "installCommand": "claude plugins add inspira-ui@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install inspira-ui@claude-skills",
     "tags": [
       "frontend",
       "vue",
@@ -17430,7 +17430,7 @@
     "slug": "interaction-design",
     "title": "Interaction Design",
     "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
-    "installCommand": "claude plugins add interaction-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install interaction-design@claude-skills",
     "tags": [
       "design"
     ],
@@ -17450,7 +17450,7 @@
     "slug": "internationalization-i18n",
     "title": "Internationalization I18n",
     "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
-    "installCommand": "claude plugins add internationalization-i18n@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install internationalization-i18n@claude-skills",
     "tags": [
       "web",
       "api"
@@ -17471,7 +17471,7 @@
     "slug": "jest-generator",
     "title": "Jest Generator",
     "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
-    "installCommand": "claude plugins add jest-generator@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install jest-generator@claude-skills",
     "tags": [
       "testing",
       "typescript",
@@ -17495,7 +17495,7 @@
     "slug": "kpi-dashboard-design",
     "title": "Kpi Dashboard Design",
     "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
-    "installCommand": "claude plugins add kpi-dashboard-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install kpi-dashboard-design@claude-skills",
     "tags": [
       "design"
     ],
@@ -17515,7 +17515,7 @@
     "slug": "logging-best-practices",
     "title": "Logging Best Practices",
     "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
-    "installCommand": "claude plugins add logging-best-practices@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install logging-best-practices@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -17535,7 +17535,7 @@
     "slug": "maz-ui",
     "title": "Maz Ui",
     "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
-    "installCommand": "claude plugins add maz-ui@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install maz-ui@claude-skills",
     "tags": [
       "tooling",
       "vue"
@@ -17556,7 +17556,7 @@
     "slug": "mcp-dynamic-orchestrator",
     "title": "Mcp Dynamic Orchestrator",
     "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
-    "installCommand": "claude plugins add mcp-dynamic-orchestrator@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mcp-dynamic-orchestrator@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -17576,7 +17576,7 @@
     "slug": "mcp-management",
     "title": "Mcp Management",
     "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
-    "installCommand": "claude plugins add mcp-management@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mcp-management@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -17596,7 +17596,7 @@
     "slug": "microservices-patterns",
     "title": "Microservices Patterns",
     "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
-    "installCommand": "claude plugins add microservices-patterns@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install microservices-patterns@claude-skills",
     "tags": [
       "architecture"
     ],
@@ -17616,7 +17616,7 @@
     "slug": "ml-model-training",
     "title": "Ml Model Training",
     "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
-    "installCommand": "claude plugins add ml-model-training@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ml-model-training@claude-skills",
     "tags": [
       "ai"
     ],
@@ -17636,7 +17636,7 @@
     "slug": "ml-pipeline-automation",
     "title": "Ml Pipeline Automation",
     "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
-    "installCommand": "claude plugins add ml-pipeline-automation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ml-pipeline-automation@claude-skills",
     "tags": [
       "ai",
       "automation"
@@ -17657,7 +17657,7 @@
     "slug": "mobile-app-debugging",
     "title": "Mobile App Debugging",
     "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
-    "installCommand": "claude plugins add mobile-app-debugging@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mobile-app-debugging@claude-skills",
     "tags": [
       "mobile",
       "react",
@@ -17679,7 +17679,7 @@
     "slug": "mobile-app-testing",
     "title": "Mobile App Testing",
     "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
-    "installCommand": "claude plugins add mobile-app-testing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mobile-app-testing@claude-skills",
     "tags": [
       "mobile",
       "testing",
@@ -17702,7 +17702,7 @@
     "slug": "mobile-first-design",
     "title": "Mobile First Design",
     "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
-    "installCommand": "claude plugins add mobile-first-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mobile-first-design@claude-skills",
     "tags": [
       "mobile"
     ],
@@ -17722,7 +17722,7 @@
     "slug": "mobile-offline-support",
     "title": "Mobile Offline Support",
     "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
-    "installCommand": "claude plugins add mobile-offline-support@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mobile-offline-support@claude-skills",
     "tags": [
       "mobile",
       "rag"
@@ -17743,7 +17743,7 @@
     "slug": "model-deployment",
     "title": "Model Deployment",
     "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
-    "installCommand": "claude plugins add model-deployment@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install model-deployment@claude-skills",
     "tags": [
       "ai",
       "kubernetes",
@@ -17768,7 +17768,7 @@
     "slug": "motion",
     "title": "Motion",
     "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
-    "installCommand": "claude plugins add motion@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install motion@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -17790,7 +17790,7 @@
     "slug": "multi-ai-consultant",
     "title": "Multi Ai Consultant",
     "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
-    "installCommand": "claude plugins add multi-ai-consultant@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install multi-ai-consultant@claude-skills",
     "tags": [
       "ai",
       "security"
@@ -17811,7 +17811,7 @@
     "slug": "mutation-testing",
     "title": "Mutation Testing",
     "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-    "installCommand": "claude plugins add mutation-testing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install mutation-testing@claude-skills",
     "tags": [
       "testing",
       "python",
@@ -17834,7 +17834,7 @@
     "slug": "nano-banana-prompts",
     "title": "Nano Banana Prompts",
     "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
-    "installCommand": "claude plugins add nano-banana-prompts@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nano-banana-prompts@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -17853,8 +17853,8 @@
   {
     "slug": "neon-vercel-postgres",
     "title": "Neon Vercel Postgres",
-    "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool…",
-    "installCommand": "claude plugins add neon-vercel-postgres@claude-skills",
+    "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install neon-vercel-postgres@claude-skills",
     "tags": [
       "database",
       "postgres",
@@ -17877,7 +17877,7 @@
     "slug": "nextjs",
     "title": "Nextjs",
     "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
-    "installCommand": "claude plugins add nextjs@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nextjs@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -17898,8 +17898,8 @@
   {
     "slug": "nuxt-content",
     "title": "Nuxt Content",
-    "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Verce…",
-    "installCommand": "claude plugins add nuxt-content@claude-skills",
+    "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Verce\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-content@claude-skills",
     "tags": [
       "frontend",
       "cloudflare",
@@ -17920,8 +17920,8 @@
   {
     "slug": "nuxt-seo",
     "title": "Nuxt Seo",
-    "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, …",
-    "installCommand": "claude plugins add nuxt-seo@claude-skills",
+    "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, \u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-seo@claude-skills",
     "tags": [
       "frontend"
     ],
@@ -17941,7 +17941,7 @@
     "slug": "nuxt-studio",
     "title": "Nuxt Studio",
     "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
-    "installCommand": "claude plugins add nuxt-studio@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-studio@claude-skills",
     "tags": [
       "frontend",
       "cloudflare",
@@ -17964,7 +17964,7 @@
     "slug": "nuxt-ui-v4",
     "title": "Nuxt Ui V4",
     "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
-    "installCommand": "claude plugins add nuxt-ui-v4@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-ui-v4@claude-skills",
     "tags": [
       "frontend",
       "typescript",
@@ -17985,8 +17985,8 @@
   {
     "slug": "nuxt-v4",
     "title": "Nuxt V4",
-    "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, …",
-    "installCommand": "claude plugins add nuxt-v4@claude-skills",
+    "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, \u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-v4@claude-skills",
     "tags": [
       "frontend",
       "performance",
@@ -18007,8 +18007,8 @@
   {
     "slug": "nuxt-v5",
     "title": "Nuxt V5",
-    "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, …",
-    "installCommand": "claude plugins add nuxt-v5@claude-skills",
+    "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, \u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install nuxt-v5@claude-skills",
     "tags": [
       "frontend",
       "performance",
@@ -18030,7 +18030,7 @@
     "slug": "oauth-implementation",
     "title": "Oauth Implementation",
     "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
-    "installCommand": "claude plugins add oauth-implementation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install oauth-implementation@claude-skills",
     "tags": [
       "auth",
       "api"
@@ -18051,7 +18051,7 @@
     "slug": "openai-agents",
     "title": "Openai Agents",
     "description": "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.",
-    "installCommand": "claude plugins add openai-agents@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install openai-agents@claude-skills",
     "tags": [
       "ai",
       "typescript",
@@ -18074,7 +18074,7 @@
     "slug": "openai-api",
     "title": "Openai Api",
     "description": "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.",
-    "installCommand": "claude plugins add openai-api@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install openai-api@claude-skills",
     "tags": [
       "ai",
       "node",
@@ -18096,8 +18096,8 @@
   {
     "slug": "openai-assistants",
     "title": "Openai Assistants",
-    "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.",
-    "installCommand": "claude plugins add openai-assistants@claude-skills",
+    "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. \u26a0\ufe0f Sunset August 26, 2026.",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install openai-assistants@claude-skills",
     "tags": [
       "ai",
       "api",
@@ -18119,7 +18119,7 @@
     "slug": "openai-responses",
     "title": "Openai Responses",
     "description": "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.",
-    "installCommand": "claude plugins add openai-responses@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install openai-responses@claude-skills",
     "tags": [
       "ai",
       "api",
@@ -18141,7 +18141,7 @@
     "slug": "payment-gateway-integration",
     "title": "Payment Gateway Integration",
     "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
-    "installCommand": "claude plugins add payment-gateway-integration@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install payment-gateway-integration@claude-skills",
     "tags": [
       "web"
     ],
@@ -18161,7 +18161,7 @@
     "slug": "pinia-colada",
     "title": "Pinia Colada",
     "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
-    "installCommand": "claude plugins add pinia-colada@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install pinia-colada@claude-skills",
     "tags": [
       "frontend",
       "vue"
@@ -18182,7 +18182,7 @@
     "slug": "pinia-v3",
     "title": "Pinia V3",
     "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
-    "installCommand": "claude plugins add pinia-v3@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install pinia-v3@claude-skills",
     "tags": [
       "frontend",
       "vue",
@@ -18204,7 +18204,7 @@
     "slug": "plan-interview",
     "title": "Plan Interview",
     "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-    "installCommand": "claude plugins add plan-interview@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install plan-interview@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -18224,7 +18224,7 @@
     "slug": "progressive-web-app",
     "title": "Progressive Web App",
     "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
-    "installCommand": "claude plugins add progressive-web-app@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install progressive-web-app@claude-skills",
     "tags": [
       "web"
     ],
@@ -18244,7 +18244,7 @@
     "slug": "push-notification-setup",
     "title": "Push Notification Setup",
     "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
-    "installCommand": "claude plugins add push-notification-setup@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install push-notification-setup@claude-skills",
     "tags": [
       "web"
     ],
@@ -18264,7 +18264,7 @@
     "slug": "react-best-practices",
     "title": "React Best Practices",
     "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
-    "installCommand": "claude plugins add react-best-practices@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install react-best-practices@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18287,7 +18287,7 @@
     "slug": "react-composition-patterns",
     "title": "React Composition Patterns",
     "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
-    "installCommand": "claude plugins add react-composition-patterns@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install react-composition-patterns@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18309,7 +18309,7 @@
     "slug": "react-hook-form-zod",
     "title": "React Hook Form Zod",
     "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
-    "installCommand": "claude plugins add react-hook-form-zod@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install react-hook-form-zod@claude-skills",
     "tags": [
       "frontend",
       "react"
@@ -18330,7 +18330,7 @@
     "slug": "react-native-skills",
     "title": "React Native Skills",
     "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
-    "installCommand": "claude plugins add react-native-skills@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install react-native-skills@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18352,7 +18352,7 @@
     "slug": "recommendation-system",
     "title": "Recommendation System",
     "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
-    "installCommand": "claude plugins add recommendation-system@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install recommendation-system@claude-skills",
     "tags": [
       "data",
       "testing",
@@ -18375,7 +18375,7 @@
     "slug": "responsive-web-design",
     "title": "Responsive Web Design",
     "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
-    "installCommand": "claude plugins add responsive-web-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install responsive-web-design@claude-skills",
     "tags": [
       "web",
       "browser"
@@ -18396,7 +18396,7 @@
     "slug": "rest-api-design",
     "title": "Rest Api Design",
     "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
-    "installCommand": "claude plugins add rest-api-design@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install rest-api-design@claude-skills",
     "tags": [
       "api",
       "rest"
@@ -18417,7 +18417,7 @@
     "slug": "root-cause-tracing",
     "title": "Root Cause Tracing",
     "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
-    "installCommand": "claude plugins add root-cause-tracing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install root-cause-tracing@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -18437,7 +18437,7 @@
     "slug": "security-headers-configuration",
     "title": "Security Headers Configuration",
     "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
-    "installCommand": "claude plugins add security-headers-configuration@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install security-headers-configuration@claude-skills",
     "tags": [
       "security",
       "ai"
@@ -18458,7 +18458,7 @@
     "slug": "seo-keyword-cluster-builder",
     "title": "Seo Keyword Cluster Builder",
     "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
-    "installCommand": "claude plugins add seo-keyword-cluster-builder@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install seo-keyword-cluster-builder@claude-skills",
     "tags": [
       "seo"
     ],
@@ -18478,7 +18478,7 @@
     "slug": "seo-optimizer",
     "title": "Seo Optimizer",
     "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
-    "installCommand": "claude plugins add seo-optimizer@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install seo-optimizer@claude-skills",
     "tags": [
       "seo"
     ],
@@ -18498,7 +18498,7 @@
     "slug": "sequential-thinking",
     "title": "Sequential Thinking",
     "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
-    "installCommand": "claude plugins add sequential-thinking@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install sequential-thinking@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -18518,7 +18518,7 @@
     "slug": "session-management",
     "title": "Session Management",
     "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
-    "installCommand": "claude plugins add session-management@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install session-management@claude-skills",
     "tags": [
       "auth",
       "go",
@@ -18541,7 +18541,7 @@
     "slug": "shadcn-vue",
     "title": "Shadcn Vue",
     "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
-    "installCommand": "claude plugins add shadcn-vue@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install shadcn-vue@claude-skills",
     "tags": [
       "frontend",
       "vue",
@@ -18563,7 +18563,7 @@
     "slug": "sql-query-optimization",
     "title": "Sql Query Optimization",
     "description": "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.",
-    "installCommand": "claude plugins add sql-query-optimization@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install sql-query-optimization@claude-skills",
     "tags": [
       "data",
       "postgres",
@@ -18586,7 +18586,7 @@
     "slug": "supabase-postgres-best-practices",
     "title": "Supabase Postgres Best Practices",
     "description": "Postgres performance optimization and best practices from Supabase. 30 rules across 8 categories prioritized by impact.",
-    "installCommand": "claude plugins add supabase-postgres-best-practices@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install supabase-postgres-best-practices@claude-skills",
     "tags": [
       "tooling",
       "go",
@@ -18608,8 +18608,8 @@
   {
     "slug": "sveltia-cms",
     "title": "Sveltia Cms",
-    "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, COR…",
-    "installCommand": "claude plugins add sveltia-cms@claude-skills",
+    "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, COR\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install sveltia-cms@claude-skills",
     "tags": [
       "cms",
       "go",
@@ -18631,8 +18631,8 @@
   {
     "slug": "swift-best-practices",
     "title": "Swift Best Practices",
-    "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 break…",
-    "installCommand": "claude plugins add swift-best-practices@claude-skills",
+    "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 break\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install swift-best-practices@claude-skills",
     "tags": [
       "mobile",
       "swift",
@@ -18655,7 +18655,7 @@
     "slug": "swift-settingskit",
     "title": "Swift Settingskit",
     "description": "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.",
-    "installCommand": "claude plugins add swift-settingskit@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install swift-settingskit@claude-skills",
     "tags": [
       "mobile",
       "swift"
@@ -18676,7 +18676,7 @@
     "slug": "systematic-debugging",
     "title": "Systematic Debugging",
     "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
-    "installCommand": "claude plugins add systematic-debugging@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install systematic-debugging@claude-skills",
     "tags": [
       "tooling",
       "ai"
@@ -18696,8 +18696,8 @@
   {
     "slug": "tailwind-v4-shadcn",
     "title": "Tailwind V4 Shadcn",
-    "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering c…",
-    "installCommand": "claude plugins add tailwind-v4-shadcn@claude-skills",
+    "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering c\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tailwind-v4-shadcn@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18718,8 +18718,8 @@
   {
     "slug": "tanstack-ai",
     "title": "Tanstack Ai",
-    "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and to…",
-    "installCommand": "claude plugins add tanstack-ai@claude-skills",
+    "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and to\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tanstack-ai@claude-skills",
     "tags": [
       "ai",
       "react",
@@ -18742,7 +18742,7 @@
     "slug": "tanstack-query",
     "title": "Tanstack Query",
     "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
-    "installCommand": "claude plugins add tanstack-query@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tanstack-query@claude-skills",
     "tags": [
       "frontend",
       "react"
@@ -18763,7 +18763,7 @@
     "slug": "tanstack-router",
     "title": "Tanstack Router",
     "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
-    "installCommand": "claude plugins add tanstack-router@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tanstack-router@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18785,7 +18785,7 @@
     "slug": "tanstack-start",
     "title": "Tanstack Start",
     "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
-    "installCommand": "claude plugins add tanstack-start@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tanstack-start@claude-skills",
     "tags": [
       "frontend",
       "react",
@@ -18807,7 +18807,7 @@
     "slug": "tanstack-table",
     "title": "Tanstack Table",
     "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
-    "installCommand": "claude plugins add tanstack-table@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install tanstack-table@claude-skills",
     "tags": [
       "frontend",
       "cloudflare"
@@ -18828,7 +18828,7 @@
     "slug": "technical-specification",
     "title": "Technical Specification",
     "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
-    "installCommand": "claude plugins add technical-specification@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install technical-specification@claude-skills",
     "tags": [
       "documentation",
       "testing",
@@ -18851,7 +18851,7 @@
     "slug": "test-quality-analysis",
     "title": "Test Quality Analysis",
     "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
-    "installCommand": "claude plugins add test-quality-analysis@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install test-quality-analysis@claude-skills",
     "tags": [
       "testing",
       "ai",
@@ -18873,7 +18873,7 @@
     "slug": "thesys-generative-ui",
     "title": "Thesys Generative Ui",
     "description": "AI-powered generative UI with Thesys - create React components from natural language.",
-    "installCommand": "claude plugins add thesys-generative-ui@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install thesys-generative-ui@claude-skills",
     "tags": [
       "ai",
       "react"
@@ -18894,7 +18894,7 @@
     "slug": "threejs",
     "title": "Threejs",
     "description": "Comprehensive Three.js skills for building 3D web experiences",
-    "installCommand": "claude plugins add threejs@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install threejs@claude-skills",
     "tags": [
       "tooling"
     ],
@@ -18914,7 +18914,7 @@
     "slug": "turborepo",
     "title": "Turborepo",
     "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
-    "installCommand": "claude plugins add turborepo@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install turborepo@claude-skills",
     "tags": [
       "tooling",
       "performance"
@@ -18935,7 +18935,7 @@
     "slug": "typescript-mcp",
     "title": "Typescript Mcp",
     "description": "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.",
-    "installCommand": "claude plugins add typescript-mcp@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install typescript-mcp@claude-skills",
     "tags": [
       "tooling",
       "typescript",
@@ -18959,7 +18959,7 @@
     "slug": "ultracite",
     "title": "Ultracite",
     "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
-    "installCommand": "claude plugins add ultracite@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install ultracite@claude-skills",
     "tags": [
       "frontend",
       "ai"
@@ -18980,7 +18980,7 @@
     "slug": "vercel-blob",
     "title": "Vercel Blob",
     "description": "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.",
-    "installCommand": "claude plugins add vercel-blob@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install vercel-blob@claude-skills",
     "tags": [
       "database",
       "vercel",
@@ -19002,7 +19002,7 @@
     "slug": "vercel-kv",
     "title": "Vercel Kv",
     "description": "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.",
-    "installCommand": "claude plugins add vercel-kv@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install vercel-kv@claude-skills",
     "tags": [
       "database",
       "redis",
@@ -19027,7 +19027,7 @@
     "slug": "verification-before-completion",
     "title": "Verification Before Completion",
     "description": "Run verification commands and confirm output before claiming success. Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.",
-    "installCommand": "claude plugins add verification-before-completion@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install verification-before-completion@claude-skills",
     "tags": [
       "tooling",
       "ai"
@@ -19048,7 +19048,7 @@
     "slug": "vitest-testing",
     "title": "Vitest Testing",
     "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
-    "installCommand": "claude plugins add vitest-testing@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install vitest-testing@claude-skills",
     "tags": [
       "testing",
       "typescript",
@@ -19070,7 +19070,7 @@
     "slug": "vulnerability-scanning",
     "title": "Vulnerability Scanning",
     "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
-    "installCommand": "claude plugins add vulnerability-scanning@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install vulnerability-scanning@claude-skills",
     "tags": [
       "security",
       "deployment",
@@ -19092,7 +19092,7 @@
     "slug": "web-performance-audit",
     "title": "Web Performance Audit",
     "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
-    "installCommand": "claude plugins add web-performance-audit@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install web-performance-audit@claude-skills",
     "tags": [
       "web",
       "performance"
@@ -19113,7 +19113,7 @@
     "slug": "web-performance-optimization",
     "title": "Web Performance Optimization",
     "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
-    "installCommand": "claude plugins add web-performance-optimization@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install web-performance-optimization@claude-skills",
     "tags": [
       "web",
       "performance",
@@ -19135,7 +19135,7 @@
     "slug": "websocket-implementation",
     "title": "Websocket Implementation",
     "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
-    "installCommand": "claude plugins add websocket-implementation@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install websocket-implementation@claude-skills",
     "tags": [
       "api"
     ],
@@ -19155,7 +19155,7 @@
     "slug": "woocommerce-backend-dev",
     "title": "Woocommerce Backend Dev",
     "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
-    "installCommand": "claude plugins add woocommerce-backend-dev@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install woocommerce-backend-dev@claude-skills",
     "tags": [
       "woocommerce"
     ],
@@ -19175,7 +19175,7 @@
     "slug": "woocommerce-code-review",
     "title": "Woocommerce Code Review",
     "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
-    "installCommand": "claude plugins add woocommerce-code-review@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install woocommerce-code-review@claude-skills",
     "tags": [
       "woocommerce"
     ],
@@ -19195,7 +19195,7 @@
     "slug": "woocommerce-copy-guidelines",
     "title": "Woocommerce Copy Guidelines",
     "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
-    "installCommand": "claude plugins add woocommerce-copy-guidelines@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install woocommerce-copy-guidelines@claude-skills",
     "tags": [
       "woocommerce"
     ],
@@ -19215,7 +19215,7 @@
     "slug": "woocommerce-dev-cycle",
     "title": "Woocommerce Dev Cycle",
     "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
-    "installCommand": "claude plugins add woocommerce-dev-cycle@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install woocommerce-dev-cycle@claude-skills",
     "tags": [
       "woocommerce"
     ],
@@ -19235,7 +19235,7 @@
     "slug": "wordpress-plugin-core",
     "title": "Wordpress Plugin Core",
     "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
-    "installCommand": "claude plugins add wordpress-plugin-core@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install wordpress-plugin-core@claude-skills",
     "tags": [
       "cms",
       "security",
@@ -19258,7 +19258,7 @@
     "slug": "xss-prevention",
     "title": "Xss Prevention",
     "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
-    "installCommand": "claude plugins add xss-prevention@claude-skills",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install xss-prevention@claude-skills",
     "tags": [
       "security"
     ],
@@ -19277,8 +19277,8 @@
   {
     "slug": "zod",
     "title": "Zod",
-    "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors…",
-    "installCommand": "claude plugins add zod@claude-skills",
+    "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install zod@claude-skills",
     "tags": [
       "tooling",
       "typescript",
@@ -19300,8 +19300,8 @@
   {
     "slug": "zustand-state-management",
     "title": "Zustand State Management",
-    "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loo…",
-    "installCommand": "claude plugins add zustand-state-management@claude-skills",
+    "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loo\u2026",
+    "installCommand": "/plugin marketplace add secondsky/claude-skills && /plugin install zustand-state-management@claude-skills",
     "tags": [
       "frontend",
       "typescript",
@@ -19325,7 +19325,7 @@
     "slug": "css-development",
     "title": "Css Development",
     "description": "CSS development workflows with Tailwind composition, semantic naming, and dark mode by default",
-    "installCommand": "claude plugins add css-development@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install css-development@claude-plugins",
     "tags": [
       "ai"
     ],
@@ -19344,7 +19344,7 @@
     "slug": "firebase-development",
     "title": "Firebase Development",
     "description": "Firebase project workflows including setup, features, debugging, and validation",
-    "installCommand": "claude plugins add firebase-development@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install firebase-development@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19361,7 +19361,7 @@
     "slug": "landing-page-design",
     "title": "Landing Page Design",
     "description": "Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles",
-    "installCommand": "claude plugins add landing-page-design@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install landing-page-design@claude-plugins",
     "tags": [
       "ai"
     ],
@@ -19380,7 +19380,7 @@
     "slug": "xtool",
     "title": "Xtool",
     "description": "Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode",
-    "installCommand": "claude plugins add xtool@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install xtool@claude-plugins",
     "tags": [
       "swift"
     ],
@@ -19399,7 +19399,7 @@
     "slug": "building-multiagent-systems",
     "title": "Building Multiagent Systems",
     "description": "Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination",
-    "installCommand": "claude plugins add building-multiagent-systems@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install building-multiagent-systems@claude-plugins",
     "tags": [
       "agent"
     ],
@@ -19418,7 +19418,7 @@
     "slug": "speed-run",
     "title": "Speed Run",
     "description": "Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.",
-    "installCommand": "claude plugins add speed-run@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install speed-run@claude-plugins",
     "tags": [
       "llm"
     ],
@@ -19437,7 +19437,7 @@
     "slug": "test-kitchen",
     "title": "Test Kitchen",
     "description": "Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner",
-    "installCommand": "claude plugins add test-kitchen@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install test-kitchen@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19454,7 +19454,7 @@
     "slug": "simmer",
     "title": "Simmer",
     "description": "Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements",
-    "installCommand": "claude plugins add simmer@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install simmer@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19471,7 +19471,7 @@
     "slug": "scenario-testing",
     "title": "Scenario Testing",
     "description": "End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth",
-    "installCommand": "claude plugins add scenario-testing@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install scenario-testing@claude-plugins",
     "tags": [
       "testing"
     ],
@@ -19490,7 +19490,7 @@
     "slug": "fresh-eyes-review",
     "title": "Fresh Eyes Review",
     "description": "Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests",
-    "installCommand": "claude plugins add fresh-eyes-review@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install fresh-eyes-review@claude-plugins",
     "tags": [
       "security"
     ],
@@ -19509,7 +19509,7 @@
     "slug": "documentation-audit",
     "title": "Documentation Audit",
     "description": "Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection",
-    "installCommand": "claude plugins add documentation-audit@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install documentation-audit@claude-plugins",
     "tags": [
       "ai"
     ],
@@ -19528,7 +19528,7 @@
     "slug": "ceo-personal-os",
     "title": "Ceo Personal Os",
     "description": "Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)",
-    "installCommand": "claude plugins add ceo-personal-os@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install ceo-personal-os@claude-plugins",
     "tags": [
       "go"
     ],
@@ -19547,7 +19547,7 @@
     "slug": "worldview-synthesis",
     "title": "Worldview Synthesis",
     "description": "Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation",
-    "installCommand": "claude plugins add worldview-synthesis@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install worldview-synthesis@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19564,7 +19564,7 @@
     "slug": "deliberation",
     "title": "Deliberation",
     "description": "Decision-making through deliberation - seeking unity through discernment rather than consensus through debate",
-    "installCommand": "claude plugins add deliberation@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install deliberation@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19581,7 +19581,7 @@
     "slug": "terminal-title",
     "title": "Terminal Title",
     "description": "Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals",
-    "installCommand": "claude plugins add terminal-title@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install terminal-title@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19598,7 +19598,7 @@
     "slug": "slack-mcp",
     "title": "Slack Mcp",
     "description": "Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration",
-    "installCommand": "claude plugins add slack-mcp@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install slack-mcp@claude-plugins",
     "tags": [
       "slack"
     ],
@@ -19617,7 +19617,7 @@
     "slug": "remote-system-maintenance",
     "title": "Remote System Maintenance",
     "description": "Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists",
-    "installCommand": "claude plugins add remote-system-maintenance@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install remote-system-maintenance@claude-plugins",
     "tags": [
       "ai"
     ],
@@ -19636,7 +19636,7 @@
     "slug": "binary-re",
     "title": "Binary Re",
     "description": "Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU",
-    "installCommand": "claude plugins add binary-re@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install binary-re@claude-plugins",
     "tags": [
       "agent"
     ],
@@ -19654,8 +19654,8 @@
   {
     "slug": "review-squad",
     "title": "Review Squad",
-    "description": "Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks",
-    "installCommand": "claude plugins add review-squad@claude-plugins",
+    "description": "Dispatch panels of specialized subagents to review projects \u2014 expert audits, first-impression personas, task-completion flows, and pedantic nitpicks",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install review-squad@claude-plugins",
     "tags": [
       "agent"
     ],
@@ -19674,7 +19674,7 @@
     "slug": "git-repo-prep",
     "title": "Git Repo Prep",
     "description": "Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review",
-    "installCommand": "claude plugins add git-repo-prep@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install git-repo-prep@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19691,7 +19691,7 @@
     "slug": "prbuddy",
     "title": "Prbuddy",
     "description": "PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.",
-    "installCommand": "claude plugins add prbuddy@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install prbuddy@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19708,7 +19708,7 @@
     "slug": "summarize-meetings",
     "title": "Summarize Meetings",
     "description": "Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction",
-    "installCommand": "claude plugins add summarize-meetings@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install summarize-meetings@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19725,7 +19725,7 @@
     "slug": "jam",
     "title": "Jam",
     "description": "Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result",
-    "installCommand": "claude plugins add jam@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install jam@claude-plugins",
     "tags": [
       "agent"
     ],
@@ -19744,7 +19744,7 @@
     "slug": "agent-drugs",
     "title": "Agent Drugs",
     "description": "Digital drugs that modify AI behavior through prompt injection",
-    "installCommand": "claude plugins add agent-drugs@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install agent-drugs@claude-plugins",
     "tags": [
       "ai",
       "agent"
@@ -19764,7 +19764,7 @@
     "slug": "socialmedia",
     "title": "Socialmedia",
     "description": "A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.",
-    "installCommand": "claude plugins add socialmedia@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install socialmedia@claude-plugins",
     "tags": [
       "ai",
       "agent"
@@ -19784,7 +19784,7 @@
     "slug": "journal",
     "title": "Journal",
     "description": "A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts",
-    "installCommand": "claude plugins add journal@claude-plugins",
+    "installCommand": "/plugin marketplace add 2389-research/claude-plugins && /plugin install journal@claude-plugins",
     "tags": [],
     "author": {
       "name": "2389-research",
@@ -19801,7 +19801,7 @@
     "slug": "ultraship",
     "title": "Ultraship",
     "description": "Full lifecycle plugin: plan, build, test, review, ship, deploy, verify, reflect. 36 tools, 42 skills, 12 agents.",
-    "installCommand": "claude plugins add ultraship@ultraship",
+    "installCommand": "/plugin marketplace add Houseofmvps/ultraship && /plugin install ultraship@ultraship",
     "tags": [
       "agent"
     ],
@@ -19820,7 +19820,7 @@
     "slug": "director-mode-lite",
     "title": "Director Mode Lite",
     "description": "Complete toolkit with 26 commands, 14 agents, 31 skills, and TDD-based Auto-Loop for autonomous development",
-    "installCommand": "claude plugins add director-mode-lite@director-mode-lite",
+    "installCommand": "/plugin marketplace add claude-world/director-mode-lite && /plugin install director-mode-lite@director-mode-lite",
     "tags": [
       "productivity",
       "agent"

--- a/src/data/blog/best-claude-code-plugins.ts
+++ b/src/data/blog/best-claude-code-plugins.ts
@@ -93,7 +93,7 @@ Plugins extend Claude Code with new slash commands, workflows, and integrations.
 Install any plugin with a single command:
 
 \`\`\`bash
-claude plugins add plugin-name@source
+/plugin install plugin-name@marketplace
 \`\`\`
 
 Plugins live in your project's \`.claude/plugins/\` directory and can be shared across your team via version control.
@@ -107,7 +107,7 @@ These three plugins are useful regardless of what you're building. If you instal
 ### 1. Feature Dev (Anthropic)
 
 \`\`\`bash
-claude plugins add feature-dev@claude-plugins-official
+/plugin install feature-dev@claude-plugins-official
 \`\`\`
 
 This is the single best plugin for writing new code. Instead of dumping a vague prompt and hoping for the best, \`/feature-dev\` walks you through a structured 7-phase workflow: discovery, codebase exploration, clarifying questions, architecture design, implementation, quality review, and summary.
@@ -119,7 +119,7 @@ Use it when you're adding anything non-trivial — a new API endpoint, a UI comp
 ### 2. Code Review (Anthropic)
 
 \`\`\`bash
-claude plugins add code-review@claude-plugins-official
+/plugin install code-review@claude-plugins-official
 \`\`\`
 
 Multi-agent code review with confidence-based filtering. Run \`/code-review\` on your current changes or point it at a PR number. It analyzes security, performance, maintainability, and correctness — then ranks findings by confidence so you're not drowning in nitpicks.
@@ -129,7 +129,7 @@ The difference between this and just asking Claude "review my code" is the struc
 ### 3. Context7 (Upstash)
 
 \`\`\`bash
-claude plugins add context7@claude-plugins-official
+/plugin install context7@claude-plugins-official
 \`\`\`
 
 This one solves a real pain point. Claude's training data has a cutoff, which means it sometimes generates code against outdated API surfaces. Context7 pulls **current** documentation directly from source repositories.
@@ -145,7 +145,7 @@ Building UIs? These plugins turn Claude Code into a design-aware frontend engine
 ### Frontend Design (Claude Code Plugins)
 
 \`\`\`bash
-claude plugins add frontend-design@claude-code-plugins
+/plugin install frontend-design@claude-plugins-official
 \`\`\`
 
 The default Claude Code experience produces functional but generic-looking UIs. This plugin fixes that. \`/frontend-design\` generates production-grade components with actual design sensibility — proper spacing, color systems, typography scales, responsive behavior.
@@ -155,7 +155,7 @@ It supports React, Vue, Svelte, and vanilla HTML/CSS. The \`/ui\` command is the
 ### Figma (Figma)
 
 \`\`\`bash
-claude plugins add figma@claude-plugins-official
+/plugin install figma@claude-plugins-official
 \`\`\`
 
 If your team has a designer, this closes the design-to-code gap. \`/figma-inspect\` extracts specs from a Figma file — colors, spacing, typography, component structure. \`/figma-code\` generates code from a Figma component. \`/figma-tokens\` exports design tokens you can feed into your theme.
@@ -165,7 +165,7 @@ Not useful if you're a solo dev designing in code. Very useful if you have Figma
 ### Storybook (Storybook)
 
 \`\`\`bash
-claude plugins add @storybook/claude-plugin
+/plugin install <plugin>@claude-plugins-official
 \`\`\`
 
 \`/story:gen\` generates Storybook stories for your components. This is one of those tasks that's tedious enough that nobody does it consistently. Having Claude auto-generate stories with sensible variants and edge cases means your component library stays documented without the overhead.
@@ -173,7 +173,7 @@ claude plugins add @storybook/claude-plugin
 ### Playwright (Microsoft)
 
 \`\`\`bash
-claude plugins add playwright@claude-plugins-official
+/plugin install playwright@claude-plugins-official
 \`\`\`
 
 E2E testing across Chromium, Firefox, and WebKit. \`/playwright-test\` runs or creates tests. \`/playwright-screenshot\` takes screenshots for visual verification. The standout is \`/playwright-codegen\` — it records browser interactions and generates test code from them.
@@ -189,7 +189,7 @@ For API developers, database engineers, and anyone who spends more time in the t
 ### Supabase (Supabase)
 
 \`\`\`bash
-claude plugins add supabase@claude-plugins-official
+/plugin install supabase@claude-plugins-official
 \`\`\`
 
 Full backend management from Claude Code. \`/supabase-query\` runs SQL, \`/supabase-migrate\` handles schema changes, \`/supabase-auth\` manages users, \`/supabase-functions\` deploys edge functions. It's basically the Supabase dashboard in your terminal.
@@ -199,7 +199,7 @@ The migration workflow is where this really shines. Describe what you want ("add
 ### Firebase (Google)
 
 \`\`\`bash
-claude plugins add firebase@claude-plugins-official
+/plugin install firebase@claude-plugins-official
 \`\`\`
 
 Same idea as Supabase but for the Firebase ecosystem. Firestore queries, auth management, function deployment, and security rules — all from Claude Code. If you're on Firebase, you need this. If you're not, skip it.
@@ -207,7 +207,7 @@ Same idea as Supabase but for the Firebase ecosystem. Firestore queries, auth ma
 ### Prisma (Prisma)
 
 \`\`\`bash
-claude plugins add prisma@claude-plugins-official
+/plugin install prisma@claude-plugins-official
 \`\`\`
 
 ORM management. \`/prisma-migrate\` creates and runs migrations, \`/prisma-generate\` regenerates the client after schema changes. The real value is that Claude understands your Prisma schema as a first-class data model and can reason about relationships, indexes, and constraints when writing queries.
@@ -215,7 +215,7 @@ ORM management. \`/prisma-migrate\` creates and runs migrations, \`/prisma-gener
 ### Stripe (Stripe)
 
 \`\`\`bash
-claude plugins add stripe@claude-plugins-official
+/plugin install stripe@claude-plugins-official
 \`\`\`
 
 If you're integrating payments, this saves hours. \`/stripe-webhook\` sets up webhook handlers with proper signature verification. \`/stripe-test\` runs your integration against Stripe's test mode. No more context-switching between the Stripe dashboard, docs, and your editor.
@@ -229,7 +229,7 @@ For the people who keep things running.
 ### Vercel (Vercel)
 
 \`\`\`bash
-claude plugins add vercel@claude-plugins-official
+/plugin install vercel@claude-plugins-official
 \`\`\`
 
 Deploy without leaving your terminal. \`/vercel-deploy\` ships your current project, \`/vercel-env\` manages environment variables, \`/vercel-logs\` tails function logs. Straightforward and does exactly what you'd expect.
@@ -237,7 +237,7 @@ Deploy without leaving your terminal. \`/vercel-deploy\` ships your current proj
 ### Docker (Docker)
 
 \`\`\`bash
-claude plugins add docker@claude-plugins-official
+/plugin install docker@claude-plugins-official
 \`\`\`
 
 Container management. Build images, manage compose services, tail logs. The \`/docker-compose\` command is especially useful — Claude can read your \`docker-compose.yml\`, understand the service graph, and help you debug networking issues or add new services that fit the existing setup.
@@ -245,7 +245,7 @@ Container management. Build images, manage compose services, tail logs. The \`/d
 ### Cloudflare (Cloudflare)
 
 \`\`\`bash
-claude plugins add @cloudflare/claude-plugin
+/plugin install <plugin>@claude-plugins-official
 \`\`\`
 
 Edge-first development. Deploy Workers, manage KV stores, query D1 databases. \`/cf:logs\` gives you real-time tailing from Workers, which is a pain to set up through the dashboard. If you're building on Cloudflare's stack, this is essential.
@@ -253,7 +253,7 @@ Edge-first development. Deploy Workers, manage KV stores, query D1 databases. \`
 ### Kubernetes (Kubernetes)
 
 \`\`\`bash
-claude plugins add @kubernetes/claude-plugin
+/plugin install <plugin>@claude-plugins-official
 \`\`\`
 
 Cluster inspection and debugging. \`/k8s:debug\` is the highlight — point it at a failing deployment or a CrashLoopBackOff pod and Claude diagnoses the issue using pod events, logs, and resource limits. Faster than \`kubectl describe\` → \`kubectl logs\` → squinting at YAML.
@@ -267,7 +267,7 @@ Because shipping code is only half the job.
 ### Sentry (Sentry)
 
 \`\`\`bash
-claude plugins add sentry@claude-plugins-official
+/plugin install sentry@claude-plugins-official
 \`\`\`
 
 \`/sentry-issues\` pulls recent errors. \`/sentry-trace\` shows the stack trace. \`/sentry-fix\` is the interesting one — Claude analyzes the error, reads the relevant code in your repo, and suggests a fix with full context. Error triage that used to take 20 minutes takes 2.
@@ -275,7 +275,7 @@ claude plugins add sentry@claude-plugins-official
 ### Datadog (Datadog)
 
 \`\`\`bash
-claude plugins add datadog@claude-plugins-official
+/plugin install datadog@claude-plugins-official
 \`\`\`
 
 Observability from your terminal. Query metrics, search logs, view APM traces, check active alerts. Most useful during incident response — you can ask Claude to correlate a spike in error rates with recent deployments and get an answer without switching between six browser tabs.
@@ -289,7 +289,7 @@ Plugins that connect Claude Code to where your team communicates and tracks work
 ### GitHub (GitHub)
 
 \`\`\`bash
-claude plugins add github@claude-plugins-official
+/plugin install github@claude-plugins-official
 \`\`\`
 
 Issues, PRs, Actions, code search — the full GitHub API from Claude Code. \`/gh-pr\` creates pull requests with Claude-generated descriptions that actually make sense. \`/gh-actions\` lets you check why the build is failing without opening a browser. Pairs naturally with the code-review plugin.
@@ -297,7 +297,7 @@ Issues, PRs, Actions, code search — the full GitHub API from Claude Code. \`/g
 ### Linear (Linear)
 
 \`\`\`bash
-claude plugins add linear@claude-plugins-official
+/plugin install linear@claude-plugins-official
 \`\`\`
 
 Issue tracking integration. Create issues, update statuses, search across projects. The workflow that makes this worth installing: finish a feature, run \`/code-review\`, fix the findings, create a PR with \`/gh-pr\`, then close the Linear issue with \`/linear-status\` — all without leaving the terminal.
@@ -305,7 +305,7 @@ Issue tracking integration. Create issues, update statuses, search across projec
 ### Slack (Slack)
 
 \`\`\`bash
-claude plugins add slack@claude-plugins-official
+/plugin install slack@claude-plugins-official
 \`\`\`
 
 Search and read Slack messages from Claude Code. \`/slack-search\` finds relevant conversations. \`/slack-thread\` pulls full context from a discussion. Useful when you're implementing something that was discussed in a channel three weeks ago and you need to find the decision.
@@ -319,7 +319,7 @@ These are less mainstream but worth knowing about.
 ### Greptile (Greptile)
 
 \`\`\`bash
-claude plugins add greptile@claude-plugins-official
+/plugin install greptile@claude-plugins-official
 \`\`\`
 
 Natural language codebase search. \`/greptile-search\` lets you ask "where do we handle authentication?" or "find all the places we call the billing API" and get precise results. Technically Claude Code can already search your code, but Greptile uses pre-built indexes that handle large monorepos where Claude's native search would choke.
@@ -335,7 +335,7 @@ Autonomous overnight coding. Start a task before bed, \`ralph\` manages context 
 ### Hookify (Anthropic)
 
 \`\`\`bash
-claude plugins add hookify@claude-plugins-official
+/plugin install hookify@claude-plugins-official
 \`\`\`
 
 If you've read our [hooks guide](/blog/claude-code-hooks-guide), you know how powerful hooks are. Hookify makes them easier to create. \`/hookify\` walks you through setting up custom hooks without manually editing settings files. Good for teams that want guardrails without requiring everyone to understand hook internals.
@@ -357,12 +357,12 @@ Not sure where to start? Here are curated setups for common workflows.
 ### The Solo Full-Stack Developer
 
 \`\`\`bash
-claude plugins add feature-dev@claude-plugins-official
-claude plugins add code-review@claude-plugins-official
-claude plugins add context7@claude-plugins-official
-claude plugins add frontend-design@claude-code-plugins
-claude plugins add supabase@claude-plugins-official
-claude plugins add vercel@claude-plugins-official
+/plugin install feature-dev@claude-plugins-official
+/plugin install code-review@claude-plugins-official
+/plugin install context7@claude-plugins-official
+/plugin install frontend-design@claude-plugins-official
+/plugin install supabase@claude-plugins-official
+/plugin install vercel@claude-plugins-official
 \`\`\`
 
 Everything you need to build, review, and ship a full-stack app. Feature Dev for structured development, Context7 for up-to-date docs, Frontend Design for polished UIs, Supabase for the backend, Vercel for deployment, and Code Review before you merge.
@@ -370,11 +370,11 @@ Everything you need to build, review, and ship a full-stack app. Feature Dev for
 ### The Frontend Specialist
 
 \`\`\`bash
-claude plugins add frontend-design@claude-code-plugins
-claude plugins add figma@claude-plugins-official
-claude plugins add playwright@claude-plugins-official
-claude plugins add @storybook/claude-plugin
-claude plugins add context7@claude-plugins-official
+/plugin install frontend-design@claude-plugins-official
+/plugin install figma@claude-plugins-official
+/plugin install playwright@claude-plugins-official
+/plugin install <plugin>@claude-plugins-official
+/plugin install context7@claude-plugins-official
 \`\`\`
 
 Design-to-code with Figma, production-quality components with Frontend Design, stories with Storybook, E2E tests with Playwright, and current docs with Context7.
@@ -382,12 +382,12 @@ Design-to-code with Figma, production-quality components with Frontend Design, s
 ### The Backend / API Developer
 
 \`\`\`bash
-claude plugins add feature-dev@claude-plugins-official
-claude plugins add code-review@claude-plugins-official
-claude plugins add prisma@claude-plugins-official
-claude plugins add docker@claude-plugins-official
-claude plugins add sentry@claude-plugins-official
-claude plugins add context7@claude-plugins-official
+/plugin install feature-dev@claude-plugins-official
+/plugin install code-review@claude-plugins-official
+/plugin install prisma@claude-plugins-official
+/plugin install docker@claude-plugins-official
+/plugin install sentry@claude-plugins-official
+/plugin install context7@claude-plugins-official
 \`\`\`
 
 Structured feature development, ORM management, containerized environments, error monitoring, and code review. Swap Prisma for Supabase or Firebase depending on your database layer.
@@ -395,12 +395,12 @@ Structured feature development, ORM management, containerized environments, erro
 ### The DevOps / Platform Engineer
 
 \`\`\`bash
-claude plugins add @kubernetes/claude-plugin
-claude plugins add docker@claude-plugins-official
-claude plugins add @cloudflare/claude-plugin
-claude plugins add datadog@claude-plugins-official
-claude plugins add github@claude-plugins-official
-claude plugins add hookify@claude-plugins-official
+/plugin install <plugin>@claude-plugins-official
+/plugin install docker@claude-plugins-official
+/plugin install <plugin>@claude-plugins-official
+/plugin install datadog@claude-plugins-official
+/plugin install github@claude-plugins-official
+/plugin install hookify@claude-plugins-official
 \`\`\`
 
 Cluster management, container orchestration, edge deployment, observability, CI/CD integration, and automated guardrails with hooks.
@@ -408,11 +408,11 @@ Cluster management, container orchestration, edge deployment, observability, CI/
 ### The Team Lead
 
 \`\`\`bash
-claude plugins add code-review@claude-plugins-official
-claude plugins add github@claude-plugins-official
-claude plugins add linear@claude-plugins-official
-claude plugins add slack@claude-plugins-official
-claude plugins add feature-dev@claude-plugins-official
+/plugin install code-review@claude-plugins-official
+/plugin install github@claude-plugins-official
+/plugin install linear@claude-plugins-official
+/plugin install slack@claude-plugins-official
+/plugin install feature-dev@claude-plugins-official
 \`\`\`
 
 PR management, issue tracking, team communication, and structured feature development. The workflow: triage Linear issues, develop with Feature Dev, review with Code Review, manage PRs with GitHub, and stay connected with Slack.

--- a/src/data/how-to/claude-folder.ts
+++ b/src/data/how-to/claude-folder.ts
@@ -80,7 +80,7 @@ Scripts executed on tool events — block dangerous commands, auto-format on wri
 Reusable multi-step workflows. Each skill is a folder containing a \`SKILL.md\` with metadata and instructions. Claude loads the index on startup and invokes skills when the user's request matches.
 
 ### \`plugins/\`
-Manifests for plugins installed via \`claude plugins add …\`. Usually not edited by hand.
+Manifests for plugins installed via \`/plugin install …\`. Usually not edited by hand.
 
 ### \`projects/\`
 Per-session history and state. Safe to delete if you want a clean slate; Claude Code will rebuild it.

--- a/src/data/how-to/plugins.ts
+++ b/src/data/how-to/plugins.ts
@@ -32,73 +32,65 @@ Plugins are bundles that can include:
 
 ## Finding Plugins
 
-### Official Plugins
+Plugins live in **marketplaces**. The official Anthropic marketplace (\`claude-plugins-official\`) is built in and available the moment you start Claude Code — you don't have to add it.
 
-\`\`\`bash
-# List official plugins
-claude plugins list --official
-\`\`\`
+Run \`/plugin\` to open the plugin manager. It has four tabs:
 
-### Community Plugins
-
-\`\`\`bash
-# Search all plugins
-claude plugins search <keyword>
-\`\`\`
+- **Discover** — browse plugins from all your marketplaces
+- **Installed** — view, enable, disable, or uninstall plugins
+- **Marketplaces** — add or remove marketplaces
+- **Errors** — view plugin load errors
 
 ## Installing Plugins
 
-### From Official Registry
+### From the official marketplace
 
-\`\`\`bash
-# Install an official plugin
-claude plugins add code-review@claude-plugins-official
+\`\`\`shell
+# Inside Claude Code
+/plugin install code-review@claude-plugins-official
 \`\`\`
 
-### From GitHub
+### From another marketplace
 
-\`\`\`bash
-# Install from a GitHub repository
-claude plugins add username/plugin-name
+You need two steps: register the marketplace, then install:
+
+\`\`\`shell
+# Add a GitHub marketplace using owner/repo
+/plugin marketplace add anthropics/claude-code
+
+# Now install plugins from it
+/plugin install commit-commands@anthropics-claude-code
 \`\`\`
 
-### From Local Path
-
-\`\`\`bash
-# Install a local plugin
-claude plugins add ./my-plugin
-\`\`\`
+You can also point at a Git URL (GitLab, Bitbucket, self-hosted), a local directory containing \`.claude-plugin/marketplace.json\`, or a remote URL.
 
 ## Managing Plugins
 
-### List Installed Plugins
+Most management happens in the interactive \`/plugin\` UI, but there are direct commands too:
 
-\`\`\`bash
-claude plugins list
-\`\`\`
+\`\`\`shell
+# Disable without uninstalling
+/plugin disable code-review@claude-plugins-official
 
-### Update Plugins
+# Re-enable
+/plugin enable code-review@claude-plugins-official
 
-\`\`\`bash
-# Update all plugins
-claude plugins update
+# Uninstall
+/plugin uninstall code-review@claude-plugins-official
 
-# Update specific plugin
-claude plugins update code-review@claude-plugins-official
-\`\`\`
+# Refresh a marketplace's catalog
+/plugin marketplace update claude-plugins-official
 
-### Remove Plugins
-
-\`\`\`bash
-claude plugins remove code-review@claude-plugins-official
+# Reload after install/enable/disable changes
+/reload-plugins
 \`\`\`
 
 ## Popular Plugins
 
 ### Code Review
 
-\`\`\`bash
-claude plugins add code-review@claude-plugins-official
+\`\`\`shell
+/plugin install code-review@claude-plugins-official
 \`\`\`
 
 Provides:
@@ -108,8 +100,8 @@ Provides:
 
 ### Feature Development
 
-\`\`\`bash
-claude plugins add feature-dev@claude-plugins-official
+\`\`\`shell
+/plugin install feature-dev@claude-plugins-official
 \`\`\`
 
 Provides:
@@ -119,8 +111,8 @@ Provides:
 
 ### Frontend Design
 
-\`\`\`bash
-claude plugins add frontend-design@claude-code-plugins
+\`\`\`shell
+/plugin install frontend-design@claude-plugins-official
 \`\`\`
 
 Provides:
@@ -201,13 +193,18 @@ my-plugin/
 
 ### Plugin Not Loading
 
-\`\`\`bash
-# Check plugin status
-claude plugins status code-review@claude-plugins-official
+Open the \`/plugin\` UI and check the **Errors** tab for load failures. To force a reinstall:
 
-# Reinstall
-claude plugins remove code-review@claude-plugins-official
-claude plugins add code-review@claude-plugins-official
+\`\`\`shell
+/plugin uninstall code-review@claude-plugins-official
+/plugin install code-review@claude-plugins-official
+/reload-plugins
+\`\`\`
+
+If the plugin still doesn't show up, clear the plugin cache and restart Claude Code:
+
+\`\`\`bash
+rm -rf ~/.claude/plugins/cache
 \`\`\`
 
 ### Conflicts Between Plugins

--- a/src/data/plugins/agent-sdk-dev.ts
+++ b/src/data/plugins/agent-sdk-dev.ts
@@ -11,7 +11,7 @@ export const agentSdkDevPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add agent-sdk-dev@claude-plugins-official",
+  installCommand: "/plugin install agent-sdk-dev@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "agent-sdk-dev@claude-plugins-official": true

--- a/src/data/plugins/anthropic-skills.ts
+++ b/src/data/plugins/anthropic-skills.ts
@@ -12,10 +12,10 @@ export const anthropicSkillsPlugin: Plugin = {
     url: "https://github.com/anthropics/skills",
   },
   repoUrl: "https://github.com/anthropics/skills",
-  installCommand: "claude plugins add anthropic-skills@anthropic-skills",
+  installCommand: "/plugin marketplace add anthropics/skills && /plugin install document-skills@anthropic-agent-skills",
   config: `{
   "enabledPlugins": {
-    "anthropic-skills@anthropic-skills": true
+    "document-skills@anthropic-agent-skills": true
   }
 }`,
   commands: [

--- a/src/data/plugins/asana.ts
+++ b/src/data/plugins/asana.ts
@@ -10,7 +10,7 @@ export const asanaPlugin: Plugin = {
     name: "Asana",
     url: "https://asana.com",
   },
-  installCommand: "claude plugins add asana@claude-plugins-official",
+  installCommand: "/plugin install asana@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "asana@claude-plugins-official": true

--- a/src/data/plugins/astro.ts
+++ b/src/data/plugins/astro.ts
@@ -12,7 +12,7 @@ export const astroPlugin: Plugin = {
     url: "https://astro.build",
   },
   repoUrl: "https://github.com/withastro/astro",
-  installCommand: "claude plugins add astro@community",
+  installCommand: "/plugin install astro@community",
   commands: [
     { name: "/astro add", description: "Add an official Astro integration to the project" },
     { name: "/astro collection", description: "Scaffold a new content collection with schema" },

--- a/src/data/plugins/aws.ts
+++ b/src/data/plugins/aws.ts
@@ -11,7 +11,7 @@ export const awsPlugin: Plugin = {
     url: "https://aws.amazon.com",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add aws@claude-plugins-official",
+  installCommand: "/plugin install aws@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "aws@claude-plugins-official": true

--- a/src/data/plugins/bug-detective.ts
+++ b/src/data/plugins/bug-detective.ts
@@ -11,7 +11,7 @@ export const bugDetectivePlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/bug-detective",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/bug-detective",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install bug-detective@awesome-claude-code-plugins",
   commands: [
     { name: "/bug-detective", description: "Debug issues with step-by-step troubleshooting" },
   ],

--- a/src/data/plugins/bun.ts
+++ b/src/data/plugins/bun.ts
@@ -12,7 +12,7 @@ export const bunPlugin: Plugin = {
     url: "https://bun.sh",
   },
   repoUrl: "https://github.com/oven-sh/bun",
-  installCommand: "claude plugins add bun@community",
+  installCommand: "/plugin install bun@community",
   commands: [
     { name: "/bun run", description: "Run a Bun script or package.json command" },
     { name: "/bun test", description: "Run the Bun test suite" },

--- a/src/data/plugins/changelog-generator.ts
+++ b/src/data/plugins/changelog-generator.ts
@@ -11,5 +11,5 @@ export const changelogGeneratorPlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/changelog-generator",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/changelog-generator",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install changelog-generator@awesome-claude-code-plugins",
 };

--- a/src/data/plugins/chrome-devtools.ts
+++ b/src/data/plugins/chrome-devtools.ts
@@ -12,7 +12,7 @@ export const chromeDevtoolsPlugin: Plugin = {
     url: "https://developer.chrome.com/docs/devtools",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add chrome-devtools@claude-plugins-official",
+  installCommand: "/plugin install chrome-devtools@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "chrome-devtools@claude-plugins-official": true

--- a/src/data/plugins/clangd-lsp.ts
+++ b/src/data/plugins/clangd-lsp.ts
@@ -11,7 +11,7 @@ export const clangdLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add clangd-lsp@claude-plugins-official",
+  installCommand: "/plugin install clangd-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "clangd-lsp@claude-plugins-official": true

--- a/src/data/plugins/claude-brain.ts
+++ b/src/data/plugins/claude-brain.ts
@@ -12,7 +12,7 @@ export const claudeBrainPlugin: Plugin = {
     url: "https://github.com/memvid",
   },
   repoUrl: "https://github.com/memvid/claude-brain",
-  installCommand: "claude plugins add claude-brain",
+  installCommand: "/plugin marketplace add memvid/claude-brain && /plugin install mind@memvid",
   commands: [
     {
       name: "/brain:save",

--- a/src/data/plugins/claude-diary.ts
+++ b/src/data/plugins/claude-diary.ts
@@ -12,7 +12,7 @@ export const claudeDiaryPlugin: Plugin = {
     url: "https://github.com/rlancemartin",
   },
   repoUrl: "https://github.com/rlancemartin/claude-diary",
-  installCommand: "claude plugins add claude-diary",
+  installCommand: "/plugin install claude-diary",
   commands: [
     {
       name: "/diary:review",

--- a/src/data/plugins/claude-in-chrome.ts
+++ b/src/data/plugins/claude-in-chrome.ts
@@ -11,7 +11,7 @@ export const claudeInChromePlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  installCommand: "claude plugins add claude-in-chrome@claude-plugins-official",
+  installCommand: "/plugin install claude-in-chrome@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "claude-in-chrome@claude-plugins-official": true

--- a/src/data/plugins/claude-mem.ts
+++ b/src/data/plugins/claude-mem.ts
@@ -12,7 +12,7 @@ export const claudeMemPlugin: Plugin = {
     url: "https://github.com/thedotmack",
   },
   repoUrl: "https://github.com/thedotmack/claude-mem",
-  installCommand: "claude plugins add claude-mem",
+  installCommand: "/plugin marketplace add thedotmack/claude-mem && /plugin install claude-mem@thedotmack",
   commands: [
     {
       name: "/mem:search",

--- a/src/data/plugins/claude-opus-migration.ts
+++ b/src/data/plugins/claude-opus-migration.ts
@@ -11,7 +11,7 @@ export const claudeOpusMigrationPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add claude-opus-4-6-migration@claude-plugins-official",
+  installCommand: "/plugin install claude-opus-4-6-migration@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "claude-opus-4-6-migration@claude-plugins-official": true

--- a/src/data/plugins/claude-preview.ts
+++ b/src/data/plugins/claude-preview.ts
@@ -11,7 +11,7 @@ export const claudePreviewPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  installCommand: "claude plugins add claude-preview@claude-plugins-official",
+  installCommand: "/plugin install claude-preview@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "claude-preview@claude-plugins-official": true

--- a/src/data/plugins/cloudflare.ts
+++ b/src/data/plugins/cloudflare.ts
@@ -10,7 +10,7 @@ export const cloudflarePlugin: Plugin = {
     name: "Cloudflare",
     url: "https://github.com/cloudflare",
   },
-  installCommand: "claude plugins add @cloudflare/claude-plugin",
+  installCommand: "/plugin install cloudflare@claude-plugins-official",
   commands: [
     { name: "/cf:deploy", description: "Deploy a Worker or Pages project" },
     { name: "/cf:logs", description: "Tail real-time logs from Workers" },

--- a/src/data/plugins/code-review.ts
+++ b/src/data/plugins/code-review.ts
@@ -11,7 +11,7 @@ export const codeReviewPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add code-review@claude-plugins-official",
+  installCommand: "/plugin install code-review@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "code-review@claude-plugins-official": true

--- a/src/data/plugins/codebase-documenter.ts
+++ b/src/data/plugins/codebase-documenter.ts
@@ -11,5 +11,5 @@ export const codebaseDocumenterPlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/codebase-documenter",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/codebase-documenter",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install codebase-documenter@awesome-claude-code-plugins",
 };

--- a/src/data/plugins/commit-commands.ts
+++ b/src/data/plugins/commit-commands.ts
@@ -11,7 +11,7 @@ export const commitCommandsPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add commit-commands@claude-plugins-official",
+  installCommand: "/plugin install commit-commands@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "commit-commands@claude-plugins-official": true

--- a/src/data/plugins/context7.ts
+++ b/src/data/plugins/context7.ts
@@ -10,7 +10,7 @@ export const context7Plugin: Plugin = {
     name: "Upstash",
     url: "https://upstash.com",
   },
-  installCommand: "claude plugins add context7@claude-plugins-official",
+  installCommand: "/plugin install context7@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "context7@claude-plugins-official": true

--- a/src/data/plugins/csharp-lsp.ts
+++ b/src/data/plugins/csharp-lsp.ts
@@ -11,7 +11,7 @@ export const csharpLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add csharp-lsp@claude-plugins-official",
+  installCommand: "/plugin install csharp-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "csharp-lsp@claude-plugins-official": true

--- a/src/data/plugins/cursor-rules.ts
+++ b/src/data/plugins/cursor-rules.ts
@@ -10,7 +10,7 @@ export const cursorRulesPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add cursor-rules",
+  installCommand: "/plugin install cursor-rules",
   commands: [
     { name: "/cursor-import", description: "Convert .cursorrules to CLAUDE.md format" },
     { name: "/cursor-diff", description: "Show differences between .cursorrules and CLAUDE.md" },

--- a/src/data/plugins/datadog.ts
+++ b/src/data/plugins/datadog.ts
@@ -11,7 +11,7 @@ export const datadogPlugin: Plugin = {
     url: "https://datadoghq.com",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add datadog@claude-plugins-official",
+  installCommand: "/plugin install datadog@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "datadog@claude-plugins-official": true

--- a/src/data/plugins/dep-audit.ts
+++ b/src/data/plugins/dep-audit.ts
@@ -10,7 +10,7 @@ export const depAuditPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add dep-audit",
+  installCommand: "/plugin install dep-audit",
   commands: [
     { name: "/deps:audit", description: "Scan dependencies for known vulnerabilities" },
     { name: "/deps:outdated", description: "List outdated packages with upgrade paths" },

--- a/src/data/plugins/deployment-engineer.ts
+++ b/src/data/plugins/deployment-engineer.ts
@@ -11,5 +11,5 @@ export const deploymentEngineerPlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/deployment-engineer",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/deployment-engineer",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install deployment-engineer@awesome-claude-code-plugins",
 };

--- a/src/data/plugins/docker.ts
+++ b/src/data/plugins/docker.ts
@@ -11,7 +11,7 @@ export const dockerPlugin: Plugin = {
     url: "https://docker.com",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add docker@claude-plugins-official",
+  installCommand: "/plugin install docker@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "docker@claude-plugins-official": true

--- a/src/data/plugins/document-skills.ts
+++ b/src/data/plugins/document-skills.ts
@@ -11,10 +11,10 @@ export const documentSkillsPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add document-skills@claude-plugins-official",
+  installCommand: "/plugin marketplace add anthropics/skills && /plugin install document-skills@anthropic-agent-skills",
   config: `{
   "enabledPlugins": {
-    "document-skills@claude-plugins-official": true
+    "document-skills@anthropic-agent-skills": true
   }
 }`,
   commands: [

--- a/src/data/plugins/env-manager.ts
+++ b/src/data/plugins/env-manager.ts
@@ -10,7 +10,7 @@ export const envManagerPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add env-manager",
+  installCommand: "/plugin install env-manager",
   commands: [
     { name: "/env:validate", description: "Validate .env files against .env.example" },
     { name: "/env:sync", description: "Sync environment variables across .env files" },

--- a/src/data/plugins/explanatory-output.ts
+++ b/src/data/plugins/explanatory-output.ts
@@ -11,7 +11,7 @@ export const explanatoryOutputPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add explanatory-output-style@claude-plugins-official",
+  installCommand: "/plugin install explanatory-output-style@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "explanatory-output-style@claude-plugins-official": true

--- a/src/data/plugins/feature-dev.ts
+++ b/src/data/plugins/feature-dev.ts
@@ -5,14 +5,14 @@ export const featureDevPlugin: Plugin = {
   title: "Feature Development",
   description: "Guided feature development with codebase understanding and architecture focus. A comprehensive 7-phase workflow for building features systematically with specialized agents for exploration, architecture, and review.",
   seoTitle: "Install feature-dev@claude-plugins-official – Claude Code Plugin Setup (2026)",
-  seoDescription: "Complete 2026 guide to installing feature-dev. Run `claude plugins add feature-dev@claude-plugins-official` for a 7-phase guided workflow: discovery, exploration, architecture, implementation, and review.",
+  seoDescription: "Complete 2026 guide to installing feature-dev. Run `/plugin install feature-dev@claude-plugins-official` for a 7-phase guided workflow: discovery, exploration, architecture, implementation, and review.",
   tags: ["feature", "development", "architecture", "official", "workflow"],
   featured: true,
   author: {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  installCommand: "claude plugins add feature-dev@claude-plugins-official",
+  installCommand: "/plugin install feature-dev@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "feature-dev@claude-plugins-official": true

--- a/src/data/plugins/figma.ts
+++ b/src/data/plugins/figma.ts
@@ -5,7 +5,7 @@ export const figmaPlugin: Plugin = {
   title: "Figma",
   description: "Figma design tool integration. Extract design specs, generate code from designs, access component libraries, and bridge the gap between design and development.",
   seoTitle: "Install figma@claude-plugins-official – Claude Code Figma Plugin Setup (2026)",
-  seoDescription: "Install with `claude plugins add figma@claude-plugins-official`. Extract design specs, generate code from Figma components, and export design tokens — complete setup guide.",
+  seoDescription: "Install with `/plugin install figma@claude-plugins-official`. Extract design specs, generate code from Figma components, and export design tokens — complete setup guide.",
   tags: ["design", "ui", "collaboration", "official"],
   featured: false,
   author: {
@@ -13,7 +13,7 @@ export const figmaPlugin: Plugin = {
     url: "https://figma.com",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add figma@claude-plugins-official",
+  installCommand: "/plugin install figma@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "figma@claude-plugins-official": true

--- a/src/data/plugins/firebase.ts
+++ b/src/data/plugins/firebase.ts
@@ -10,7 +10,7 @@ export const firebasePlugin: Plugin = {
     name: "Google",
     url: "https://firebase.google.com",
   },
-  installCommand: "claude plugins add firebase@claude-plugins-official",
+  installCommand: "/plugin install firebase@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "firebase@claude-plugins-official": true

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -5,7 +5,7 @@ export const frontendDesignPlugin: Plugin = {
   title: "Frontend Design",
   description: "Create distinctive, production-grade frontend interfaces with high design quality. UI/UX specialist plugin that generates polished, creative code avoiding generic AI aesthetics. Supports React, Vue, Svelte, and vanilla HTML/CSS with modern design patterns.",
   seoTitle: "Install Frontend Design Plugin for Claude Code – frontend-design@claude-plugins-official (2026)",
-  seoDescription: "Step-by-step install guide for the frontend-design plugin. Run `claude plugins add frontend-design@claude-code-plugins` in Claude Code to generate production-grade React, Vue, and Svelte UIs — setup in under a minute.",
+  seoDescription: "Step-by-step install guide for the frontend-design plugin. Run `/plugin install frontend-design@claude-plugins-official` in Claude Code to generate production-grade React, Vue, and Svelte UIs — setup in under a minute.",
   tags: ["frontend", "design", "ui", "ux", "react", "official"],
   featured: true,
   author: {
@@ -13,10 +13,10 @@ export const frontendDesignPlugin: Plugin = {
     url: "https://github.com/anthropics/claude-plugins-official",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add frontend-design@claude-code-plugins",
+  installCommand: "/plugin install frontend-design@claude-plugins-official",
   config: `{
   "enabledPlugins": {
-    "frontend-design@claude-code-plugins": true
+    "frontend-design@claude-plugins-official": true
   }
 }`,
   commands: [

--- a/src/data/plugins/github.ts
+++ b/src/data/plugins/github.ts
@@ -10,7 +10,7 @@ export const githubPlugin: Plugin = {
     name: "GitHub",
     url: "https://github.com",
   },
-  installCommand: "claude plugins add github@claude-plugins-official",
+  installCommand: "/plugin install github@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "github@claude-plugins-official": true

--- a/src/data/plugins/gitlab.ts
+++ b/src/data/plugins/gitlab.ts
@@ -10,7 +10,7 @@ export const gitlabPlugin: Plugin = {
     name: "GitLab",
     url: "https://gitlab.com",
   },
-  installCommand: "claude plugins add gitlab@claude-plugins-official",
+  installCommand: "/plugin install gitlab@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "gitlab@claude-plugins-official": true

--- a/src/data/plugins/gopls-lsp.ts
+++ b/src/data/plugins/gopls-lsp.ts
@@ -11,7 +11,7 @@ export const goplsLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add gopls-lsp@claude-plugins-official",
+  installCommand: "/plugin install gopls-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "gopls-lsp@claude-plugins-official": true

--- a/src/data/plugins/greptile.ts
+++ b/src/data/plugins/greptile.ts
@@ -10,7 +10,7 @@ export const greptilePlugin: Plugin = {
     name: "Greptile",
     url: "https://greptile.com",
   },
-  installCommand: "claude plugins add greptile@claude-plugins-official",
+  installCommand: "/plugin install greptile@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "greptile@claude-plugins-official": true

--- a/src/data/plugins/hookify.ts
+++ b/src/data/plugins/hookify.ts
@@ -11,7 +11,7 @@ export const hookifyPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add hookify@claude-plugins-official",
+  installCommand: "/plugin install hookify@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "hookify@claude-plugins-official": true

--- a/src/data/plugins/i18n-manager.ts
+++ b/src/data/plugins/i18n-manager.ts
@@ -10,7 +10,7 @@ export const i18nManagerPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add i18n-manager",
+  installCommand: "/plugin install i18n-manager",
   commands: [
     { name: "/i18n:extract", description: "Extract hardcoded strings into translation keys" },
     { name: "/i18n:sync", description: "Find missing translations across locale files" },

--- a/src/data/plugins/jdtls-lsp.ts
+++ b/src/data/plugins/jdtls-lsp.ts
@@ -11,7 +11,7 @@ export const jdtlsLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add jdtls-lsp@claude-plugins-official",
+  installCommand: "/plugin install jdtls-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "jdtls-lsp@claude-plugins-official": true

--- a/src/data/plugins/jira.ts
+++ b/src/data/plugins/jira.ts
@@ -11,7 +11,7 @@ export const jiraPlugin: Plugin = {
     url: "https://www.atlassian.com/software/jira",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add jira@claude-plugins-official",
+  installCommand: "/plugin install jira@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "jira@claude-plugins-official": true

--- a/src/data/plugins/kubernetes.ts
+++ b/src/data/plugins/kubernetes.ts
@@ -10,7 +10,7 @@ export const kubernetesPlugin: Plugin = {
     name: "Kubernetes",
     url: "https://github.com/kubernetes",
   },
-  installCommand: "claude plugins add @kubernetes/claude-plugin",
+  installCommand: "/plugin install @kubernetes/claude-plugin",
   commands: [
     { name: "/k8s:pods", description: "List and inspect pods in current context" },
     { name: "/k8s:logs", description: "Stream logs from a pod or deployment" },

--- a/src/data/plugins/laravel-boost.ts
+++ b/src/data/plugins/laravel-boost.ts
@@ -10,7 +10,7 @@ export const laravelBoostPlugin: Plugin = {
     name: "Laravel",
     url: "https://laravel.com",
   },
-  installCommand: "claude plugins add laravel-boost@claude-plugins-official",
+  installCommand: "/plugin install laravel-boost@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "laravel-boost@claude-plugins-official": true

--- a/src/data/plugins/linear.ts
+++ b/src/data/plugins/linear.ts
@@ -10,7 +10,7 @@ export const linearPlugin: Plugin = {
     name: "Linear",
     url: "https://linear.app",
   },
-  installCommand: "claude plugins add linear@claude-plugins-official",
+  installCommand: "/plugin install linear@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "linear@claude-plugins-official": true

--- a/src/data/plugins/mcp-registry.ts
+++ b/src/data/plugins/mcp-registry.ts
@@ -11,7 +11,7 @@ export const mcpRegistryPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  installCommand: "claude plugins add mcp-registry@claude-plugins-official",
+  installCommand: "/plugin install mcp-registry@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "mcp-registry@claude-plugins-official": true

--- a/src/data/plugins/mongodb.ts
+++ b/src/data/plugins/mongodb.ts
@@ -10,7 +10,7 @@ export const mongodbPlugin: Plugin = {
     name: "MongoDB",
     url: "https://github.com/mongodb",
   },
-  installCommand: "claude plugins add @mongodb/claude-plugin",
+  installCommand: "/plugin install mongodb@claude-plugins-official",
   commands: [
     { name: "/mongo:query", description: "Run queries against a MongoDB collection" },
     { name: "/mongo:schema", description: "Infer and display collection schemas" },

--- a/src/data/plugins/monorepo-nav.ts
+++ b/src/data/plugins/monorepo-nav.ts
@@ -10,7 +10,7 @@ export const monorepoNavPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add monorepo-nav",
+  installCommand: "/plugin install monorepo-nav",
   commands: [
     { name: "/mono", description: "List all packages in the monorepo" },
     { name: "/mono:focus", description: "Focus Claude's context on a specific package" },

--- a/src/data/plugins/netlify-plugin.ts
+++ b/src/data/plugins/netlify-plugin.ts
@@ -12,7 +12,7 @@ export const netlifyPlugin: Plugin = {
     url: "https://github.com/netlify",
   },
   repoUrl: "https://github.com/netlify/netlify-mcp",
-  installCommand: "claude plugins add netlify",
+  installCommand: "/plugin install netlify",
   commands: [
     {
       name: "/netlify:deploy",

--- a/src/data/plugins/notion.ts
+++ b/src/data/plugins/notion.ts
@@ -11,7 +11,7 @@ export const notionPlugin: Plugin = {
     url: "https://notion.so",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add notion@claude-plugins-official",
+  installCommand: "/plugin install notion@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "notion@claude-plugins-official": true

--- a/src/data/plugins/openapi-expert.ts
+++ b/src/data/plugins/openapi-expert.ts
@@ -11,5 +11,5 @@ export const openapiExpertPlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/openapi-expert",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/openapi-expert",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install openapi-expert@awesome-claude-code-plugins",
 };

--- a/src/data/plugins/perf-profiler.ts
+++ b/src/data/plugins/perf-profiler.ts
@@ -10,7 +10,7 @@ export const perfProfilerPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add perf-profiler",
+  installCommand: "/plugin install perf-profiler",
   commands: [
     { name: "/perf:bundle", description: "Analyze bundle size and suggest tree-shaking opportunities" },
     { name: "/perf:bench", description: "Benchmark a function or code block" },

--- a/src/data/plugins/php-lsp.ts
+++ b/src/data/plugins/php-lsp.ts
@@ -11,7 +11,7 @@ export const phpLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add php-lsp@claude-plugins-official",
+  installCommand: "/plugin install php-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "php-lsp@claude-plugins-official": true

--- a/src/data/plugins/playwright.ts
+++ b/src/data/plugins/playwright.ts
@@ -10,7 +10,7 @@ export const playwrightPlugin: Plugin = {
     name: "Microsoft",
     url: "https://playwright.dev",
   },
-  installCommand: "claude plugins add playwright@claude-plugins-official",
+  installCommand: "/plugin install playwright@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "playwright@claude-plugins-official": true

--- a/src/data/plugins/plugin-dev.ts
+++ b/src/data/plugins/plugin-dev.ts
@@ -11,7 +11,7 @@ export const pluginDevPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add plugin-dev@claude-plugins-official",
+  installCommand: "/plugin install plugin-dev@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "plugin-dev@claude-plugins-official": true

--- a/src/data/plugins/pr-review-toolkit.ts
+++ b/src/data/plugins/pr-review-toolkit.ts
@@ -11,7 +11,7 @@ export const prReviewToolkitPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add pr-review-toolkit@claude-plugins-official",
+  installCommand: "/plugin install pr-review-toolkit@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "pr-review-toolkit@claude-plugins-official": true

--- a/src/data/plugins/prisma.ts
+++ b/src/data/plugins/prisma.ts
@@ -11,7 +11,7 @@ export const prismaPlugin: Plugin = {
     url: "https://prisma.io",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add prisma@claude-plugins-official",
+  installCommand: "/plugin install prisma@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "prisma@claude-plugins-official": true

--- a/src/data/plugins/pyright-lsp.ts
+++ b/src/data/plugins/pyright-lsp.ts
@@ -11,7 +11,7 @@ export const pyrightLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add pyright-lsp@claude-plugins-official",
+  installCommand: "/plugin install pyright-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true

--- a/src/data/plugins/redis.ts
+++ b/src/data/plugins/redis.ts
@@ -10,7 +10,7 @@ export const redisPlugin: Plugin = {
     name: "Redis",
     url: "https://github.com/redis",
   },
-  installCommand: "claude plugins add @redis/claude-plugin",
+  installCommand: "/plugin install @redis/claude-plugin",
   commands: [
     { name: "/redis:keys", description: "Browse and inspect Redis keys by pattern" },
     { name: "/redis:monitor", description: "Monitor real-time Redis commands" },

--- a/src/data/plugins/rust-analyzer-lsp.ts
+++ b/src/data/plugins/rust-analyzer-lsp.ts
@@ -11,7 +11,7 @@ export const rustAnalyzerLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add rust-analyzer-lsp@claude-plugins-official",
+  installCommand: "/plugin install rust-analyzer-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true

--- a/src/data/plugins/scheduled-tasks.ts
+++ b/src/data/plugins/scheduled-tasks.ts
@@ -11,7 +11,7 @@ export const scheduledTasksPlugin: Plugin = {
     name: "Anthropic",
     url: "https://github.com/anthropics",
   },
-  installCommand: "claude plugins add scheduled-tasks@claude-plugins-official",
+  installCommand: "/plugin install scheduled-tasks@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "scheduled-tasks@claude-plugins-official": true

--- a/src/data/plugins/security-guidance.ts
+++ b/src/data/plugins/security-guidance.ts
@@ -11,7 +11,7 @@ export const securityGuidancePlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add security-guidance@claude-plugins-official",
+  installCommand: "/plugin install security-guidance@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true

--- a/src/data/plugins/sentry.ts
+++ b/src/data/plugins/sentry.ts
@@ -11,7 +11,7 @@ export const sentryPlugin: Plugin = {
     url: "https://sentry.io",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add sentry@claude-plugins-official",
+  installCommand: "/plugin install sentry@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "sentry@claude-plugins-official": true

--- a/src/data/plugins/serena.ts
+++ b/src/data/plugins/serena.ts
@@ -10,7 +10,7 @@ export const serenaPlugin: Plugin = {
     name: "Oraios",
     url: "https://github.com/oraios",
   },
-  installCommand: "claude plugins add serena@claude-plugins-official",
+  installCommand: "/plugin install serena@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "serena@claude-plugins-official": true

--- a/src/data/plugins/shadcn.ts
+++ b/src/data/plugins/shadcn.ts
@@ -12,7 +12,7 @@ export const shadcnPlugin: Plugin = {
     url: "https://ui.shadcn.com",
   },
   repoUrl: "https://github.com/shadcn-ui/ui",
-  installCommand: "claude plugins add shadcn@community",
+  installCommand: "/plugin install shadcn@community",
   commands: [
     { name: "/shadcn add", description: "Add a shadcn/ui component to the project" },
     { name: "/shadcn list", description: "List available components in the registry" },

--- a/src/data/plugins/slack.ts
+++ b/src/data/plugins/slack.ts
@@ -10,7 +10,7 @@ export const slackPlugin: Plugin = {
     name: "Slack",
     url: "https://slack.com",
   },
-  installCommand: "claude plugins add slack@claude-plugins-official",
+  installCommand: "/plugin install slack@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "slack@claude-plugins-official": true

--- a/src/data/plugins/storybook.ts
+++ b/src/data/plugins/storybook.ts
@@ -10,7 +10,7 @@ export const storybookPlugin: Plugin = {
     name: "Storybook",
     url: "https://github.com/storybookjs",
   },
-  installCommand: "claude plugins add @storybook/claude-plugin",
+  installCommand: "/plugin install @storybook/claude-plugin",
   commands: [
     { name: "/story:gen", description: "Generate stories for a component file" },
     { name: "/story:list", description: "List all stories in the project" },

--- a/src/data/plugins/stripe.ts
+++ b/src/data/plugins/stripe.ts
@@ -10,7 +10,7 @@ export const stripePlugin: Plugin = {
     name: "Stripe",
     url: "https://stripe.com",
   },
-  installCommand: "claude plugins add stripe@claude-plugins-official",
+  installCommand: "/plugin install stripe@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "stripe@claude-plugins-official": true

--- a/src/data/plugins/supabase.ts
+++ b/src/data/plugins/supabase.ts
@@ -10,7 +10,7 @@ export const supabasePlugin: Plugin = {
     name: "Supabase",
     url: "https://supabase.com",
   },
-  installCommand: "claude plugins add supabase@claude-plugins-official",
+  installCommand: "/plugin install supabase@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "supabase@claude-plugins-official": true

--- a/src/data/plugins/swift-lsp.ts
+++ b/src/data/plugins/swift-lsp.ts
@@ -11,7 +11,7 @@ export const swiftLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add swift-lsp@claude-plugins-official",
+  installCommand: "/plugin install swift-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true

--- a/src/data/plugins/terraform.ts
+++ b/src/data/plugins/terraform.ts
@@ -10,7 +10,7 @@ export const terraformPlugin: Plugin = {
     name: "HashiCorp",
     url: "https://github.com/hashicorp",
   },
-  installCommand: "claude plugins add @hashicorp/terraform",
+  installCommand: "/plugin install terraform@claude-plugins-official",
   repoUrl: "https://github.com/hashicorp/terraform-mcp-server",
   commands: [
     { name: "/tf:plan", description: "Preview infrastructure changes" },

--- a/src/data/plugins/test-writer-fixer.ts
+++ b/src/data/plugins/test-writer-fixer.ts
@@ -11,5 +11,5 @@ export const testWriterFixerPlugin: Plugin = {
     url: "https://github.com/ccplugins/awesome-claude-code-plugins",
   },
   repoUrl: "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/test-writer-fixer",
-  installCommand: "claude plugins:add ccplugins/awesome-claude-code-plugins/plugins/test-writer-fixer",
+  installCommand: "/plugin marketplace add ccplugins/awesome-claude-code-plugins && /plugin install test-writer-fixer@awesome-claude-code-plugins",
 };

--- a/src/data/plugins/trail-of-bits-security.ts
+++ b/src/data/plugins/trail-of-bits-security.ts
@@ -12,7 +12,7 @@ export const trailOfBitsSecurityPlugin: Plugin = {
     url: "https://github.com/trailofbits",
   },
   repoUrl: "https://github.com/trailofbits/claude-code-config",
-  installCommand: "claude plugins add trail-of-bits-security",
+  installCommand: "/plugin install trail-of-bits-security",
   commands: [
     {
       name: "/security:audit",

--- a/src/data/plugins/turbo-commit.ts
+++ b/src/data/plugins/turbo-commit.ts
@@ -10,7 +10,7 @@ export const turboCommitPlugin: Plugin = {
     name: "Claude Directory",
     url: "https://github.com/tmcpa/claudedirectory",
   },
-  installCommand: "claude plugins add turbo-commit",
+  installCommand: "/plugin install turbo-commit",
   commands: [
     { name: "/tc", description: "Generate a conventional commit for staged changes" },
     { name: "/tc:amend", description: "Amend the last commit message" },

--- a/src/data/plugins/typescript-lsp.ts
+++ b/src/data/plugins/typescript-lsp.ts
@@ -11,7 +11,7 @@ export const typescriptLspPlugin: Plugin = {
     url: "https://github.com/anthropics",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add typescript-lsp@claude-plugins-official",
+  installCommand: "/plugin install typescript-lsp@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true

--- a/src/data/plugins/vercel.ts
+++ b/src/data/plugins/vercel.ts
@@ -11,7 +11,7 @@ export const vercelPlugin: Plugin = {
     url: "https://vercel.com",
   },
   repoUrl: "https://github.com/anthropics/claude-plugins-official",
-  installCommand: "claude plugins add vercel@claude-plugins-official",
+  installCommand: "/plugin install vercel@claude-plugins-official",
   config: `{
   "enabledPlugins": {
     "vercel@claude-plugins-official": true


### PR DESCRIPTION
## Summary

A user reported that plugin install commands didn't work — they had to fall back to the GitHub link to install. Confirmed: the repo was using `claude plugins add ...` (plural, wrong verb) across plugin entries, docs, and the ingestion pipeline. That command doesn't exist.

Per the [official Claude Code docs](https://code.claude.com/docs/en/discover-plugins), plugins install via:
- `/plugin install <name>@<marketplace>` (slash command, what most users see)
- `claude plugin install ...` (CLI, **singular** "plugin")

## What changed

- **64 curated plugin entries** under `src/data/plugins/` — verb fixed to `/plugin install`. For non-official marketplaces, prepended the `/plugin marketplace add ...` step.
- **946 auto-ingested entries** in `src/data/_ingested/plugins.json` — bulk-updated; non-official marketplaces now include the marketplace-add step.
- **Ingestion script** `scripts/ingest/marketplaces.mjs` — emits the correct format and reads the actual marketplace name from `marketplace.json` instead of guessing from the repo basename.
- **Verified marketplace/plugin-name corrections** (checked against the real `marketplace.json` for each repo):
  - `frontend-design`: `@claude-code-plugins` → `@claude-plugins-official`
  - `document-skills`: actually lives in `anthropic-agent-skills` at `anthropics/skills`, not `claude-plugins-official`
  - `claude-brain`: the real plugin in `memvid/claude-brain` is named `mind`, not `claude-brain`
  - `claude-mem`: confirmed in the `thedotmack` marketplace
  - `cloudflare`/`mongodb`/`terraform`: confirmed in `claude-plugins-official` (were using fictional npm-scoped names like `@cloudflare/claude-plugin`)
- **Tutorial** `src/data/how-to/plugins.ts` — removed fictional commands (`claude plugins list/search/status/remove/update`) and rewrote around the real `/plugin` interactive UI.
- **Blog post**, `claude-folder` how-to, `CONTRIBUTING.md` example — inline commands updated.

## Known gaps (not fixed in this PR)

These entries now use the correct syntax but reference plugins/marketplaces I couldn't verify exist:

- `anthropic-skills.ts` — no "anthropic-skills" bundle plugin exists; commands listed span multiple plugins. Now installs `document-skills` as a stand-in, but the slug/description are misleading.
- `astro`, `bun`, `shadcn` — reference a `@community` marketplace that I can't find on GitHub.
- `claude-diary`, `cursor-rules`, `dep-audit`, `env-manager`, `i18n-manager`, `kubernetes`, `monorepo-nav`, `netlify-plugin`, `perf-profiler`, `redis`, `storybook`, `trail-of-bits-security`, `turbo-commit` — couldn't find them in any known marketplace by that slug.

Worth a follow-up to remove or relocate these.

## Test plan

- [x] `npm run build` succeeds (6199 static pages generated, no errors)
- [ ] Spot-check a few plugin detail pages in the live site to confirm the copy-button shows the new command
- [ ] Try one of the corrected commands (e.g. `/plugin install code-review@claude-plugins-official`) in Claude Code to confirm it works