### PR TITLE
Generate blog OG images at build time via next/og

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -103,7 +103,7 @@ export async function generateMetadata(props: Props) {
       publishedTime: new Date(post.publishedDate).toISOString(),
       images: [
         {
-          url: `${BASE_URL}/og/blog/${post.slug}.png`,
+          url: `${BASE_URL}/og/blog/${post.slug}`,
           width: 1200,
           height: 630,
           alt: post.title,
@@ -114,7 +114,7 @@ export async function generateMetadata(props: Props) {
       card: "summary_large_image",
       title,
       description,
-      images: [`${BASE_URL}/og/blog/${post.slug}.png`],
+      images: [`${BASE_URL}/og/blog/${post.slug}`],
     },
     alternates: {
       canonical: url,
@@ -152,7 +152,7 @@ export default async function BlogPostPage(props: Props) {
         author={post.author}
         tags={post.tags}
         datePublished={post.publishedDate}
-        image={`${BASE_URL}/og/blog/${post.slug}.png`}
+        image={`${BASE_URL}/og/blog/${post.slug}`}
       />
       <BreadcrumbJsonLd
         items={[

--- a/src/app/og/blog/[slug]/route.tsx
+++ b/src/app/og/blog/[slug]/route.tsx
@@ -1,0 +1,176 @@
+import { ImageResponse } from "next/og";
+import { blogPosts, getBlogPostBySlug } from "@/data/blog";
+
+// Pre-render an OG card for every known blog slug at build time so the
+// images ship as static assets (matches the site's mostly-static model).
+export function generateStaticParams() {
+  return blogPosts.map((post) => ({ slug: post.slug }));
+}
+
+// Warm Claude-brand palette, translated to hex/rgba — Satori (the engine
+// behind ImageResponse) does not support the oklch() colors used in CSS.
+const COLORS = {
+  bgFrom: "#1c1714",
+  bgTo: "#2a1f17",
+  coral: "#d97757",
+  title: "#f7f2ec",
+  muted: "#b8a99d",
+  border: "rgba(247,242,236,0.12)",
+  pillBg: "rgba(217,119,87,0.14)",
+  pillText: "#e8a583",
+  pillBorder: "rgba(217,119,87,0.38)",
+};
+
+function titleFontSize(title: string): number {
+  if (title.length > 70) return 50;
+  if (title.length > 52) return 56;
+  if (title.length > 36) return 62;
+  return 70;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const post = getBlogPostBySlug(slug);
+
+  const title = post?.title ?? "Claude Directory";
+  const tags = (post?.tags ?? ["claude-code"]).slice(0, 3);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px",
+          backgroundColor: COLORS.bgFrom,
+          backgroundImage: `linear-gradient(135deg, ${COLORS.bgFrom} 0%, ${COLORS.bgTo} 100%)`,
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* Header: brand wordmark + section eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "56px",
+                height: "56px",
+                borderRadius: "14px",
+                backgroundColor: COLORS.coral,
+                marginRight: "22px",
+              }}
+            >
+              <div
+                style={{
+                  width: "22px",
+                  height: "22px",
+                  borderRadius: "6px",
+                  backgroundColor: "rgba(28,23,20,0.85)",
+                }}
+              />
+            </div>
+            <div
+              style={{ fontSize: "32px", fontWeight: 600, color: COLORS.title }}
+            >
+              Claude Directory
+            </div>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: "22px",
+              fontWeight: 600,
+              letterSpacing: "3px",
+              color: COLORS.muted,
+              border: `1px solid ${COLORS.border}`,
+              borderRadius: "999px",
+              padding: "10px 22px",
+            }}
+          >
+            BLOG
+          </div>
+        </div>
+
+        {/* Title block with a coral accent bar */}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              width: "84px",
+              height: "8px",
+              borderRadius: "4px",
+              backgroundColor: COLORS.coral,
+              marginBottom: "30px",
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              fontSize: `${titleFontSize(title)}px`,
+              fontWeight: 700,
+              lineHeight: 1.15,
+              color: COLORS.title,
+              maxWidth: "1000px",
+            }}
+          >
+            {title}
+          </div>
+        </div>
+
+        {/* Footer: topic tags + domain */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: `1px solid ${COLORS.border}`,
+            paddingTop: "28px",
+          }}
+        >
+          <div style={{ display: "flex" }}>
+            {tags.map((tag) => (
+              <div
+                key={tag}
+                style={{
+                  display: "flex",
+                  fontSize: "24px",
+                  color: COLORS.pillText,
+                  backgroundColor: COLORS.pillBg,
+                  border: `1px solid ${COLORS.pillBorder}`,
+                  borderRadius: "999px",
+                  padding: "8px 20px",
+                  marginRight: "14px",
+                }}
+              >
+                #{tag}
+              </div>
+            ))}
+          </div>
+          <div style={{ display: "flex", fontSize: "26px", color: COLORS.muted }}>
+            claudedirectory.org
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      headers: {
+        "Cache-Control": "public, max-age=86400, s-maxage=604800, immutable",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Every blog post's metadata points at an OG image — `${BASE_URL}/og/blog/<slug>.png` — in three places ([openGraph, twitter, and JSON-LD](src/app/blog/[slug]/page.tsx)). But `public/og/` is **empty** and nothing in the repo generates those files (no `ImageResponse`, no `opengraph-image` convention, no build script). So all 35+ posts advertise a **404 OG image**: shared on Twitter/LinkedIn/Slack, the link preview has no card.

Found while adding two new posts (#93) — this is a pre-existing, site-wide gap, not specific to those posts.

## Fix

Add a prerendered image route at **`src/app/og/blog/[slug]/route.tsx`** using `next/og`'s `ImageResponse` (ships with Next 16 — no new dependency). It renders a branded **1200×630** card per post: warm Claude-palette gradient, coral brand chip + wordmark, a "BLOG" pill, the post title (size auto-scaled to length), topic-tag pills, and the domain. `generateStaticParams` prerenders one image per slug at build time, so they ship as static assets (matching the site's mostly-static model).

The three metadata references now point at `/og/blog/<slug>` (the working route) instead of the dead `.png` path.

Benefits:
- Fixes **all** existing posts at once, and **every future post automatically** — no hand-made images, ever.
- A slug with no matching post renders a generic branded fallback, so the meta tag never 404s.

## Verification
- `tsc --noEmit` — clean
- `npm run build` — compiles; `/og/blog/[slug]` prerenders for every slug with **no font errors**
- Confirmed a generated file is a valid `PNG image data, 1200 x 630` (~80 KB) and visually inspected the rendered card (attached below in description / verified locally)

## Notes / possible follow-ups
- Scope is **blog** OG images (the only content type that referenced per-item OG URLs). Other sections inherit the default site OG, which has no image — a default site-wide OG card could be a separate follow-up.
- Typography uses `ImageResponse`'s built-in sans font for build robustness (no runtime font fetch). Swapping in the site's Geist font is possible later if desired.