### PR TITLE
Add comparison pages: 'A vs B for [use case]'

### DIFF
--- a/src/app/compare/[type]/[pair]/for/[useCase]/page.tsx
+++ b/src/app/compare/[type]/[pair]/for/[useCase]/page.tsx
@@ -1,0 +1,369 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowLeft, ArrowRight, ExternalLink, Star } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { BreadcrumbJsonLd } from "@/components/json-ld";
+import { BASE_URL } from "@/lib/constants";
+import { getCurrentMonthYear } from "@/lib/seo";
+import { useCases } from "@/data/use-cases";
+import {
+  COMPARABLE_TYPE_LABELS,
+  type ComparableItem,
+  type ComparableType,
+  getAllComparisonParams,
+  getPoolForUseCase,
+  pairSlug,
+  resolveComparison,
+} from "@/lib/comparisons";
+
+interface Props {
+  params: Promise<{ type: string; pair: string; useCase: string }>;
+}
+
+const VALID_TYPES = new Set<ComparableType>([
+  "skills",
+  "plugins",
+  "mcp-servers",
+  "agents",
+]);
+
+function asComparableType(type: string): ComparableType | null {
+  return VALID_TYPES.has(type as ComparableType)
+    ? (type as ComparableType)
+    : null;
+}
+
+export function generateStaticParams() {
+  return getAllComparisonParams();
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { type, pair, useCase } = await props.params;
+  const t = asComparableType(type);
+  if (!t) return { title: "Not Found" };
+
+  const resolved = resolveComparison(t, pair, useCase);
+  if (!resolved) return { title: "Not Found" };
+
+  const { a, b, useCase: uc } = resolved;
+  const labels = COMPARABLE_TYPE_LABELS[t];
+  const month = getCurrentMonthYear();
+  const title = `${a.title} vs ${b.title}: which ${labels.singular} for ${uc.title} in Claude Code? (${month})`;
+  const description = `Side-by-side comparison of ${a.title} and ${b.title} for ${uc.title.toLowerCase()} in Claude Code. Tag fit, popularity, recency, and a pick-one verdict. Updated ${month}.`;
+  const url = `${BASE_URL}/compare/${t}/${pair}/for/${uc.slug}`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      ...uc.keywords,
+      `${a.title} vs ${b.title}`,
+      `${a.title} ${b.title} ${uc.title.toLowerCase()}`,
+      `claude code ${labels.singular.toLowerCase()} comparison`,
+      a.title.toLowerCase(),
+      b.title.toLowerCase(),
+    ],
+    openGraph: { title, description, url, type: "article" },
+    twitter: { card: "summary", title, description },
+    alternates: { canonical: url },
+  };
+}
+
+export default async function ComparePage(props: Props) {
+  const { type, pair, useCase } = await props.params;
+  const t = asComparableType(type);
+  if (!t) notFound();
+
+  const resolved = resolveComparison(t, pair, useCase);
+  if (!resolved) notFound();
+
+  const { a, b, useCase: uc, verdict } = resolved;
+  const labels = COMPARABLE_TYPE_LABELS[t];
+  const url = `${BASE_URL}/compare/${t}/${pair}/for/${uc.slug}`;
+  const heading = `${a.title} vs ${b.title} for ${uc.title}`;
+
+  // Side rail: same A paired against other pool members in the same use case.
+  const pool = getPoolForUseCase(t, uc);
+  const otherOpponents = pool.filter(
+    (item) => item.slug !== a.slug && item.slug !== b.slug,
+  );
+
+  return (
+    <div className="container py-8 max-w-4xl">
+      <BreadcrumbJsonLd
+        items={[
+          { name: "Home", url: BASE_URL },
+          { name: labels.plural, url: `${BASE_URL}${labels.path}` },
+          { name: uc.title, url: `${BASE_URL}/for/${uc.slug}` },
+          { name: `${a.title} vs ${b.title}`, url },
+        ]}
+      />
+
+      <Button variant="ghost" size="sm" asChild className="mb-6">
+        <Link href={`/for/${uc.slug}`}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {uc.title} setups
+        </Link>
+      </Button>
+
+      <header className="mb-8 max-w-3xl">
+        <h1 className="text-3xl font-bold mb-3">{heading}</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          Comparing two Claude Code {labels.plural.toLowerCase()} for{" "}
+          {uc.title.toLowerCase()}. Below: side-by-side facts, then a verdict
+          you can disagree with.
+        </p>
+      </header>
+
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">Side by side</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ItemColumn item={a} type={t} useCase={uc.tags} />
+          <ItemColumn item={b} type={t} useCase={uc.tags} />
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-3">Verdict</h2>
+        <Card>
+          <CardContent className="pt-6 space-y-3">
+            <p className="font-medium">{verdict.summary}</p>
+            <ul className="space-y-1 text-sm text-muted-foreground">
+              <li>{verdict.pickA}</li>
+              <li>{verdict.pickB}</li>
+              {verdict.tieBreaker && <li>{verdict.tieBreaker}</li>}
+            </ul>
+            {verdict.source === "heuristic" && (
+              <p className="text-xs text-muted-foreground pt-2 border-t">
+                Auto-generated from tag fit, popularity, recency, and featured
+                status. Not a hand review.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      {otherOpponents.length > 0 && (
+        <>
+          <Separator className="my-6" />
+          <section>
+            <h2 className="text-sm font-medium text-muted-foreground mb-3">
+              More {labels.plural.toLowerCase()} to compare for{" "}
+              {uc.title.toLowerCase()}
+            </h2>
+            <div className="flex flex-wrap gap-2 mb-6">
+              {otherOpponents.slice(0, 8).map((opp) => (
+                <Link
+                  key={opp.slug}
+                  href={`/compare/${t}/${pairSlug(a.slug, opp.slug)}/for/${uc.slug}`}
+                >
+                  <Badge
+                    variant="secondary"
+                    className="cursor-pointer hover:bg-accent"
+                  >
+                    {a.title} vs {opp.title}
+                  </Badge>
+                </Link>
+              ))}
+            </div>
+            <CrossUseCaseLinks
+              type={t}
+              a={a.slug}
+              b={b.slug}
+              currentUseCase={uc.slug}
+            />
+          </section>
+        </>
+      )}
+
+      <div className="border-t pt-6 mt-10">
+        <Link
+          href={`/for/${uc.slug}`}
+          className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+        >
+          Browse all {uc.title.toLowerCase()} setups
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ItemColumn({
+  item,
+  type,
+  useCase,
+}: {
+  item: ComparableItem;
+  type: ComparableType;
+  useCase: string[];
+}) {
+  const labels = COMPARABLE_TYPE_LABELS[type];
+  const ucSet = new Set(useCase);
+  const detailHref = `${labels.path}/${item.slug}`;
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-lg">
+            <Link href={detailHref} className="hover:underline">
+              {item.title}
+            </Link>
+          </CardTitle>
+          {item.featured && (
+            <Badge variant="default" className="text-xs">
+              Featured
+            </Badge>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground line-clamp-3">
+          {item.description}
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground mb-1.5">
+            Tags
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {item.tags.slice(0, 8).map((tag) => (
+              <Badge
+                key={tag}
+                variant={ucSet.has(tag) ? "default" : "secondary"}
+                className="text-xs"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-1 text-xs">
+          <dt className="text-muted-foreground">Author</dt>
+          <dd>
+            {item.author.url ? (
+              <a
+                href={item.author.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                {item.author.name}
+              </a>
+            ) : (
+              item.author.name
+            )}
+          </dd>
+
+          {typeof item.stars === "number" && (
+            <>
+              <dt className="text-muted-foreground">Stars</dt>
+              <dd className="inline-flex items-center gap-1">
+                <Star className="h-3 w-3" />
+                {item.stars.toLocaleString()}
+              </dd>
+            </>
+          )}
+
+          {item.lastUpdated && (
+            <>
+              <dt className="text-muted-foreground">Updated</dt>
+              <dd>
+                {new Date(item.lastUpdated).toLocaleDateString("en-US", {
+                  month: "short",
+                  year: "numeric",
+                })}
+              </dd>
+            </>
+          )}
+
+          {item.repoUrl && (
+            <>
+              <dt className="text-muted-foreground">Source</dt>
+              <dd>
+                <a
+                  href={item.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:underline"
+                >
+                  GitHub
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </dd>
+            </>
+          )}
+        </dl>
+
+        {item.installCommand && (
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground mb-1.5">
+              Install
+            </div>
+            <code className="block text-xs bg-muted rounded px-2 py-1.5 overflow-x-auto">
+              {item.installCommand}
+            </code>
+          </div>
+        )}
+
+        <div>
+          <Button variant="outline" size="sm" asChild className="w-full">
+            <Link href={detailHref}>View {labels.singular.toLowerCase()}</Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CrossUseCaseLinks({
+  type,
+  a,
+  b,
+  currentUseCase,
+}: {
+  type: ComparableType;
+  a: string;
+  b: string;
+  currentUseCase: string;
+}) {
+  // Show the same comparison under other use cases where both items still
+  // fit. Drops use cases where either item doesn't match.
+  const links = useCases
+    .filter((u) => u.slug !== currentUseCase)
+    .filter((u) => {
+      const pool = getPoolForUseCase(type, u);
+      const slugs = new Set(pool.map((p) => p.slug));
+      return slugs.has(a) && slugs.has(b);
+    });
+
+  if (links.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="text-sm font-medium text-muted-foreground mb-3">
+        Same comparison, other workflows
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {links.map((u) => (
+          <Link
+            key={u.slug}
+            href={`/compare/${type}/${pairSlug(a, b)}/for/${u.slug}`}
+          >
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent"
+            >
+              for {u.title}
+            </Badge>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,6 +9,7 @@ import { agents, getAllAgentTags } from "@/data/agents";
 import { blogPosts, getAllBlogPostTags } from "@/data/blog";
 import { useCases } from "@/data/use-cases";
 import { getCrossPageParams } from "@/lib/use-cases";
+import { getAllComparisonParams } from "@/lib/comparisons";
 import { BASE_URL } from "@/lib/constants";
 
 type SitemapId =
@@ -23,7 +24,8 @@ type SitemapId =
   | "blog"
   | "topics"
   | "use-cases"
-  | "cross";
+  | "cross"
+  | "compare";
 
 export async function generateSitemaps(): Promise<{ id: SitemapId }[]> {
   return [
@@ -39,6 +41,7 @@ export async function generateSitemaps(): Promise<{ id: SitemapId }[]> {
     { id: "topics" },
     { id: "use-cases" },
     { id: "cross" },
+    { id: "compare" },
   ];
 }
 
@@ -234,6 +237,14 @@ export default async function sitemap({
         })),
       );
     }
+
+    case "compare":
+      return getAllComparisonParams().map(({ type, pair, useCase }) => ({
+        url: `${BASE_URL}/compare/${type}/${pair}/for/${useCase}`,
+        lastModified: now,
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      }));
 
     default:
       return [];

--- a/src/data/comparisons.ts
+++ b/src/data/comparisons.ts
@@ -1,0 +1,16 @@
+// Editor-authored verdicts for specific comparisons. Keys are
+// `${type}|${aSlug}|${bSlug}|${useCaseSlug}` where (aSlug, bSlug) is the
+// alphabetized canonical pair — see canonicalPair() in lib/comparisons.ts.
+//
+// Any entry here replaces the auto-generated heuristic verdict on the
+// corresponding /compare page. Leave empty until a comparison is worth a
+// real take.
+
+export interface VerdictOverride {
+  summary: string;
+  pickA: string;
+  pickB: string;
+  tieBreaker?: string;
+}
+
+export const verdictOverrides: Record<string, VerdictOverride> = {};

--- a/src/lib/comparisons.ts
+++ b/src/lib/comparisons.ts
@@ -1,0 +1,225 @@
+// Comparison pages: "A vs B for [use case]".
+//
+// Pages are pre-rendered. To keep the page count and quality both bounded,
+// we only pair the top N items per (type, use case) by popularity/featured.
+// Within that pool we pair every combination, alphabetized so each pair
+// appears exactly once.
+//
+// A verdict for each comparison is auto-generated from a small heuristic
+// (tag overlap with the use case, stars, recency, featured). Editors can
+// override the verdict per (type, a, b, useCase) in data/comparisons.ts.
+
+import { skills } from "@/data/skills";
+import { plugins } from "@/data/plugins";
+import { mcpServers } from "@/data/mcp-servers";
+import { agents } from "@/data/agents";
+import type { Skill, Plugin, MCPServer, Agent } from "@/lib/types";
+import { useCases, type UseCase } from "@/data/use-cases";
+import { verdictOverrides } from "@/data/comparisons";
+
+export type ComparableType = "skills" | "plugins" | "mcp-servers" | "agents";
+
+export interface ComparableItem {
+  slug: string;
+  title: string;
+  description: string;
+  tags: string[];
+  author: { name: string; url?: string };
+  featured?: boolean;
+  stars?: number;
+  lastUpdated?: string;
+  repoUrl?: string;
+  installCommand?: string;
+}
+
+// Items per (type, use case) included in the comparison pool. With 4 types
+// and 10 use cases that caps generated pages at ~4 * 10 * (12 choose 2) = 2640.
+const POOL_SIZE = 12;
+
+const collections: Record<ComparableType, ComparableItem[]> = {
+  skills: skills as Skill[],
+  plugins: (plugins as Plugin[]).map((p) => ({ ...p })),
+  "mcp-servers": (mcpServers as MCPServer[]).map((m) => ({ ...m })),
+  agents: agents as Agent[],
+};
+
+export function getCollection(type: ComparableType): ComparableItem[] {
+  return collections[type];
+}
+
+export const COMPARABLE_TYPE_LABELS: Record<
+  ComparableType,
+  { singular: string; plural: string; path: string }
+> = {
+  skills: { singular: "Skill", plural: "Skills", path: "/skills" },
+  plugins: { singular: "Plugin", plural: "Plugins", path: "/plugins" },
+  "mcp-servers": {
+    singular: "MCP Server",
+    plural: "MCP Servers",
+    path: "/mcp-servers",
+  },
+  agents: { singular: "Agent", plural: "Agents", path: "/agents" },
+};
+
+function matchesUseCase(item: ComparableItem, useCase: UseCase): boolean {
+  const set = new Set(useCase.tags);
+  return item.tags.some((t) => set.has(t));
+}
+
+function tagOverlap(item: ComparableItem, useCase: UseCase): number {
+  const set = new Set(useCase.tags);
+  return item.tags.reduce((n, t) => n + (set.has(t) ? 1 : 0), 0);
+}
+
+function recencyBonus(lastUpdated?: string): number {
+  if (!lastUpdated) return 0;
+  const updated = new Date(lastUpdated).getTime();
+  if (Number.isNaN(updated)) return 0;
+  const ageMs = Date.now() - updated;
+  const sixMonthsMs = 1000 * 60 * 60 * 24 * 30 * 6;
+  return ageMs <= sixMonthsMs ? 1 : 0;
+}
+
+// Score used for two purposes: pool selection (which items make the cut)
+// and verdict tilt (which side the heuristic prefers).
+function scoreFor(item: ComparableItem, useCase: UseCase): number {
+  const overlap = tagOverlap(item, useCase);
+  const stars = Math.min(item.stars ?? 0, 5000); // cap so a viral repo doesn't dwarf fit
+  const featured = item.featured ? 1 : 0;
+  return overlap * 1000 + featured * 500 + stars * 0.1 + recencyBonus(item.lastUpdated) * 50;
+}
+
+export function getPoolForUseCase(
+  type: ComparableType,
+  useCase: UseCase,
+): ComparableItem[] {
+  return getCollection(type)
+    .filter((item) => matchesUseCase(item, useCase))
+    .sort((a, b) => scoreFor(b, useCase) - scoreFor(a, useCase))
+    .slice(0, POOL_SIZE);
+}
+
+// Alphabetized pair so each comparison has one canonical URL.
+export function canonicalPair(aSlug: string, bSlug: string): [string, string] {
+  return aSlug < bSlug ? [aSlug, bSlug] : [bSlug, aSlug];
+}
+
+export function pairSlug(aSlug: string, bSlug: string): string {
+  const [a, b] = canonicalPair(aSlug, bSlug);
+  return `${a}-vs-${b}`;
+}
+
+export function parsePair(
+  pair: string,
+): { a: string; b: string } | null {
+  // "a-vs-b" — slug can contain hyphens, so split on the literal " vs " marker.
+  const idx = pair.indexOf("-vs-");
+  if (idx <= 0 || idx >= pair.length - 4) return null;
+  const a = pair.slice(0, idx);
+  const b = pair.slice(idx + 4);
+  if (!a || !b || a === b) return null;
+  return { a, b };
+}
+
+export interface ComparisonParams {
+  type: ComparableType;
+  pair: string;
+  useCase: string;
+}
+
+export function getAllComparisonParams(): ComparisonParams[] {
+  const params: ComparisonParams[] = [];
+  for (const type of Object.keys(collections) as ComparableType[]) {
+    for (const useCase of useCases) {
+      const pool = getPoolForUseCase(type, useCase);
+      for (let i = 0; i < pool.length; i++) {
+        for (let j = i + 1; j < pool.length; j++) {
+          const [a, b] = canonicalPair(pool[i].slug, pool[j].slug);
+          params.push({ type, pair: `${a}-vs-${b}`, useCase: useCase.slug });
+        }
+      }
+    }
+  }
+  return params;
+}
+
+export interface ResolvedComparison {
+  type: ComparableType;
+  a: ComparableItem;
+  b: ComparableItem;
+  useCase: UseCase;
+  verdict: Verdict;
+}
+
+export interface Verdict {
+  source: "override" | "heuristic";
+  // One-liner summary.
+  summary: string;
+  // "Pick A if …" / "Pick B if …" / optional tie-breaker.
+  pickA: string;
+  pickB: string;
+  tieBreaker?: string;
+}
+
+export function resolveComparison(
+  type: ComparableType,
+  pair: string,
+  useCaseSlug: string,
+): ResolvedComparison | null {
+  const parsed = parsePair(pair);
+  if (!parsed) return null;
+  const useCase = useCases.find((u) => u.slug === useCaseSlug);
+  if (!useCase) return null;
+
+  const collection = getCollection(type);
+  const a = collection.find((i) => i.slug === parsed.a);
+  const b = collection.find((i) => i.slug === parsed.b);
+  if (!a || !b) return null;
+
+  // Both must matter for this use case.
+  if (!matchesUseCase(a, useCase) || !matchesUseCase(b, useCase)) return null;
+
+  const verdict = buildVerdict(type, a, b, useCase);
+  return { type, a, b, useCase, verdict };
+}
+
+function buildVerdict(
+  type: ComparableType,
+  a: ComparableItem,
+  b: ComparableItem,
+  useCase: UseCase,
+): Verdict {
+  const key = `${type}|${a.slug}|${b.slug}|${useCase.slug}`;
+  const override = verdictOverrides[key];
+  if (override) return { source: "override", ...override };
+
+  const aScore = scoreFor(a, useCase);
+  const bScore = scoreFor(b, useCase);
+  const aTags = new Set(a.tags);
+  const bTags = new Set(b.tags);
+  const aOnly = a.tags.filter((t) => !bTags.has(t));
+  const bOnly = b.tags.filter((t) => !aTags.has(t));
+
+  const aHook = aOnly[0] ?? a.tags[0] ?? useCase.title.toLowerCase();
+  const bHook = bOnly[0] ?? b.tags[0] ?? useCase.title.toLowerCase();
+
+  const summary =
+    aScore === bScore
+      ? `${a.title} and ${b.title} are close to a coin flip for ${useCase.title.toLowerCase()} — pick on stack fit.`
+      : aScore > bScore
+        ? `${a.title} edges out ${b.title} for ${useCase.title.toLowerCase()} on this site's signals (tag fit, popularity, recency).`
+        : `${b.title} edges out ${a.title} for ${useCase.title.toLowerCase()} on this site's signals (tag fit, popularity, recency).`;
+
+  return {
+    source: "heuristic",
+    summary,
+    pickA: `Pick ${a.title} if your project leans on ${aHook}.`,
+    pickB: `Pick ${b.title} if you need stronger ${bHook} support.`,
+    tieBreaker:
+      a.featured && !b.featured
+        ? `${a.title} is editor-featured on this site.`
+        : b.featured && !a.featured
+          ? `${b.title} is editor-featured on this site.`
+          : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- New route `/compare/[type]/[pair]/for/[useCase]` for skills, plugins, MCP servers, and agents — side-by-side cards plus a verdict.
- Pool capped at top 12 items per (type, use case) by tag fit + stars + recency + featured, yielding ~1,538 prerendered pages.
- Verdicts are auto-generated and clearly labeled as such; editors override per-pair via `src/data/comparisons.ts` keyed by `${type}|${a}|${b}|${useCase}`.
- Sitemap segment `compare` added so the new pages get indexed.

This is Phase 3 (moat-building): competes on judgment, not aggregation. Sample URL: `/compare/skills/pr-vs-security-audit/for/code-review`.

## Test plan
- [ ] `npm run build` succeeds and lists 1,538 paths under `/compare/[type]/[pair]/for/[useCase]`
- [ ] Spot-check a few rendered pages locally: verdict box renders, "auto-generated" disclaimer present, side-rail comparison badges link to canonical pair URLs
- [ ] Confirm `/sitemap/compare.xml` lists the new URLs
- [ ] Add one hand-written override to `src/data/comparisons.ts` and verify the disclaimer disappears on that page