### PR TITLE
Hotfix: revert www→non-www redirect (prod redirect loop)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  async redirects() {
-    return [
-      {
-        source: "/:path*",
-        has: [{ type: "host", value: "www.claudedirectory.org" }],
-        destination: "https://claudedirectory.org/:path*",
-        permanent: true,
-      },
-    ];
-  },
+  /* config options here */
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Reverts the `redirects()` block added to `next.config.ts` in #80.

The redirect was intended to consolidate `www.claudedirectory.org` → `claudedirectory.org` for SEO. In production it causes **ERR_TOO_MANY_REDIRECTS** on the apex domain — Vercel is already redirecting at the platform level, so the Next.js-level redirect creates an infinite loop.

The SEO title changes from #80 (`anthropic-claude-certification-program.ts`, `frontend-design.ts`) are kept — only the `next.config.ts` redirect block is reverted.

## Right way to fix the www split

Configure it in Vercel's domain settings (Project Settings → Domains → set `claudedirectory.org` as primary, mark `www.claudedirectory.org` as redirect-to-primary). That avoids the code-level loop entirely.

## Test plan

- [ ] After deploy, visit `https://claudedirectory.org/` — should load normally, no redirect error.
- [ ] Visit `https://www.claudedirectory.org/` — should still 301 to apex (via Vercel platform redirect, if configured).

This should be merged ASAP — production is currently broken.