### PR TITLE
Fix Skills card description on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ const categories = [
   },
   {
     name: "Skills",
-    description: "Custom slash commands and workflows",
+    description: "Model-invoked capabilities with bundled context",
     href: "/skills",
     icon: Zap,
   },


### PR DESCRIPTION
## Summary
- Updates the Skills category card on the homepage from "Custom slash commands and workflows" to "Model-invoked capabilities with bundled context"
- The previous copy conflated Skills (model-invoked, loaded into context when relevant) with slash commands (user-invoked)

## Test plan
- [ ] Load the homepage and confirm the Skills card description renders the new copy