### PR TITLE
Collapse listing-page tag walls into a compact, sorted filter

### DIFF
--- a/src/app/agents/_components/agents-listing.tsx
+++ b/src/app/agents/_components/agents-listing.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { AgentCard } from "@/components/cards/agent-card";
 import { Search } from "@/components/search";
+import { TopicTags } from "@/components/topic-tags";
 import { Badge } from "@/components/ui/badge";
-import { agents, getAllAgentTags, getAllAgentCategories } from "@/data/agents";
+import { agents, getAllAgentCategories } from "@/data/agents";
 import { Agent } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -22,7 +22,6 @@ const categoryLabels: Record<Agent["category"], string> = {
 export function AgentsListing() {
   const [search, setSearch] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<Agent["category"] | null>(null);
-  const allTags = getAllAgentTags();
   const allCategories = getAllAgentCategories();
 
   const filteredAgents = agents.filter((agent) => {
@@ -81,21 +80,7 @@ export function AgentsListing() {
           </div>
         </div>
 
-        <div>
-          <p className="text-sm text-muted-foreground mb-2">Tags</p>
-          <div className="flex flex-wrap gap-2">
-            {allTags.map((tag) => (
-              <Link key={tag} href={`/agents/topic/${tag}`}>
-                <Badge
-                  variant="secondary"
-                  className="cursor-pointer hover:bg-accent"
-                >
-                  {tag}
-                </Badge>
-              </Link>
-            ))}
-          </div>
-        </div>
+        <TopicTags items={agents} hrefPrefix="/agents/topic" label="Tags" />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/blog/_components/blog-listing.tsx
+++ b/src/app/blog/_components/blog-listing.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { BlogCard } from "@/components/cards/blog-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { blogPosts, getAllBlogPostTags } from "@/data/blog";
+import { TopicTags } from "@/components/topic-tags";
+import { blogPosts } from "@/data/blog";
 
 export function BlogListing() {
   const [search, setSearch] = useState("");
-  const allTags = getAllBlogPostTags();
 
   const filteredPosts = blogPosts.filter((post) => {
     return (
@@ -34,21 +32,7 @@ export function BlogListing() {
         </div>
       </div>
 
-      <div className="space-y-3">
-        <div className="flex flex-wrap gap-2">
-          <span className="text-sm text-muted-foreground mr-2">Topic:</span>
-          {allTags.map((tag) => (
-            <Link key={tag} href={`/blog/topic/${tag}`}>
-              <Badge
-                variant="secondary"
-                className="cursor-pointer hover:bg-accent"
-              >
-                {tag}
-              </Badge>
-            </Link>
-          ))}
-        </div>
-      </div>
+      <TopicTags items={blogPosts} hrefPrefix="/blog/topic" label="Topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredPosts.map((post) => (

--- a/src/app/hooks/_components/hooks-listing.tsx
+++ b/src/app/hooks/_components/hooks-listing.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { HookCard } from "@/components/cards/hook-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { hooks, getAllHookTags } from "@/data/hooks";
+import { TopicTags } from "@/components/topic-tags";
+import { hooks } from "@/data/hooks";
 
 export function HooksListing() {
   const [search, setSearch] = useState("");
-  const allTags = getAllHookTags();
 
   const filteredHooks = hooks.filter((hook) => {
     return (
@@ -34,18 +32,7 @@ export function HooksListing() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {allTags.map((tag) => (
-          <Link key={tag} href={`/hooks/topic/${tag}`}>
-            <Badge
-              variant="secondary"
-              className="cursor-pointer hover:bg-accent"
-            >
-              {tag}
-            </Badge>
-          </Link>
-        ))}
-      </div>
+      <TopicTags items={hooks} hrefPrefix="/hooks/topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredHooks.map((hook) => (

--- a/src/app/how-to/_components/how-to-listing.tsx
+++ b/src/app/how-to/_components/how-to-listing.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { HowToCard } from "@/components/cards/how-to-card";
 import { Search } from "@/components/search";
+import { TopicTags } from "@/components/topic-tags";
 import { Badge } from "@/components/ui/badge";
-import { howTos, getAllHowToTags } from "@/data/how-to";
+import { howTos } from "@/data/how-to";
 import { cn } from "@/lib/utils";
 
 const difficulties = ["beginner", "intermediate", "advanced"] as const;
@@ -13,7 +13,6 @@ const difficulties = ["beginner", "intermediate", "advanced"] as const;
 export function HowToListing() {
   const [search, setSearch] = useState("");
   const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
-  const allTags = getAllHowToTags();
 
   const filteredHowTos = howTos.filter((howTo) => {
     const matchesSearch =
@@ -69,19 +68,7 @@ export function HowToListing() {
           ))}
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          <span className="text-sm text-muted-foreground mr-2">Topic:</span>
-          {allTags.map((tag) => (
-            <Link key={tag} href={`/how-to/topic/${tag}`}>
-              <Badge
-                variant="secondary"
-                className="cursor-pointer hover:bg-accent"
-              >
-                {tag}
-              </Badge>
-            </Link>
-          ))}
-        </div>
+        <TopicTags items={howTos} hrefPrefix="/how-to/topic" label="Topic" />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/mcp-servers/_components/mcp-servers-listing.tsx
+++ b/src/app/mcp-servers/_components/mcp-servers-listing.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { MCPCard } from "@/components/cards/mcp-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
+import { TopicTags } from "@/components/topic-tags";
 import { Button } from "@/components/ui/button";
-import { mcpServers, getAllMCPServerTags } from "@/data/mcp-servers";
+import { mcpServers } from "@/data/mcp-servers";
 import {
   INITIAL_DISPLAY_COUNT,
   SHOW_MORE_INCREMENT,
@@ -17,7 +16,6 @@ import {
 export function MCPServersListing() {
   const [search, setSearch] = useState("");
   const [displayCount, setDisplayCount] = useState(INITIAL_DISPLAY_COUNT);
-  const allTags = getAllMCPServerTags();
 
   const sortedServers = useMemo(() => sortListingItems(mcpServers), []);
 
@@ -57,18 +55,7 @@ export function MCPServersListing() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {allTags.map((tag) => (
-          <Link key={tag} href={`/mcp-servers/topic/${tag}`}>
-            <Badge
-              variant="secondary"
-              className="cursor-pointer hover:bg-accent"
-            >
-              {tag}
-            </Badge>
-          </Link>
-        ))}
-      </div>
+      <TopicTags items={mcpServers} hrefPrefix="/mcp-servers/topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {visibleServers.map((server) => (

--- a/src/app/plugins/_components/plugins-listing.tsx
+++ b/src/app/plugins/_components/plugins-listing.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { PluginCard } from "@/components/cards/plugin-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
+import { TopicTags } from "@/components/topic-tags";
 import { Button } from "@/components/ui/button";
-import { plugins, getAllPluginTags } from "@/data/plugins";
+import { plugins } from "@/data/plugins";
 import {
   INITIAL_DISPLAY_COUNT,
   SHOW_MORE_INCREMENT,
@@ -17,7 +16,6 @@ import {
 export function PluginsListing() {
   const [search, setSearch] = useState("");
   const [displayCount, setDisplayCount] = useState(INITIAL_DISPLAY_COUNT);
-  const allTags = getAllPluginTags();
 
   const sortedPlugins = useMemo(() => sortListingItems(plugins), []);
 
@@ -57,18 +55,7 @@ export function PluginsListing() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {allTags.map((tag) => (
-          <Link key={tag} href={`/plugins/topic/${tag}`}>
-            <Badge
-              variant="secondary"
-              className="cursor-pointer hover:bg-accent"
-            >
-              {tag}
-            </Badge>
-          </Link>
-        ))}
-      </div>
+      <TopicTags items={plugins} hrefPrefix="/plugins/topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {visiblePlugins.map((plugin) => (

--- a/src/app/prompts/_components/prompts-listing.tsx
+++ b/src/app/prompts/_components/prompts-listing.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { PromptCard } from "@/components/cards/prompt-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
-import { prompts, getAllPromptTags } from "@/data/prompts";
+import { TopicTags } from "@/components/topic-tags";
+import { prompts } from "@/data/prompts";
 
 export function PromptsListing() {
   const [search, setSearch] = useState("");
-  const allTags = getAllPromptTags();
 
   const filteredPrompts = prompts.filter((prompt) => {
     return (
@@ -34,18 +32,7 @@ export function PromptsListing() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {allTags.map((tag) => (
-          <Link key={tag} href={`/prompts/topic/${tag}`}>
-            <Badge
-              variant="secondary"
-              className="cursor-pointer hover:bg-accent"
-            >
-              {tag}
-            </Badge>
-          </Link>
-        ))}
-      </div>
+      <TopicTags items={prompts} hrefPrefix="/prompts/topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredPrompts.map((prompt) => (

--- a/src/app/skills/_components/skills-listing.tsx
+++ b/src/app/skills/_components/skills-listing.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { SkillCard } from "@/components/cards/skill-card";
 import { Search } from "@/components/search";
-import { Badge } from "@/components/ui/badge";
+import { TopicTags } from "@/components/topic-tags";
 import { Button } from "@/components/ui/button";
-import { skills, getAllSkillTags } from "@/data/skills";
+import { skills } from "@/data/skills";
 import {
   INITIAL_DISPLAY_COUNT,
   SHOW_MORE_INCREMENT,
@@ -17,7 +16,6 @@ import {
 export function SkillsListing() {
   const [search, setSearch] = useState("");
   const [displayCount, setDisplayCount] = useState(INITIAL_DISPLAY_COUNT);
-  const allTags = getAllSkillTags();
 
   const sortedSkills = useMemo(() => sortListingItems(skills), []);
 
@@ -57,18 +55,7 @@ export function SkillsListing() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {allTags.map((tag) => (
-          <Link key={tag} href={`/skills/topic/${tag}`}>
-            <Badge
-              variant="secondary"
-              className="cursor-pointer hover:bg-accent"
-            >
-              {tag}
-            </Badge>
-          </Link>
-        ))}
-      </div>
+      <TopicTags items={skills} hrefPrefix="/skills/topic" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {visibleSkills.map((skill) => (

--- a/src/components/topic-tags.tsx
+++ b/src/components/topic-tags.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface TaggedItem {
+  tags: string[];
+}
+
+interface TopicTagsProps {
+  items: TaggedItem[];
+  hrefPrefix: string;
+  label?: string;
+  initialCount?: number;
+  className?: string;
+}
+
+const DEFAULT_INITIAL_COUNT = 18;
+
+export function TopicTags({
+  items,
+  hrefPrefix,
+  label = "Browse by topic",
+  initialCount = DEFAULT_INITIAL_COUNT,
+  className,
+}: TopicTagsProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const sortedTags = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      for (const tag of item.tags) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries()).sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    });
+  }, [items]);
+
+  if (sortedTags.length === 0) return null;
+
+  const visible = expanded ? sortedTags : sortedTags.slice(0, initialCount);
+  const hidden = sortedTags.length - visible.length;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="text-xs text-muted-foreground">
+          {sortedTags.length} topic{sortedTags.length === 1 ? "" : "s"}
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {visible.map(([tag, count]) => (
+          <Link key={tag} href={`${hrefPrefix}/${tag}`}>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer hover:bg-accent gap-1.5"
+            >
+              <span>{tag}</span>
+              <span className="text-muted-foreground text-[10px] font-normal tabular-nums">
+                {count}
+              </span>
+            </Badge>
+          </Link>
+        ))}
+        {hidden > 0 && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground underline underline-offset-4 px-1"
+          >
+            +{hidden} more
+          </button>
+        )}
+        {expanded && sortedTags.length > initialCount && (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground underline underline-offset-4 px-1"
+          >
+            Show less
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The plugins, skills, hooks, mcp-servers, prompts, agents, blog, and how-to listing pages all opened with a wall of every topic tag rendered above the cards. On `/plugins` that was ~200 badges — the page looked like a data dump before any real content was visible.

This PR replaces the per-page tag rendering with a shared `TopicTags` component.

## What changed

- New `src/components/topic-tags.tsx`:
  - Adds a **"Browse by topic"** header with a topic count, so the section reads as a deliberate filter.
  - **Sorts tags by frequency** (popular first) instead of alphabetical, surfacing the most useful filters.
  - Shows the **item count** next to each tag badge.
  - **Collapses to the top 18 tags** by default with a `+N more` / `Show less` toggle. The plugins page now lands at ~2 rows of badges instead of ~10.
- Eight listing components updated to use it: agents, blog, hooks, how-to, mcp-servers, plugins, prompts, skills.
- No changes to the card grid, search, sort logic, or per-tag (`/topic/[tag]`) pages.

## Test plan

- [ ] Visit `/plugins` — tag section is compact, headed "Browse by topic", with item counts and a "+N more" toggle.
- [ ] Expand the topic list, then collapse with "Show less".
- [ ] Click a topic badge — still routes to `/plugins/topic/<tag>`.
- [ ] Repeat on `/skills`, `/hooks`, `/mcp-servers`, `/prompts`, `/agents`, `/blog`, `/how-to`.
- [ ] Confirm card grid, search, and "Show more" pagination behave unchanged.