### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -94,6 +94,7 @@ import { trelloServer } from "./trello";
 import { googleColabServer } from "./google-colab";
 import { apifyServer } from "./apify";
 import { rnwy } from "./rnwy";
+import { publicGrantsServer } from "./public-grants";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -205,6 +206,8 @@ const curatedMcpServers: MCPServer[] = [
   googleColabServer,
   apifyServer,
   rnwy,
+  // Finance & Grants
+  publicGrantsServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/public-grants.ts
+++ b/src/data/mcp-servers/public-grants.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const publicGrantsServer: MCPServer = {
+  slug: "public-grants",
+  title: "Public Grants",
+  description:
+    "Grants advisor for French startups and AI agents. 21 tools: profile pre-fill, profile enrichment, eligibility DSL across 49 programmes (CIR, JEI, BPI, CNC, ADEME, EIC), drafting with .md/.docx export, and strategic briefing PDF. Rules coded from official legal texts - not hallucinated. Free discovery; EUR 49/dossier vs EUR 2,000-5,000 at a consulting firm. EU-hosted, RGPD compliant.",
+  tags: ["grants", "france", "startup", "finance", "government", "ai-agents"],
+  featured: false,
+  author: {
+    name: "PyratzLabs",
+    url: "https://pyratzlabs.com",
+  },
+  config: `{
+  "mcpServers": {
+    "public-grants": {
+      "url": "https://grants.mrchief.ai/mcp/"
+    }
+  }
+}`,
+};
+


### PR DESCRIPTION
## Add Public Grants MCP server

**Grants advisor for French startups and AI agents.**

Traditional grant consultants charge EUR 2,000-5,000 + success fees. Public Grants: **free discovery, EUR 49/dossier, 15 minutes for eligibility**. No subscription.

**21 MCP tools + 3 guided prompts** covering the full workflow:
- **Onboarding:** profile pre-fill (SIRENE registry), profile enrichment (auto-enrichment + customisable input)
- **Discovery:** search 49 programmes, per-rule eligibility check (pass/fail/unknown from official legal texts)
- **Drafting:** preview, draft, validate, save, export (.md / .docx)
- **Briefing:** free strategic consultant briefing with downloadable PDF

**49 programmes, 5 verticals:** Tech (CIR, JEI, i-Nov), Culture (CNC, CNM), Climate (ADEME), EU (EIC Accelerator), Regional (Innov'Up, PM'up).

Works with Claude, Cursor, VS Code, or any MCP-compatible AI agent. EU-hosted (Fly.io Paris + Supabase Frankfurt), RGPD compliant.

Built by [PyratzLabs](https://pyratzlabs.com) | https://grants.mrchief.ai