### PR TITLE
Restore sitemap index at public/sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://claudedirectory.org/sitemap/static.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/prompts.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/mcp-servers.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/hooks.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/skills.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/plugins.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/how-to.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/agents.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/blog.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/topics.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/use-cases.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/cross.xml</loc></sitemap>
+  <sitemap><loc>https://claudedirectory.org/sitemap/compare.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary

- Restores `public/sitemap.xml` (deleted in #77) — this file is the sitemap index, not a "shadow" of the dynamic route.
- Adds the new `compare.xml` shard that PR #66 introduced.
- Fixes Search Console's "Couldn't fetch" error and the associated drop in indexed pages / page views.

## Root cause

PR #77 (`5489a61`) removed `public/sitemap.xml` believing it was shadowing `src/app/sitemap.ts`. That premise is incorrect: Next.js's `generateSitemaps()` only serves the individual shards at `/sitemap/<id>.xml` — it does **not** auto-generate an index at `/sitemap.xml`. The deleted file *was* the index that tied the shards together.

Verified via curl against production:

| URL | Status |
| --- | --- |
| `https://www.claudedirectory.org/sitemap.xml` | **404** |
| `https://www.claudedirectory.org/sitemap/static.xml` | 200 |
| `https://www.claudedirectory.org/sitemap/compare.xml` | 200 |

Search Console's "Last read: May 21" matches the day after #77 was merged, and "Couldn't fetch" matches the 404. The apex→www 307 redirect is harmless (Googlebot follows redirects); the 404 at the destination is the real problem.

## Test plan

- [ ] After Vercel deploy, `curl -I https://www.claudedirectory.org/sitemap.xml` returns 200 with `content-type: application/xml`
- [ ] Each shard listed in the index returns 200 (`static`, `prompts`, `mcp-servers`, `hooks`, `skills`, `plugins`, `how-to`, `agents`, `blog`, `topics`, `use-cases`, `cross`, `compare`)
- [ ] In Search Console, click the three-dot menu next to the sitemap and resubmit; status should flip to "Success" on the next read
- [ ] Monitor the Pages / Indexing report over the following week to confirm page count recovers