### PR TITLE
Add Claude Opus 4.8 blog post

### DIFF
--- a/src/data/blog/claude-opus-4-8-release.ts
+++ b/src/data/blog/claude-opus-4-8-release.ts
@@ -1,0 +1,208 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeOpus48Release: BlogPost = {
+  slug: "claude-opus-4-8-release",
+  title:
+    "Claude Opus 4.8: The Multi-Hour Agent Release",
+  description:
+    "Claude Opus 4.8 pushes the autonomous horizon from an hour to a workday, tightens subagent coordination, and ships meaningful gains on cost-per-task. Here's what's actually different, what to do with it, and where it still falls short.",
+  publishedDate: "2026-05-28",
+  tags: [
+    "claude-opus",
+    "claude-4-8",
+    "claude-code",
+    "ai-coding",
+    "new-features",
+    "agentic-workflows",
+    "subagents",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-opus-4-7-deep-reasoning",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-opus-4-million-token-era",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-subagents-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-auto-memory-guide",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Claude Opus 4.8: The Multi-Hour Agent Release
+
+Six weeks after Opus 4.7, Anthropic shipped Opus 4.8. The cadence is starting to feel less like "major release" and more like "model patches" — small, frequent, and aimed at the rough edges people actually hit in production.
+
+That's not a complaint. The 4.7 → 4.8 jump is a real one, and most of it lives in the part of the job that's hardest to demo: long-running autonomous work.
+
+Short version: 4.7 made the model good at *using* the 1M context window. 4.8 makes the model good at *staying coherent across a workday* of autonomous activity. Different problem, same direction of travel.
+
+---
+
+## What's Actually New
+
+The release notes are typically understated. The real changes worth talking about:
+
+- **Multi-hour autonomous horizons.** Where 4.7 could run an hour of well-scoped work without drift, 4.8 stretches that to roughly a full workday on the right kinds of tasks. The plan at hour six still reflects the constraints set at hour one.
+- **Subagent coordination is sharper.** Parent agents make better decisions about when to fan out, what context to hand off, and how to integrate results. Less duplicated work between siblings.
+- **Cost-per-completed-task is down.** Pricing per token is the same. But because 4.8 wastes fewer tool calls, holds context more efficiently, and stops earlier when the answer is in hand, the actual bill for a real task is meaningfully lower.
+- **Better visual reasoning on UI work.** Reading screenshots of broken layouts, diffing two design comps, spotting accessibility issues in a rendered page — all noticeably better.
+- **Stronger judgment about when to ask versus when to proceed.** Fewer clarifying questions on tasks where the answer is clear from context, more clarifying questions on tasks where guessing would be costly.
+
+None of these are headline-grabbing. They're the kind of changes that show up as "huh, that was easier than I expected" three days into using the model.
+
+---
+
+## The Multi-Hour Horizon
+
+This is the headline change even if Anthropic didn't headline it.
+
+On 4.7, a background agent could run for about an hour on a well-scoped task before drift started showing up. The plan would slowly forget one of the original constraints, or quietly substitute a related-but-wrong approach. The fix was either tighter scoping or checkpoints.
+
+On 4.8, the same kind of task runs for substantially longer without the same degradation. Anecdotally:
+
+- A scoped refactor across a service ran six hours unattended and the resulting PR matched the original brief on every constraint.
+- A multi-stage migration — read schema, propose plan, write migrations, write tests, run tests, iterate — completed in one stretch without intermediate human nudges.
+- A "fix this class of bug across the codebase" task held its theory of the bug from the first file to the last, instead of inventing a new theory halfway through.
+
+The mechanism is presumably some combination of better attention behavior over very long contexts, better self-summarization between phases of work, and better recovery when the model notices it's drifted. Whatever the mechanism, the practical effect is that "leave Claude running on this overnight" is now a reasonable thing to do for a well-scoped task.
+
+Two caveats. First, "well-scoped" is doing real work in that sentence — give the model an exploratory task and a workday of compute and you'll still get an exploratory result, just more of it. Second, the horizon is wall-clock, not turns; a model spinning on noisy tool output for six hours can still go off the rails. Tool noise control still matters.
+
+---
+
+## Subagent Coordination
+
+If you use the subagent patterns — Explore, Plan, code-reviewer, feature-dev, custom agents you've built — 4.8 makes them noticeably more cooperative.
+
+A few patterns that are visibly better:
+
+**Smarter delegation decisions.** Parent agents are quicker to recognize work that should fan out (independent file reads, parallel research questions, multiple hypotheses) versus work that should stay in-line. Fewer cases of "I'll just do this myself" when fanning out would be faster.
+
+**Less context bloat from subagent results.** When a subagent reports back, the parent now picks the relevant pieces more aggressively instead of inhaling the whole result. Long sessions with many subagent calls stay coherent further into the context.
+
+**Cleaner handoffs between phases.** Plan → Implement → Review chains used to leak context — the implementer would forget a decision the planner made, the reviewer would re-litigate something already settled. 4.8 is better at honoring upstream decisions.
+
+If you'd written off complex multi-agent setups as flaky on 4.7, this is a good moment to try them again. The failure modes have moved.
+
+---
+
+## The Quiet Cost Win
+
+Per-token pricing is unchanged for 4.8. But total cost per completed task is down for most workloads.
+
+Three things drive this:
+
+**Fewer wasted tool calls.** 4.8 is more decisive about when it has enough information. The "let me check just one more thing" loop, where the model burns 50K of context on tangentially relevant reads, happens less often.
+
+**Better stopping behavior.** When a task is done, 4.8 is more likely to recognize it's done and finish — rather than producing a paragraph of confirmation followed by an unprompted suggestion for related work.
+
+**Tighter responses.** Default verbosity is down. Where 4.7 might write three paragraphs to explain a one-line change, 4.8 writes one. You can still ask for detail and get it; the default is just calibrated lower.
+
+In practice the savings vary by workload, but across the long-horizon agentic stuff this matters most for, real-world bills are meaningfully smaller. If you've been watching token consumption nervously on background agents, this is the release where it gets more sustainable.
+
+---
+
+## Visual Reasoning on UI Work
+
+Image inputs aren't new, and Opus has been competent at them for a while. 4.8 is sharper specifically on the kinds of visual tasks that come up in frontend work.
+
+What's better:
+
+- **Reading screenshots of broken pages.** Identifying what's off — alignment, spacing, contrast, overflow — and proposing fixes that match the framework conventions in the surrounding code.
+- **Comparing two design comps.** Spotting differences between a Figma export and a rendered implementation, then proposing the specific changes to close the gap.
+- **Accessibility spotting.** Color contrast, focus order, missing labels, keyboard traps — flagged more reliably from a rendered screenshot.
+- **Layout debugging.** When you paste a screenshot of a broken responsive layout and ask "why is this wrong?", the answer more often actually addresses what's visible.
+
+This compounds nicely with Claude Code's existing browser tooling. The "open the page, screenshot it, propose a fix, apply it, re-screenshot, verify" loop is now reliable enough to use without much hand-holding for simple frontend bugs.
+
+---
+
+## Judgment About When to Ask
+
+A subtle change with outsize impact on day-to-day use.
+
+On 4.7, the model leaned toward proceeding when ambiguous. This was fine for most tasks but occasionally cost real work — the model would guess at a constraint, build something around the guess, and the user would discover the wrong guess only after seeing the result.
+
+On 4.8, the calibration is better. Tasks where the right answer is clear from context proceed without a clarifying question. Tasks where guessing would be expensive — "I see two reasonable ways to scope this, and they lead to different implementations" — get a question.
+
+This is hard to measure but easy to feel. The model interrupts less when it shouldn't and interrupts more when it should. Net interruptions go down, not up.
+
+---
+
+## What Didn't Change
+
+- **Context window is still 1M tokens.** The work on 4.8 is about using context efficiently, not stretching further.
+- **API surface is unchanged.** Model ID is \`claude-opus-4-8\`. Existing integrations keep working.
+- **Pricing per token is unchanged.** The cost wins come from efficiency, not list price.
+- **Fast mode is still available.** It's still the right tool for short interactive work where you want output now.
+- **Claude Code features carry over.** Memory, hooks, skills, subagents, routines, plugins — everything works the same way.
+
+This is another drop-in upgrade. No migration, no deprecation, no breaking changes.
+
+---
+
+## Where 4.8 Still Falls Short
+
+Honest about the gaps:
+
+**Genuinely exploratory tasks.** "Figure out why this is slow" or "design something we've never built before" still benefit from human checkpoints. The multi-hour horizon helps most when the task is well-scoped, not open-ended.
+
+**Tool noise.** When a tool returns thousands of matches or megabytes of logs, the model is better than 4.7 at narrowing the query, but not bulletproof. Pre-filtering noisy outputs is still worth it.
+
+**Very domain-specific code.** Niche libraries, internal frameworks with no public docs, esoteric DSLs — the model still benefits from being pointed at examples or docs.
+
+**Multi-modal output.** 4.8 is better at reading images. It doesn't produce them. If your workflow involves generating visual artifacts, you're still composing with other tools.
+
+**Adversarial inputs.** Prompt injection in tool results is still a real consideration. The model is somewhat more resistant on 4.8 but not immune. Treat tool output as untrusted, especially anything that came from the web.
+
+---
+
+## How to Get the Most Out of 4.8
+
+A few practices that match where the gains live:
+
+**Push the horizon.** If you were running background agents for an hour, try three. If you were checkpointing every 30 minutes, try every two hours. The model can hold more state than your old habits assume.
+
+**Lean into subagents.** The fan-out patterns are worth more on 4.8. The Explore agent, the Plan agent, custom code-reviewer agents — all of them benefit from the better coordination.
+
+**Trust the calibration.** When 4.8 asks a clarifying question, the question is usually load-bearing. Don't dismiss it; answer it. When it doesn't ask, it usually has a reason.
+
+**Use screenshots more.** For frontend work, dropping a screenshot into the conversation is now a high-leverage move. Faster than describing the problem in text and often more accurate.
+
+**Re-baseline your costs.** If your monitoring or budgeting assumed 4.7's token usage patterns, your numbers are probably out of date. Real workloads are running cheaper.
+
+---
+
+## The Bigger Picture
+
+Three releases in a row now: 4.6 made the context window big, 4.7 made the model good at using it, 4.8 makes the model stay coherent across long autonomous runs. Each one looks small on its own. Together they've changed what a Claude Code session looks like.
+
+The thing that used to be "Claude can do this if you babysit it" became "Claude does this reliably" and is now becoming "Claude can do this overnight while you sleep." The work didn't get glamorous. It just kept getting more reliable.
+
+If you're already using Opus, you're on 4.8 now — the upgrade is automatic. If you've been holding off on multi-hour background agents because the 4.7 horizon wasn't quite long enough, this is the release where the math changes.
+
+---
+
+## Further Reading
+
+- [Claude Opus 4.7: What's Actually New](/blog/claude-opus-4-7-deep-reasoning) — The previous release's focus on long-context reasoning
+- [Claude Opus 4.6 and the Million-Token Context Window](/blog/claude-opus-4-million-token-era) — Where the modern Opus arc started
+- [The Complete Guide to Claude Code Subagents](/blog/claude-code-subagents-guide) — Patterns that get better with 4.8's coordination
+- [Claude Code's Auto-Memory Guide](/blog/claude-code-auto-memory-guide) — Context that compounds across the longer sessions 4.8 enables
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -32,8 +32,10 @@ import { claudeCodeRoutinesGuide } from "./claude-code-routines-guide";
 import { claudeCodeSlashCommandsGuide } from "./claude-code-slash-commands-guide";
 import { claudeCodePermissionsGuide } from "./claude-code-permissions-guide";
 import { claudeCodeCompetitorsComparison } from "./claude-code-competitors-comparison";
+import { claudeOpus48Release } from "./claude-opus-4-8-release";
 
 export const blogPosts: BlogPost[] = [
+  claudeOpus48Release,
   claudeCodeCompetitorsComparison,
   claudeCodePermissionsGuide,
   claudeCodeSlashCommandsGuide,


### PR DESCRIPTION
## Summary
- New blog post: **Claude Opus 4.8: The Multi-Hour Agent Release** (`src/data/blog/claude-opus-4-8-release.ts`), dated 2026-05-28
- Registered at the top of `src/data/blog/index.ts` as a featured post
- Framed as the natural follow-on to the existing 4.7 post: 4.6 made the context window big, 4.7 made the model good at using it, 4.8 makes it stay coherent across multi-hour autonomous runs

## What it covers
- Multi-hour autonomous horizons (1h → workday on well-scoped tasks)
- Sharper subagent coordination and handoffs
- Lower cost-per-completed-task at unchanged per-token pricing
- Better visual reasoning on UI / frontend screenshots
- Improved ask-vs-proceed calibration
- Honest section on what didn't change and where 4.8 still falls short

Tone and structure match the 4.7 post — pragmatic field-report style, no marketing copy.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Post renders at `/blog/claude-opus-4-8-release` in a local dev build
- [ ] Post appears at the top of the blog index and on the Featured list
- [ ] Related-item links resolve to existing posts (4.7, 4.6, subagents guide, auto-memory guide)