### PR TITLE
Remove stat strip from homepage hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,15 +73,6 @@ export default function Home() {
     plugins.length +
     agents.length;
 
-  const stats = [
-    { label: "MCP servers", value: mcpServers.length },
-    { label: "Plugins", value: plugins.length },
-    { label: "Agents", value: agents.length },
-    { label: "Skills", value: skills.length },
-    { label: "Prompts", value: prompts.length },
-    { label: "Hooks", value: hooks.length },
-  ];
-
   return (
     <div className="flex flex-col">
       {/* Hero Section */}
@@ -130,22 +121,6 @@ export default function Home() {
                 Get Started Guide
               </Link>
             </Button>
-          </div>
-
-          {/* Stat strip — social proof */}
-          <div className="mt-12 w-full">
-            <div className="grid grid-cols-3 gap-3 sm:grid-cols-6 sm:gap-6">
-              {stats.map((s) => (
-                <div key={s.label} className="text-center">
-                  <div className="text-2xl font-bold tracking-tight sm:text-3xl">
-                    {s.value}
-                  </div>
-                  <div className="text-xs text-muted-foreground sm:text-sm">
-                    {s.label}
-                  </div>
-                </div>
-              ))}
-            </div>
           </div>
 
           {/* Compact inline newsletter — one row, no card */}


### PR DESCRIPTION
## What changed

Removes the six-count stat strip (MCP servers, Plugins, Agents, Skills, Prompts, Hooks) from the homepage hero in `src/app/page.tsx`, along with the now-unused `stats` array.

## Why

The strip rendered six large bold numbers directly beneath the search box and primary CTAs, making it the loudest element in the hero and pulling attention away from the actions we want visitors to take (search, "Browse Skills", "Get Started Guide").

The social-proof signal it provided isn't lost:
- The **`{totalConfigs}+ community-curated configurations`** badge at the top of the hero still conveys the directory's scale.
- The **Browse by Use Case** section further down still shows per-category item counts.

Net effect: the hero now reads cleanly as **search → CTAs → newsletter**.

## Reviewer notes

- Pure removal — no behavior or data changes. `totalConfigs` is retained (still used by the hero badge).
- Typechecks clean (`tsc --noEmit`); no remaining references to `stats`.
- Verified locally on `localhost:3000` that the strip no longer renders.