### PR TITLE
SEO: www→non-www redirect, sharpen top-page titles

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.claudedirectory.org" }],
+        destination: "https://claudedirectory.org/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/data/blog/anthropic-claude-certification-program.ts
+++ b/src/data/blog/anthropic-claude-certification-program.ts
@@ -7,9 +7,9 @@ export const anthropicClaudeCertificationProgram: BlogPost = {
   description:
     "Anthropic just launched its first official certification — the Claude Certified Architect. Here's what it covers, who it's for, and how to prepare.",
   seoTitle:
-    "Claude Certified Architect (CCA) Exam – Anthropic's Proctored Skilljar Certification Guide",
+    "How to Get Anthropic's Claude Certification: Complete CCA Exam Guide (2026)",
   seoDescription:
-    "Complete guide to Anthropic's Claude Certification Program and the Claude Certified Architect (CCA) exam. Skilljar-proctored, 60 questions — topics, format, cost, and how to prepare.",
+    "Step-by-step guide to passing Anthropic's Claude Certified Architect (CCA) exam — topics covered, cost, format, study plan, and how to prepare in 2026.",
   publishedDate: "2026-03-16",
   tags: [
     "claude-code",

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -4,8 +4,8 @@ export const frontendDesignPlugin: Plugin = {
   slug: "frontend-design",
   title: "Frontend Design",
   description: "Create distinctive, production-grade frontend interfaces with high design quality. UI/UX specialist plugin that generates polished, creative code avoiding generic AI aesthetics. Supports React, Vue, Svelte, and vanilla HTML/CSS with modern design patterns.",
-  seoTitle: "Install Frontend Design Plugin for Claude Code – frontend-design@claude-plugins-official (2026)",
-  seoDescription: "Step-by-step install guide for the frontend-design plugin. Run `/plugin install frontend-design@claude-plugins-official` in Claude Code to generate production-grade React, Vue, and Svelte UIs — setup in under a minute.",
+  seoTitle: "Frontend Design Plugin for Claude Code: Production-Grade UI in One Command (2026)",
+  seoDescription: "Generate polished React, Vue, and Svelte components with Anthropic's official frontend-design plugin. One install command, modern design patterns, no generic AI aesthetics — setup in under a minute.",
   tags: ["frontend", "design", "ui", "ux", "react", "official"],
   featured: true,
   author: {


### PR DESCRIPTION
## Summary

Three targeted SEO fixes driven by Search Console data over the last 3 months (6.08K clicks / 272K impressions / 2.2% CTR / 8.3 avg position).

- **Add 301 redirect from `www.claudedirectory.org` to the canonical apex domain** ([next.config.ts](../blob/claude/wizardly-heisenberg-c6f404/next.config.ts)). GSC currently lists both `www` and non-`www` variants of the same pages — e.g. `/plugins/frontend-design` appears on both subdomains — splitting Google's authority and depressing rankings. The canonical tag in `layout.tsx` already points to non-`www`; this redirect makes the server enforce it.
- **Rewrite the SEO title for the Anthropic Claude Certification blog post.** It pulls 8,516 impressions but only ~1.8% CTR. The old title led with "Skilljar/Proctored" — internal jargon nobody searches for. New title leads with a how-to action verb that matches the dominant search intent.
- **Rewrite the frontend-design plugin SEO title.** Top-performing page (871 clicks / 17.9K impressions) but the `@claude-plugins-official` suffix was eating the title's persuasion budget in SERP snippets. New title leads with the benefit; description leads with concrete frameworks (React/Vue/Svelte).

## Why

CTR is the cheapest lever available given the impression volume: at 2.2% there are ~266K impressions per quarter that don't convert. Even moving to 3% CTR on a handful of high-impression pages would add ~2K+ clicks/quarter. The www/non-www split is a silent leak that costs ranking on every page, not just one.

## Test plan

- [ ] After merge + deploy: visit `https://www.claudedirectory.org/plugins/frontend-design` and confirm it 301s to `https://claudedirectory.org/plugins/frontend-design`.
- [ ] Spot-check that `https://claudedirectory.org/` and other non-`www` URLs still serve normally (no redirect loop).
- [ ] In Google Search Console: re-request indexing for `/plugins/frontend-design` and `/blog/anthropic-claude-certification-program` so the new titles propagate to SERPs faster.
- [ ] Monitor GSC over the next 2–4 weeks to confirm CTR lift on the two retitled pages and consolidation of impressions onto the apex domain.

## Not included (follow-ups)

- Mobile Core Web Vitals review (needs a real Lighthouse run, not a code change).
- Long-tail query mining from GSC rows 20–100 (needs the GSC CSV export).
- Internal linking pass to boost `/plugins/frontend-design` (depends on which source pages we want to link from).