### PR TITLE
Revert PR #80 (production redirect loop)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  async redirects() {
-    return [
-      {
-        source: "/:path*",
-        has: [{ type: "host", value: "www.claudedirectory.org" }],
-        destination: "https://claudedirectory.org/:path*",
-        permanent: true,
-      },
-    ];
-  },
+  /* config options here */
 };
 
 export default nextConfig;

--- a/src/data/blog/anthropic-claude-certification-program.ts
+++ b/src/data/blog/anthropic-claude-certification-program.ts
@@ -7,9 +7,9 @@ export const anthropicClaudeCertificationProgram: BlogPost = {
   description:
     "Anthropic just launched its first official certification — the Claude Certified Architect. Here's what it covers, who it's for, and how to prepare.",
   seoTitle:
-    "How to Get Anthropic's Claude Certification: Complete CCA Exam Guide (2026)",
+    "Claude Certified Architect (CCA) Exam – Anthropic's Proctored Skilljar Certification Guide",
   seoDescription:
-    "Step-by-step guide to passing Anthropic's Claude Certified Architect (CCA) exam — topics covered, cost, format, study plan, and how to prepare in 2026.",
+    "Complete guide to Anthropic's Claude Certification Program and the Claude Certified Architect (CCA) exam. Skilljar-proctored, 60 questions — topics, format, cost, and how to prepare.",
   publishedDate: "2026-03-16",
   tags: [
     "claude-code",

--- a/src/data/plugins/frontend-design.ts
+++ b/src/data/plugins/frontend-design.ts
@@ -4,8 +4,8 @@ export const frontendDesignPlugin: Plugin = {
   slug: "frontend-design",
   title: "Frontend Design",
   description: "Create distinctive, production-grade frontend interfaces with high design quality. UI/UX specialist plugin that generates polished, creative code avoiding generic AI aesthetics. Supports React, Vue, Svelte, and vanilla HTML/CSS with modern design patterns.",
-  seoTitle: "Frontend Design Plugin for Claude Code: Production-Grade UI in One Command (2026)",
-  seoDescription: "Generate polished React, Vue, and Svelte components with Anthropic's official frontend-design plugin. One install command, modern design patterns, no generic AI aesthetics — setup in under a minute.",
+  seoTitle: "Install Frontend Design Plugin for Claude Code – frontend-design@claude-plugins-official (2026)",
+  seoDescription: "Step-by-step install guide for the frontend-design plugin. Run `/plugin install frontend-design@claude-plugins-official` in Claude Code to generate production-grade React, Vue, and Svelte UIs — setup in under a minute.",
   tags: ["frontend", "design", "ui", "ux", "react", "official"],
   featured: true,
   author: {


### PR DESCRIPTION
Reverts #80.

The `next.config.ts` redirect from `www.claudedirectory.org` → `claudedirectory.org` caused **ERR_TOO_MANY_REDIRECTS** in production. Vercel already handles the www→apex redirect at the platform level, so the Next.js redirect created an infinite loop.

This is a full `git revert -m 1` of the merge commit — both the redirect and the two SEO title changes are reverted. Merge ASAP to restore production.

The www/non-www consolidation should be configured in **Vercel → Project Settings → Domains** (set apex as primary, mark www as redirect-to-primary), not in code. The SEO title rewrites can be re-applied in a follow-up PR after this is merged.