### PR TITLE
Add PortalJS plugin (datopian/portaljs)

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -1,4 +1,5 @@
 import { Plugin } from "@/lib/types";
+import { portaljsPlugin } from "./portaljs";
 import { agentSdkDevPlugin } from "./agent-sdk-dev";
 import { bugDetectivePlugin } from "./bug-detective";
 import { ccpmPlugin } from "./ccpm";
@@ -162,6 +163,7 @@ const curatedPlugins: Plugin[] = [
   cloudflarePlugin,
   storybookPlugin,
   // Community plugins
+  portaljsPlugin,
   perfProfilerPlugin,
   i18nManagerPlugin,
   depAuditPlugin,

--- a/src/data/plugins/portaljs.ts
+++ b/src/data/plugins/portaljs.ts
@@ -1,0 +1,20 @@
+import { Plugin } from "@/lib/types";
+
+export const portaljsPlugin: Plugin = {
+  slug: "portaljs",
+  title: "PortalJS",
+  description: "Agent skills that build data portals: scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+  tags: ["data", "open-data", "data-portal", "ckan", "dcat"],
+  author: { name: "Datopian", url: "https://github.com/datopian" },
+  repoUrl: "https://github.com/datopian/portaljs",
+  installCommand: "npx skills add datopian/portaljs",
+  commands: [
+    { name: "/portaljs-new-portal", description: "Scaffold a new data portal from a brief" },
+    { name: "/portaljs-add-dataset", description: "Add CSV/TSV/JSON/GeoJSON datasets and register them" },
+    { name: "/portaljs-add-dcat", description: "Generate DCAT (v2/v3, DCAT-US, DCAT-AP, GeoDCAT-AP) and Croissant metadata" },
+    { name: "/portaljs-add-chart", description: "Add a visualization to a dataset page" },
+    { name: "/portaljs-add-map", description: "Render GeoJSON on an interactive map" },
+    { name: "/portaljs-connect-ckan", description: "Wire a portal to a CKAN backend" },
+    { name: "/portaljs-deploy", description: "Deploy the portal" },
+  ],
+};


### PR DESCRIPTION
Adds PortalJS to src/data/plugins per CONTRIBUTING.md: new src/data/plugins/portaljs.ts and registration in the folder's index.ts (under Community plugins).

PortalJS is an open source, AI-native framework for building data portals. The repo ships a .claude-plugin manifest and 12 agent skills (scaffold a portal, add datasets/charts/maps, connect CKAN, generate DCAT and Croissant metadata). MIT licensed, maintained by Datopian. Repo: https://github.com/datopian/portaljs

Submitted by a PortalJS maintainer.