### PR TITLE
chore(ingest): run listing refresh weekly instead of daily

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -2,8 +2,8 @@ name: Refresh ingested listings
 
 on:
   schedule:
-    # Daily at 06:30 UTC. Adjust if you don't want noise this often.
-    - cron: "30 6 * * *"
+    # Weekly on Mondays at 06:30 UTC. Adjust if you don't want noise this often.
+    - cron: "30 6 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Changes the `Refresh ingested listings` workflow schedule from **daily** (`30 6 * * *`) to **weekly on Mondays** at 06:30 UTC (`30 6 * * 1`).

## Why

The ingest job opens a `chore(ingest): refresh listings` PR whenever upstream data changes. Running it daily generates more automated-PR noise than the listing data warrants. Weekly is enough to keep listings reasonably fresh while cutting the churn.

## Notes for reviewers

- This runs 30 minutes after the separate weekly metadata refresh (`refresh-github-metadata.yml`, Mondays 06:00 UTC), so the two won't collide.
- `workflow_dispatch` is unchanged — the job can still be triggered manually anytime.