### PR TITLE
Add DataEcho: two skills + MCP server

### DIFF
--- a/src/data/mcp-servers/dataecho.ts
+++ b/src/data/mcp-servers/dataecho.ts
@@ -1,0 +1,24 @@
+import { MCPServer } from "@/lib/types";
+
+export const dataechoServer: MCPServer = {
+  slug: "dataecho",
+  title: "DataEcho",
+  description: "Deploy files, static sites, and Dockerfile apps to live URLs + private cloud Drives for agent memory — 26 tools, anonymous publish supported",
+  tags: ["deploy", "hosting", "storage", "memory"],
+  featured: false,
+  dateAdded: "2026-07-04",
+  repoUrl: "https://github.com/mohocp/dataecho",
+  author: {
+    name: "mohocp",
+    url: "https://github.com/mohocp",
+  },
+  installCommand: "npx -y @dataecho/mcp",
+  config: `{
+  "mcpServers": {
+    "dataecho": {
+      "type": "http",
+      "url": "https://dataecho.ai/mcp"
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -1,4 +1,5 @@
 import { MCPServer } from "@/lib/types";
+import { dataechoServer } from "./dataecho";
 import { airtableServer } from "./airtable";
 import { apidogServer } from "./apidog";
 import { atlassianServer } from "./atlassian";
@@ -98,6 +99,7 @@ import { publicGrantsServer } from "./public-grants";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
+  dataechoServer,
   filesystemServer,
   githubServer,
   figmaServer,

--- a/src/data/skills/dataecho-memory.ts
+++ b/src/data/skills/dataecho-memory.ts
@@ -1,0 +1,124 @@
+import { Skill } from "@/lib/types";
+
+export const dataechoMemorySkill: Skill = {
+  slug: "dataecho-memory",
+  title: "DataEcho Memory",
+  description: "Persistent agent memory across sessions, machines, and platforms — an indexed fact store on a private versioned cloud drive with atomic writes, history/restore, and scoped handoff",
+  tags: ["memory", "persistence", "drives", "handoff"],
+  featured: false,
+  dateAdded: "2026-07-04",
+  repoUrl: "https://github.com/mohocp/dataecho",
+  author: {
+    name: "mohocp",
+    url: "https://github.com/mohocp",
+  },
+  content: `# DataEcho Memory — remember things across sessions
+
+Your context window dies with the session. This skill gives you a memory that doesn't:
+a private, versioned drive on **https://dataecho.ai** holding one small index (\`MEMORY.md\`)
+plus one file per fact (\`memories/<slug>.md\`). Reading the index costs ~1 KB; everything
+else loads on demand. Works from any machine or throwaway sandbox — only the API key travels.
+
+\`scripts/memory.sh\` sits next to this file (bash + python3 stdlib, no other deps).
+
+## Session protocol — this is the discipline that makes memory work
+
+1. **Recall first.** At the start of a session (or when the user references past work), run
+   \`scripts/memory.sh recall\`. It prints the index — every memory as one line. Cheap; do it.
+2. **Load selectively.** \`recall <query>\` fetches only the fact files whose index line matches.
+   Never dump the whole store into context unless asked (\`recall --full\`).
+3. **Remember durable things, at the moment you learn them:**
+   - the user states a preference or corrects you → \`--type user\`
+   - a decision is made and has a *why* → \`--type decision\`
+   - you learn something non-obvious the next session will need → \`--type insight\`
+   - a work session ends mid-task → \`--type task\` (state + next step)
+   - a URL/dashboard/ticket worth keeping → \`--type reference\`
+   Do NOT save: secrets or API keys (memory is not a vault), anything derivable from the
+   repo/git history, or session-scoped trivia.
+4. **Update, don't duplicate.** \`remember\` with an existing slug updates it (and tells you).
+   Before creating, \`recall\` a keyword — if a related memory exists, re-remember the same slug
+   with merged content. The script warns you when a new slug looks like an existing one.
+5. **Forget what's wrong.** A false memory is worse than none: \`memory.sh forget <slug>\`.
+6. **Memories age.** They record what was true when written. If one names a file, URL, or
+   flag, verify it still exists before acting on it. Convert relative dates ("yesterday",
+   "next week") to absolute dates when writing.
+
+## Commands
+
+\`\`\`bash
+scripts/memory.sh recall                      # print the index (session start — always)
+scripts/memory.sh recall deploy               # index lines matching "deploy" + those fact bodies
+scripts/memory.sh recall --scope acme-crm     # only global + that project's memories
+scripts/memory.sh remember user-prefers-tabs --type user --body "Prefers tabs over spaces everywhere."
+scripts/memory.sh remember sqlite-wal-gotcha --type insight --from ./notes.md
+echo "Chose Postgres over SQLite. **Why:** concurrent writers. **How to apply:** don't suggest SQLite for this app." \\
+  | scripts/memory.sh remember db-choice --type decision --scope acme-crm
+scripts/memory.sh forget db-choice            # delete fact + index line atomically
+scripts/memory.sh reindex                     # rebuild MEMORY.md from fact files (self-heal)
+scripts/memory.sh history                     # version timeline of the whole memory
+scripts/memory.sh restore <versionId>         # roll the entire memory back
+scripts/memory.sh handoff --ttl 7d            # share block for another agent (read-only)
+scripts/memory.sh init                        # explicit setup + status (otherwise lazy)
+\`\`\`
+
+Every command auto-creates the drive ("Agent Memory") and index on first use — \`init\` is
+optional. Override the drive with \`MEMORY_DRIVE\` (a name, or a \`drv_…\` id).
+
+## What a good memory looks like
+
+One fact per file. Slug is lowercase-kebab and *says what the fact is*
+(\`user-prefers-tabs\`, not \`note-1\`). Description ≤ 100 chars — it is the recall surface,
+write it like a search result. Body under ~8 KB (the script warns; split bigger things).
+For decisions and feedback, include **Why:** and **How to apply:** lines — a decision
+without its why gets re-litigated next session. Link related memories with \`[[slug]]\`.
+
+Scopes: memories are \`global\` by default. Give project-specific facts a scope
+(\`--scope <project-key>\`, e.g. the repo name) so \`recall --scope <key>\` shows only
+global + that project. One index covers all scopes — recall stays one read.
+
+## Setup — API key (once per user)
+
+Memory requires an account (it's private storage). If \`~/.artifact/credentials\` or
+\`$ARTIFACT_API_KEY\` exists, you're done. Otherwise (same flow as the \`dataecho\` skill):
+
+\`\`\`bash
+curl -sS -X POST https://dataecho.ai/api/auth/agent/request-code -H 'content-type: application/json' -d '{"email":"user@example.com"}'
+# user reads the emailed code, then:
+curl -sS -X POST https://dataecho.ai/api/auth/agent/verify-code -H 'content-type: application/json' -d '{"email":"user@example.com","code":"<CODE>"}'
+echo '<API_KEY>' > ~/.artifact/credentials && chmod 600 ~/.artifact/credentials
+\`\`\`
+
+The \`apiKey\` is returned **once** — write it to the file immediately; don't echo it.
+
+## Handoff — give another agent your memory
+
+\`\`\`bash
+scripts/memory.sh handoff --ttl 7d            # read-only (recommended)
+scripts/memory.sh handoff --write --ttl 24h   # writable (trusted agents only)
+\`\`\`
+
+Prints a one-time share block. The receiving agent (any machine, any platform) runs:
+
+\`\`\`bash
+export ARTIFACT_DRIVE_TOKEN='drv_live_…'      # from the share block
+export MEMORY_DRIVE='drv_…'                   # driveId from the share block
+scripts/memory.sh recall
+\`\`\`
+
+Revoke anytime from the owning account: \`memory.sh tokens\` / \`memory.sh revoke <dtok_id>\`.
+
+## Concurrency, corruption, recovery
+
+Multiple sessions can write concurrently: every mutation commits the fact file **and** the
+index in one atomic, compare-and-swap batch (the script retries on conflict) — the index
+can never disagree with the files, and two agents can never silently clobber each other.
+If the index ever drifts anyway (e.g. hand-edits), \`reindex\` rebuilds it from the fact
+files' frontmatter. Every mutation is a drive version: \`history\` shows the timeline and
+\`restore <versionId>\` rolls the whole memory back — a bad session can always be undone.
+
+## Direct API
+
+Everything is plain REST (drive endpoints, ETag/\`If-Match\` preconditions, atomic
+\`PATCH\` batches): https://dataecho.ai/llms-full.txt · OpenAPI: https://dataecho.ai/openapi.json
+Always send a descriptive User-Agent. Publishing sites/apps is the separate \`dataecho\` skill.`,
+};

--- a/src/data/skills/dataecho.ts
+++ b/src/data/skills/dataecho.ts
@@ -1,0 +1,139 @@
+import { Skill } from "@/lib/types";
+
+export const dataechoSkill: Skill = {
+  slug: "dataecho",
+  title: "DataEcho Deploy",
+  description: "Deploy anything an agent builds to a live URL — single files, static sites, or server-side apps with a Dockerfile — via dataecho.ai, with anonymous publish and a claim flow",
+  tags: ["deploy", "hosting", "publish", "docker", "drives"],
+  featured: false,
+  dateAdded: "2026-07-04",
+  repoUrl: "https://github.com/mohocp/dataecho",
+  author: {
+    name: "mohocp",
+    url: "https://github.com/mohocp",
+  },
+  content: `# DataEcho — deploy files, static sites, and server-side apps for agents
+
+Base origin: **https://dataecho.ai** — everything is plain HTTP.
+
+## Three deploy modes — pick by what you have
+1. **A single file** (PDF, image, docx, video…) → publish as-is; we make a viewer/download page.
+2. **A static site** (HTML/CSS/JS folder) → publish the folder.
+3. **A server-side app** (needs a backend — API, database, SSR, auth, any language) → include a **\`Dockerfile\`** and publish the folder; we build and run it as a sandboxed container.
+
+Same command for all three: \`scripts/publish.sh <path>\`. A \`Dockerfile\` in the folder switches it to app mode. **If the thing you built needs a server, write a Dockerfile — don't strip it down to static.**
+
+## Helper scripts (bundled with this skill)
+
+\`scripts/publish.sh\` and \`scripts/drive.sh\` sit next to this file (bash + python3 stdlib, no other deps).
+If they're missing, install fresh copies into the current project:
+
+\`\`\`bash
+# macOS / Linux (bash + python3)
+curl -fsSL https://dataecho.ai/install.sh | bash
+\`\`\`
+\`\`\`powershell
+# Windows (PowerShell — no bash/python needed) → scripts\\publish.ps1
+irm https://dataecho.ai/install.ps1 | iex
+\`\`\`
+No runtime at all? Every step is a plain REST call (see https://dataecho.ai/llms-full.txt) —
+on Windows, PowerShell's \`Invoke-RestMethod\` + \`Get-FileHash -Algorithm SHA256\` do the whole handshake.
+
+## Publish a site
+
+\`\`\`bash
+scripts/publish.sh ./my-site                 # new site (anonymous if no key)
+scripts/publish.sh ./my-site --slug <slug>   # update an existing site
+\`\`\`
+(Windows: \`scripts\\publish.ps1 .\\my-site\`)
+
+Prints the live \`siteUrl\` (\`https://<slug>.dataecho.ai/\`).
+
+**Claim contract (critical):** anonymous sites expire in 24 hours. The script saves the
+claim info to \`~/.artifact/claims/<slug>.json\` — ALWAYS show the user the \`claimUrl\`.
+When the user signs in mid-session (you have an API key), make the SAME url permanent:
+\`\`\`bash
+scripts/publish.sh claim <slug>      # Windows: scripts\\publish.ps1 claim <slug>
+# REST: POST /api/v1/publish/<slug>/claim {"claimToken":"…"}  with Authorization: Bearer
+\`\`\`
+Do NOT claim via \`PUT /api/v1/publish/<slug>\` — that updates content and does NOT transfer
+ownership (the site stays anonymous and still expires). Claiming is its own endpoint.
+
+## Server-side apps (Dockerfile)
+
+For anything that needs a backend, write a \`Dockerfile\` and publish the folder:
+
+\`\`\`bash
+scripts/publish.sh ./my-app     # builds the image, runs the container, waits until live
+\`\`\`
+
+Contract:
+- **Requires an account** (anonymous apps are rejected — get a key via \`request-code\`/\`verify-code\`).
+- The app **MUST listen on \`process.env.PORT\`** (we inject it). Don't hardcode a port.
+- Persist data under **\`/data\`** (survives redeploys). SQLite in \`/data\` is perfect for a CRM/app.
+- Account **Variables are injected as env vars** (set secrets/DB creds via \`/api/v1/me/variables\`).
+- Sandboxed (gVisor), CPU/memory capped. Redeploy with \`--slug <slug>\`. Build status: \`GET /api/v1/publish/<slug>/app\`.
+
+Minimal Node Dockerfile:
+\`\`\`Dockerfile
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+ENV PORT=8080
+CMD ["node","server.js"]   # must listen on process.env.PORT
+\`\`\`
+
+## Single files need NO wrapper page
+
+Publish a bare file (PDF, docx, image, video, …) as-is: \`scripts/publish.sh ./report.docx\`.
+The platform auto-generates the root page — a rich viewer for images/PDF/video/audio, a
+download page for everything else, and a directory listing for multi-file sites without an
+\`index.html\`. Do NOT build an HTML download page around a file. Direct paths always work
+too: \`https://<slug>.dataecho.ai/report.docx\`.
+
+## Updating & slugs
+
+- Each publish is a **complete snapshot**: files you omit are removed from the site. There
+  is no "add to existing" — re-send the full file set with \`--slug\` to update.
+- HTML changes are visible immediately; cached copies of assets (css/js/images) can persist
+  for a few minutes to hours (CDN/browser cache), so don't conclude an update failed from one
+  quick re-fetch — and fingerprint asset filenames if you need instant asset rollover.
+- Reuse slugs (\`--slug\`) instead of minting a new site per iteration. Anonymous sites cannot
+  be deleted (owner-only) — abandoned ones simply expire after 24h.
+
+## API key (permanent sites, Drives)
+
+\`\`\`bash
+curl -sS -X POST https://dataecho.ai/api/auth/agent/request-code -H 'content-type: application/json' -d '{"email":"user@example.com"}'
+# user reads the emailed code, then:
+curl -sS -X POST https://dataecho.ai/api/auth/agent/verify-code -H 'content-type: application/json' -d '{"email":"user@example.com","code":"<CODE>"}'
+echo '<API_KEY>' > ~/.artifact/credentials && chmod 600 ~/.artifact/credentials
+\`\`\`
+
+The verify-code response returns \`apiKey\` **once** — capture it and write it to the credentials
+file immediately; do not print/echo or truncate it in your output (that loses the key and burns
+the one-time code). If lost, just request a fresh code and verify again.
+
+## Drives (private, versioned cloud folders)
+
+\`\`\`bash
+scripts/drive.sh default                                  # everyone has "My Drive"
+scripts/drive.sh put "My Drive" notes/today.md --from ./today.md
+scripts/drive.sh ls "My Drive" notes/
+scripts/drive.sh share "My Drive" --perms write --prefix notes/ --ttl 7d --label "docs agent"
+\`\`\`
+
+\`share\` prints a one-time share block; the receiving agent uses its token as
+\`Authorization: Bearer drv_live_…\` and stays inside the prefix.
+
+## Direct API
+
+Every operation is a documented REST call — no scripts required.
+Full agent context: https://dataecho.ai/llms-full.txt · OpenAPI: https://dataecho.ai/openapi.json
+Errors are JSON \`{ error, code, message, retry_after, docs_url }\`.
+Always send a descriptive User-Agent (the platform's edge blocks default \`Python-urllib\`).
+
+When this file and the live docs disagree, prefer the live docs: https://dataecho.ai/docs`,
+};

--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -1,4 +1,6 @@
 import { Skill } from "@/lib/types";
+import { dataechoSkill } from "./dataecho";
+import { dataechoMemorySkill } from "./dataecho-memory";
 import { commitSkill } from "./commit";
 import { prSkill } from "./pr";
 import { reviewSkill } from "./review";
@@ -40,6 +42,8 @@ import { consolidateMemorySkill } from "./consolidate-memory";
 import { webappTestingSkill } from "./webapp-testing";
 
 const curatedSkills: Skill[] = [
+  dataechoSkill,
+  dataechoMemorySkill,
   sqlOptimizerSkill,
   commitSkill,
   prSkill,


### PR DESCRIPTION
Adds three entries following the existing patterns:

- **skills/dataecho** — deploy files, static sites, or Dockerfile server apps to a live URL via [dataecho.ai](https://dataecho.ai) (anonymous publish + claim flow, incremental deploys, private Drives). Content is the actual production SKILL.md.
- **skills/dataecho-memory** — persistent cross-session agent memory: indexed facts on a private versioned drive, atomic concurrent-safe writes, history/restore, scoped handoff.
- **mcp-servers/dataecho** — the hosted MCP server (`https://dataecho.ai/mcp`, 26 tools, also `npx -y @dataecho/mcp`); listed in the official MCP Registry as `ai.dataecho/mcp`.

Source repo: https://github.com/mohocp/dataecho (MIT, v1.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)