### PR TITLE
Add blog posts: extension comparison guide + /loop guide

### DIFF
--- a/src/data/blog/claude-code-loop-guide.ts
+++ b/src/data/blog/claude-code-loop-guide.ts
@@ -1,0 +1,174 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeCodeLoopGuide: BlogPost = {
+  slug: "claude-code-loop-guide",
+  title: "Claude Code /loop: Run a Prompt on a Schedule Without Leaving Your Session",
+  description:
+    "The /loop command runs a prompt or slash command on a repeating interval inside your active Claude Code session — polling a deploy, babysitting tests, iterating until something passes. Here's how it works, when to use it, and how it differs from routines.",
+  publishedDate: "2026-06-24",
+  tags: [
+    "claude-code",
+    "loops",
+    "automation",
+    "slash-commands",
+    "routines",
+    "ai-coding",
+    "productivity",
+  ],
+  featured: false,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-code-routines-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-skills-vs-subagents-vs-mcp",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-slash-commands-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-hooks-guide",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Claude Code /loop: Run a Prompt on a Schedule Without Leaving Your Session
+
+Some work isn't one-and-done. You want Claude to *keep* doing something — check the deploy every few minutes until it's green, re-run the failing test after each fix, poll a long migration, watch a queue. You could babysit it yourself, hitting enter every time. Or you could hand the repetition to \`/loop\`.
+
+\`/loop\` runs a prompt or a slash command **repeatedly, on an interval, inside your current session**. It's the simplest automation primitive in Claude Code: no config files, no cloud setup, no cron syntax to memorize. You type one line and Claude keeps going until you stop it or the goal is met.
+
+This guide covers what \`/loop\` is, the two ways to run it, the jobs it's genuinely good at, the ones it isn't, and exactly how it differs from [routines](/blog/claude-code-routines-guide) — the cloud-based cousin people constantly confuse it with.
+
+---
+
+## What /loop Actually Does
+
+\`/loop\` takes a task and re-runs it on a cadence in your live session. Each iteration is a real Claude turn: it reads the current state, does the work, and reports back, then waits for the next tick.
+
+The basic form takes an interval and a task:
+
+\`\`\`
+/loop 5m check the deploy status and tell me if it's live yet
+\`\`\`
+
+You can loop a **slash command** just as easily — handy for re-running a skill or a saved workflow:
+
+\`\`\`
+/loop 10m /babysit-prs
+\`\`\`
+
+Intervals are short and human: \`30s\`, \`5m\`, \`1h\`. Every tick, Claude runs the task fresh, so it always sees the *current* state — the latest CI result, the newest queue depth, the file as it is now.
+
+Two things make this different from just asking Claude to "keep checking":
+
+- **It's deterministic about cadence.** The loop fires on schedule, not whenever the conversation happens to wander back to it.
+- **It's hands-off.** You start it once and walk away. The session does the repeating, not you.
+
+---
+
+## The Two Modes: Fixed Interval vs. Self-Paced
+
+\`/loop\` runs in one of two modes, and picking the right one matters.
+
+**Fixed interval — you set the clock.** Give it an interval and it fires on that schedule, full stop. This is what you want when the *thing you're watching* changes on its own timeline and you just need to check in:
+
+\`\`\`
+/loop 2m poll the build at https://ci.example.com/job/42 and ping me the moment it finishes
+\`\`\`
+
+**Self-paced — Claude sets the clock.** Omit the interval and you hand pacing to the model. It decides how long to wait before the next iteration based on what's happening — checking more often when things are moving, backing off when they're idle:
+
+\`\`\`
+/loop keep refining the failing test until the suite passes, then stop
+\`\`\`
+
+The rule of thumb: **use a fixed interval when an external clock drives the work** (a deploy that takes ~8 minutes, a queue you check every 30 seconds), and **let it self-pace when the work itself drives the rhythm** (iterate, evaluate, decide whether to go again). Self-pacing also avoids a classic waste — hammering a check every 60 seconds when the thing you're waiting on only changes every 10 minutes.
+
+---
+
+## When /loop Is the Right Tool
+
+\`/loop\` shines on **short-horizon, in-session repetition** — work you'd otherwise sit and babysit:
+
+- **Polling external state.** "Watch the deploy / the CI run / the queue and tell me when it changes." The canonical use case.
+- **Iterate-until-green.** "Run the tests, fix what fails, repeat until they pass." The loop carries the goal across attempts so you don't re-prompt each round.
+- **Monitoring during a work session.** Keep an eye on error rates, a long-running job's progress, or a metric while you do something else in the same terminal.
+- **Periodic housekeeping while you work.** Re-run a lint pass or a status summary every N minutes during a long session.
+
+The common thread: you're **present**, the horizon is **minutes to hours**, and the value is in *not* having to manually re-trigger the same step.
+
+---
+
+## When /loop Is the Wrong Tool
+
+\`/loop\` is in-session and model-driven, which makes it the wrong choice for a few things:
+
+- **It stops when your session does.** Close the terminal, lose the connection, or shut the laptop and the loop ends. For anything that must run unattended — overnight, while you're away, on a real schedule — you want a **routine**, not a loop.
+- **It costs tokens every tick.** Each iteration is a full Claude turn. A tight interval on a long-running watch can burn through tokens fast. Match the interval to how often the state actually changes, and prefer self-pacing for idle waits.
+- **It's not for one-off work.** If you just need something done once, ask once. \`/loop\` is for repetition.
+- **It's not an event trigger.** "Do X *when a file changes*" or "block commits to main" is a [hook](/blog/claude-code-hooks-guide), which fires deterministically on a harness event — not a loop polling for the event.
+
+---
+
+## /loop vs. Routines: The Distinction That Trips Everyone Up
+
+These two get conflated constantly because both "run Claude on a schedule." The difference is **where they run and whether you need to be there.**
+
+| | \`/loop\` | Routines |
+|---|----------|----------|
+| **Where it runs** | Your active session, on your machine | The cloud, on Anthropic's infra |
+| **Needs you present?** | Yes — dies with the session | No — runs unattended |
+| **Trigger** | Interval (or self-paced) | Cron schedule, webhook, or GitHub event |
+| **Setup** | One line, zero config | A saved prompt + configuration |
+| **Best horizon** | Minutes to hours | Days, weeks, ongoing |
+| **Typical job** | Babysitting a deploy while you work | The nightly dependency-bump PR |
+
+The one-sentence version: **\`/loop\` repeats on a timer while you're watching; a routine runs on its own when you're not.** If you'd close the laptop and expect the work to continue, that's a routine — start with the [routines guide](/blog/claude-code-routines-guide). If you're at the keyboard and just don't want to keep hitting enter, that's \`/loop\`.
+
+---
+
+## Practical Tips
+
+A few things that make \`/loop\` behave:
+
+- **Give it a stop condition.** "...until the suite passes, then stop" or "...until the deploy is live" lets the loop end itself. Without one, it runs until *you* stop it — fine for open-ended monitoring, wasteful otherwise.
+- **Match the interval to reality.** If the deploy takes eight minutes, don't poll every 30 seconds — you'll pay for fifteen checks that all say "still building." Poll every two minutes, or self-pace.
+- **Loop a slash command for anything non-trivial.** Inline prompts are great for quick checks; for a real procedure, wrap it in a [slash command or skill](/blog/claude-code-slash-commands-guide) and loop *that*. The loop stays readable and the logic is reusable.
+- **Watch the token cost on long watches.** A loop that runs for hours is a lot of turns. Self-pacing and a sensible interval are your main levers.
+- **Stop it when you're done.** Interrupt the session to end the loop. It won't outlive the session, but it also won't stop on its own unless you gave it a condition.
+
+---
+
+## Where /loop Fits in the Bigger Picture
+
+\`/loop\` is one piece of Claude Code's automation story, and it helps to see the whole shape:
+
+- **Hooks** react to *events* — deterministic, on a file edit or session stop.
+- **\`/loop\`** repeats on a *timer*, in your session, while you're there.
+- **Routines** run on a *schedule or trigger*, in the cloud, while you're not.
+
+All three are about *when* work runs — a different axis from *what* Claude can do, which is the job of skills, subagents, and MCP servers. For the full map of how these fit together, see [Skills vs Subagents vs MCP vs Hooks](/blog/claude-code-skills-vs-subagents-vs-mcp).
+
+\`/loop\` is the one you reach for most casually: no setup, no commitment, just "keep doing this until I say stop." For everything that needs to outlive your session, graduate to a routine.
+
+---
+
+## Further Reading
+
+- [Claude Code Routines: Putting Claude on Autopilot](/blog/claude-code-routines-guide) — the unattended, cloud-based counterpart to \`/loop\`
+- [Skills vs Subagents vs MCP vs Hooks](/blog/claude-code-skills-vs-subagents-vs-mcp) — how every extension and automation mechanism fits together
+- [The Complete Guide to Claude Code Slash Commands](/blog/claude-code-slash-commands-guide) — build the reusable commands worth looping
+- [Claude Code Hooks: The Complete Guide](/blog/claude-code-hooks-guide) — event-based automation, the third kind
+`,
+};

--- a/src/data/blog/claude-code-skills-vs-subagents-vs-mcp.ts
+++ b/src/data/blog/claude-code-skills-vs-subagents-vs-mcp.ts
@@ -1,0 +1,285 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeCodeSkillsVsSubagentsVsMcp: BlogPost = {
+  slug: "claude-code-skills-vs-subagents-vs-mcp",
+  title:
+    "Skills vs Subagents vs MCP vs Hooks: Which Claude Code Extension Should You Use?",
+  description:
+    "Claude Code has six ways to extend it — CLAUDE.md, skills, subagents, MCP servers, hooks, and plugins — and they overlap just enough to be confusing. This decision guide explains what each one is, when to reach for it, when not to, and how to combine them.",
+  publishedDate: "2026-06-24",
+  tags: [
+    "claude-code",
+    "skills",
+    "subagents",
+    "mcp",
+    "hooks",
+    "plugins",
+    "loops",
+    "routines",
+    "customization",
+    "ai-coding",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "how-to-create-claude-skills",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-subagents-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "mcp-servers-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-hooks-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-md-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "best-claude-code-plugins",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-routines-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-loop-guide",
+      relationship: "recommends",
+    },
+  ],
+  content: `# Skills vs Subagents vs MCP vs Hooks: Which Claude Code Extension Should You Use?
+
+If you've spent any time customizing Claude Code, you've hit the question: should this be a **skill**? A **subagent**? An **MCP server**? A **hook**? A line in **CLAUDE.md**? A **plugin**? Or should it just run on a **loop** or a scheduled **routine**?
+
+They all "extend Claude Code," which is exactly why people get stuck. The names don't tell you which job each one is for, and they overlap just enough that two of them can usually be bent to solve the same problem — badly.
+
+Here's the shortcut, and the rest of this guide just unpacks it: **each mechanism answers a different question.** Once you know which question you're asking, the choice is obvious.
+
+- *What should Claude always know?* → **CLAUDE.md**
+- *What repeatable task should Claude be able to do on demand?* → **Skill**
+- *What big or parallel job needs its own clean context?* → **Subagent**
+- *What external system does Claude need to reach?* → **MCP server**
+- *What must happen automatically, every time, no matter what the model decides?* → **Hook**
+- *When and how often should something run on its own?* → **a \`/loop\` or a routine** (automation is its own axis — more on that below)
+- *How do I package and share all of the above?* → **Plugin**
+
+Let's make that concrete.
+
+---
+
+## The 30-Second Comparison
+
+| Mechanism | Who triggers it | What it actually is | Reach for it when… |
+|-----------|-----------------|---------------------|--------------------|
+| **CLAUDE.md** | Always loaded | Persistent instructions and project context | Claude keeps forgetting a convention it should always follow |
+| **Skill** | Claude (auto) or you (\`/name\`) | A bundled prompt + optional scripts and files for one repeatable task | You do the same multi-step thing often and want it packaged |
+| **Subagent** | Claude delegates to it | A fresh, isolated context window for a focused job | A task is big, parallelizable, or would pollute your main context |
+| **MCP server** | Claude calls its tools | A bridge to an external system (DB, API, browser, SaaS) | Claude needs data or actions that live outside your repo |
+| **Hook** | The harness, on lifecycle events | A deterministic shell command tied to an event | Something must run *every* time, regardless of the model's choices |
+| **Plugin** | You install it | A package bundling any of the above | You want to share or reuse a whole setup in one step |
+
+The single most useful distinction in that table: **who pulls the trigger.** Skills and subagents are *model-invoked* — Claude decides to use them. Hooks are *deterministic* — the harness fires them on events whether the model likes it or not. MCP is *connectivity* — it just makes external tools available. CLAUDE.md is *context* — it's always there. Plugins are *distribution* — they bundle the rest.
+
+---
+
+## CLAUDE.md: The Things Claude Should Always Know
+
+\`CLAUDE.md\` is a Markdown file Claude Code loads into context automatically at the start of a session. It's not executable and it's not clever — it's a standing brief. Project conventions, the commands to run tests, architectural rules, "never touch this directory," your preferred libraries.
+
+**Use it when:** you find yourself repeating the same correction. "Use pnpm, not npm." "Tests live next to the file." "Don't add comments unless asked." If you've said it twice, it belongs in CLAUDE.md.
+
+**Don't use it when:** the instruction only matters for one specific task (that's a skill), or the knowledge is huge (a 4,000-line CLAUDE.md just burns context on every turn — keep it tight and link out instead).
+
+The trap is bloat. CLAUDE.md is loaded *every* turn, so every line is a tax on your context window. Treat it like a cheat sheet, not a wiki.
+
+---
+
+## Skills: Repeatable Tasks, Packaged
+
+A **skill** is a folder with a \`SKILL.md\` file — a name, a description, an instruction set, and optionally scripts and reference files it can pull in. Claude reads the description and invokes the skill automatically when a request matches, or you can call it explicitly as a slash command.
+
+The key idea: a skill is *progressive disclosure*. The description sits in context cheaply; the full instructions and bundled files only load when the skill actually fires. That makes a skill the right home for a procedure that's too long for CLAUDE.md and too specific to be always-on — generating a release changelog, scaffolding a component to your house style, running your PDF-export pipeline.
+
+**Use it when:** there's a repeatable, multi-step task with a clear procedure — especially one with its own scripts or templates.
+
+**Don't use it when:** you just need Claude to *know* a fact (CLAUDE.md), or the work needs its own isolated context and parallelism (subagent), or it's really about reaching an external system (MCP).
+
+Skills are also the unit most worth borrowing rather than writing. A good chunk of the [Claude Directory skills collection](/skills) is copy-paste-ready. If you do roll your own, the [guide to creating custom skills](/blog/how-to-create-claude-skills) walks through the \`SKILL.md\` format end to end.
+
+---
+
+## Subagents: A Clean Context for a Focused Job
+
+A **subagent** is a separate Claude instance with its own context window, spawned by the main agent to handle one slice of work and report back. Claude Code ships with built-ins like \`Explore\` (read-only search) and \`general-purpose\`, and you can define your own in \`.claude/agents/\` with a name, description, tool allowlist, and model.
+
+Subagents buy you two things money can't otherwise: **context isolation** and **parallelism**. A code search that would dump fifty files into your main context can run in a subagent that reads all fifty and returns a three-line conclusion. And N independent subagents can run at once — review four files in parallel, scout three subsystems simultaneously.
+
+**Use it when:** a task is large, noisy, or embarrassingly parallel — broad searches, multi-file reviews, "go understand this whole subsystem and summarize it."
+
+**Don't use it when:** the task is small and linear (just do it inline), or it's really a reusable procedure (skill), or you need a persistent guardrail (hook). Subagents are also one-shot delegations — they can't carry on a conversation with you, only return a result.
+
+The deeper patterns — agent teams, fan-out, model tiering for cost — are in the [subagents guide](/blog/claude-code-subagents-guide) and the [custom agents guide](/blog/claude-code-agents-guide).
+
+---
+
+## MCP Servers: The Bridge to Everything Outside Your Repo
+
+The **Model Context Protocol** is the open standard for connecting Claude to external systems. An MCP server exposes *tools* (actions Claude can call), *resources* (data it can read), and *prompts*. Connect one and Claude Code can query your Postgres database, open pull requests, drive a browser, read Sentry errors, or hit any API the server wraps.
+
+The litmus test is simple: **does the capability live outside your codebase?** Files, code, and shell commands are already covered by Claude Code's built-in tools — you don't need MCP for those. MCP is for the things Claude *can't* reach on its own: your production database, your issue tracker, your design tool, your observability stack.
+
+**Use it when:** Claude needs to read from or act on an external system.
+
+**Don't use it when:** the "tool" is just a shell script or a code transformation — that's a skill or a plain Bash call, and wrapping it in an MCP server is over-engineering. (For more on when MCP is and isn't the right call, see [Is MCP Dead?](/blog/is-mcp-dead).)
+
+Browse [MCP servers in the directory](/mcp-servers) to see what's already wrapped, and the [complete MCP guide](/blog/mcp-servers-guide) for setup and configuration.
+
+---
+
+## Hooks: The Things That Must Happen Automatically
+
+A **hook** is a shell command the Claude Code harness runs on a lifecycle event — \`PreToolUse\`, \`PostToolUse\`, \`UserPromptSubmit\`, \`Stop\`, \`SessionStart\`, and more. Configured in \`settings.json\`, hooks are the *deterministic* layer: they fire regardless of what the model decides, which is exactly the point.
+
+This is the one mechanism the model doesn't control, and that's its whole value. Auto-format every file after an edit. Block writes to \`.env\`. Run the test suite when Claude says it's done. Log every command for audit. If the rule is "this happens *every* time, no exceptions," a hook is the only tool that guarantees it — a skill or a CLAUDE.md note can be skipped by the model; a hook cannot.
+
+**Use it when:** you need a guardrail or an automation that must run on an event, deterministically.
+
+**Don't use it when:** the action requires judgment about *whether* to run (let the model decide via a skill), or it's a one-off (just ask).
+
+The [hooks guide](/blog/claude-code-hooks-guide) has copy-paste configs for the common cases, and the [directory's hooks collection](/hooks) has more.
+
+---
+
+## Plugins: The Wrapper Around All of It
+
+A **plugin** isn't a seventh kind of thing — it's a *bundle* of the other six. A plugin can ship skills, subagents, hooks, MCP server configs, and slash commands together, installable in one step from a marketplace.
+
+**Use it when:** you've built a setup worth sharing, or you want to install someone else's curated stack (a security-review bundle, a framework-specific toolkit) without wiring up each piece by hand.
+
+**Don't use it when:** you're solving a single problem for a single repo — that's just one skill or one hook, and packaging it as a plugin is premature.
+
+See the [best Claude Code plugins](/blog/best-claude-code-plugins) roundup and the full [plugins collection](/plugins).
+
+---
+
+## The Decision Flow
+
+When you're not sure, walk down this list and stop at the first "yes":
+
+1. **Does it need to reach an external system (DB, API, browser, SaaS)?** → **MCP server.**
+2. **Must it run automatically on an event, every time, no exceptions?** → **Hook.**
+3. **Should it run on a timer or a schedule, rather than on demand?** → **a \`/loop\` or a routine** (see the next section).
+4. **Is it a big, noisy, or parallelizable job that needs its own context?** → **Subagent.**
+5. **Is it a repeatable multi-step procedure Claude should do on demand?** → **Skill.**
+6. **Is it just something Claude should always know?** → **CLAUDE.md.**
+7. **Do you want to share a whole setup in one install?** → **Plugin.**
+
+The order matters: the more specific, infrastructure-y answers (external reach, deterministic events, scheduling) come first, because if one of those fits, it's almost always the right call. The general-purpose context tools (skills, CLAUDE.md) are the fallback.
+
+---
+
+## They Work Best Together
+
+The real power move is combining them. A few patterns that show up constantly:
+
+- **Skill + subagents:** a "review this PR" skill that spawns parallel subagents, one per file, then synthesizes.
+- **MCP + skill:** an MCP server connects to your database; a skill wraps the exact query-and-report workflow you run against it weekly.
+- **Hook + CLAUDE.md:** CLAUDE.md says "we use Prettier"; a \`PostToolUse\` hook actually runs it, so the rule can't be forgotten.
+- **Plugin = all of it:** a single \`security-review\` plugin ships the skill, the subagents, the hooks, and the MCP config as one install.
+
+You're not picking *one* mechanism for your whole workflow. You're picking the right one for each piece.
+
+---
+
+## Where Loops and Routines Fit
+
+A fair objection: what about \`/loop\` and routines? They're real, they're current, and they're deliberately *not* in the table above — because they sit on a different axis.
+
+The six mechanisms so far answer **"what can Claude do, know, or reach?"** Loops and routines answer **"when and how often does the work run?"** That's automation, not capability — and it comes in three flavors worth keeping straight:
+
+- **Hooks** — *event-based.* Fire on a lifecycle event (a tool call, a session start, a stop). Deterministic, in-session, and free. Covered above.
+- **\`/loop\`** — *interval-based, in your session.* Runs a prompt or slash command repeatedly inside your *active* session, on your machine — "re-run the failing test every 5 minutes," "keep polling this PR until it's green." It lives and dies with the session that started it.
+- **Routines** — *schedule- or trigger-based, in the cloud.* A saved prompt that runs unattended on a cron schedule, a webhook, or a GitHub event — no open session required. This is the autopilot tier.
+
+The clean mental model: **hooks react to events, \`/loop\` repeats on a timer while you're watching, and routines run on their own when you're not.** So if your question is "how do I make Claude do this automatically on a cadence," the answer isn't a skill or a subagent — it's a loop (you're around) or a routine (you're not). The [\`/loop\` guide](/blog/claude-code-loop-guide) covers the in-session side and the [routines guide](/blog/claude-code-routines-guide) covers the cloud side, end to end.
+
+Note the natural pairing: the *what* and the *when* combine. A routine's saved prompt usually *invokes a skill*, which may *delegate to subagents* and *call MCP tools* — the automation layer decides when work runs, and the extension layer decides what that work is.
+
+---
+
+## Frequently Asked Questions
+
+### What's the difference between a skill and a subagent?
+
+A **skill** is a packaged set of instructions (plus optional scripts) that runs in your current context — it's *what* to do. A **subagent** is a separate Claude instance with its own context window — it's *where* the work runs. Use a skill for a repeatable procedure; use a subagent when that work is large or parallel enough that it shouldn't crowd your main session. They compose: a skill can delegate to subagents.
+
+### When should I use an MCP server instead of a skill?
+
+Use an **MCP server** when the capability lives *outside* your codebase — a database, an API, a browser, a SaaS product. Use a **skill** when the work is a procedure over things Claude can already touch (your files, code, and shell). If you catch yourself building an MCP server just to run a local script, you want a skill instead.
+
+### Are slash commands the same as skills?
+
+They're closely related. A **skill** can be invoked two ways: automatically, when Claude matches your request to its description, or explicitly, when you type it as a \`/slash-command\`. Slash commands are the manual entry point into a skill — same underlying mechanism, different trigger.
+
+### Do hooks cost tokens?
+
+No. Hooks are shell commands run by the harness, not by the model — they don't consume context or tokens the way a skill or subagent does. That's part of why they're the right tool for always-on guardrails: they're deterministic *and* free.
+
+### Are \`/loop\` and routines extensions like skills or hooks?
+
+Not quite — they're *automation*, a different axis. Skills, subagents, MCP, and hooks change *what Claude can do*; loops and routines change *when it runs*. \`/loop\` repeats a prompt inside your active session on an interval, on your machine; **routines** run a saved prompt unattended in the cloud on a schedule or trigger. Reach for them when the question is about cadence, not capability — and note they usually call the extension mechanisms (a routine that runs a skill, for example) rather than replace them.
+
+### What's the simplest way to start customizing Claude Code?
+
+Start with **CLAUDE.md** — write down the conventions you keep repeating. Then add a **skill** for the first multi-step task you do often. Reach for subagents, MCP servers, and hooks only when you hit the specific need each one solves. Don't build infrastructure you don't have a problem for yet.
+
+---
+
+## The Bottom Line
+
+The six mechanisms aren't competitors — they're a toolkit, and the confusion only comes from trying to pick a favorite instead of matching the tool to the job:
+
+- **CLAUDE.md** for what Claude should always know.
+- **Skills** for repeatable tasks, packaged.
+- **Subagents** for big or parallel work that needs a clean context.
+- **MCP servers** to reach the world outside your repo.
+- **Hooks** for what must happen automatically, every time.
+- **Plugins** to bundle and share it all.
+
+And on the automation axis, **loops and routines** decide *when* that work runs — on a timer in your session, or on a schedule in the cloud.
+
+Learn the question each one answers, and you'll stop guessing.
+
+---
+
+## Further Reading
+
+- [How to Create Custom Claude Code Skills](/blog/how-to-create-claude-skills) — the \`SKILL.md\` format, end to end
+- [Claude Code Subagents Guide](/blog/claude-code-subagents-guide) — fan-out, agent teams, and cost-aware model tiering
+- [The Complete Guide to MCP Servers](/blog/mcp-servers-guide) — what MCP is and how to connect your first server
+- [Claude Code Hooks: The Complete Guide](/blog/claude-code-hooks-guide) — copy-paste configs for the common automations
+- [The CLAUDE.md Guide](/blog/claude-md-guide) — how to write project context that pays for its place
+- [Claude Code /loop](/blog/claude-code-loop-guide) — run a prompt on a repeating interval inside your session
+- [Claude Code Routines: Putting Claude on Autopilot](/blog/claude-code-routines-guide) — scheduled cloud agents, and how they differ from \`/loop\`
+- [Best Claude Code Plugins](/blog/best-claude-code-plugins) — curated bundles worth installing today
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -35,8 +35,12 @@ import { claudeCodeCompetitorsComparison } from "./claude-code-competitors-compa
 import { claudeOpus48Release } from "./claude-opus-4-8-release";
 import { claudeFable5Guide } from "./claude-fable-5-guide";
 import { claudeCodeBestPractices } from "./claude-code-best-practices";
+import { claudeCodeSkillsVsSubagentsVsMcp } from "./claude-code-skills-vs-subagents-vs-mcp";
+import { claudeCodeLoopGuide } from "./claude-code-loop-guide";
 
 export const blogPosts: BlogPost[] = [
+  claudeCodeLoopGuide,
+  claudeCodeSkillsVsSubagentsVsMcp,
   claudeCodeBestPractices,
   claudeFable5Guide,
   claudeOpus48Release,


### PR DESCRIPTION
## Summary

Two new blog posts that fill a content gap and form an internal-link cluster around Claude Code's extension and automation mechanisms.

### 1. Skills vs Subagents vs MCP vs Hooks: Which Claude Code Extension Should You Use?
`/blog/claude-code-skills-vs-subagents-vs-mcp`

A decision guide that ties together the existing single-mechanism deep-dives (skills, subagents, MCP, hooks, CLAUDE.md, plugins). The site had a guide for each piece individually but nothing explaining *which to choose*.

- Targets high-intent comparison/"vs" search queries
- Comparison table, a numbered decision flow, and an FAQ section (built for "People Also Ask"/featured snippets)
- Heavy internal linking to existing posts + directory sections (`/skills`, `/mcp-servers`, `/hooks`, `/plugins`)
- Includes a dedicated **"Where Loops and Routines Fit"** section distinguishing the automation axis (hooks = event-based, `/loop` = interval/in-session, routines = scheduled/cloud) from the capability axis

### 2. Claude Code /loop: Run a Prompt on a Schedule Without Leaving Your Session
`/blog/claude-code-loop-guide`

A standalone guide for the in-session `/loop` command — a keyword no existing page targeted (it was only mentioned inside other posts).

- Covers fixed-interval vs. self-paced modes, when to use it, when not to
- A `/loop` vs. routines comparison table (the distinction users conflate most)
- Cross-linked with the comparison post and the existing routines guide to complete the automation cluster

## Wiring
Both posts are registered in `src/data/blog/index.ts`, which auto-propagates to the sitemap, RSS feed (`feed.xml`), listing/topic pages, and OpenGraph/Twitter metadata.

## Verification
- `tsc --noEmit` — clean
- `npm run build` — compiles; both static routes generate (`/blog/claude-code-skills-vs-subagents-vs-mcp`, `/blog/claude-code-loop-guide`)
- Lint — no new issues (pre-existing warnings in unrelated files only)

## Note
OG images live at `/og/blog/<slug>.png` by convention; `public/og/blog/` is currently empty for all posts, so nothing new is required here, but these two slugs will need images if/when that step runs.