### PR TITLE
Add Pluribus Evidence Attestation skill

### DIFF
--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -38,6 +38,7 @@ import { xlsxSkill } from "./xlsx";
 import { docxSkill } from "./docx";
 import { consolidateMemorySkill } from "./consolidate-memory";
 import { webappTestingSkill } from "./webapp-testing";
+import { pluribusEvidenceAttestationSkill } from "./pluribus-evidence-attestation";
 
 const curatedSkills: Skill[] = [
   sqlOptimizerSkill,
@@ -46,6 +47,7 @@ const curatedSkills: Skill[] = [
   reviewSkill,
   superpowersSkill,
   contextEngineeringSkill,
+  pluribusEvidenceAttestationSkill,
   webAssetGeneratorSkill,
   // New community skills
   playwrightSkill,

--- a/src/data/skills/pluribus-evidence-attestation.ts
+++ b/src/data/skills/pluribus-evidence-attestation.ts
@@ -1,0 +1,53 @@
+import { Skill } from "@/lib/types";
+
+export const pluribusEvidenceAttestationSkill: Skill = {
+  slug: "pluribus-evidence-attestation",
+  title: "Pluribus Evidence Attestation",
+  description:
+    "Emit privacy-safe claim/evidence/verdict packets for agent reviews, handoffs, approvals, scores, and skills.",
+  tags: ["evidence", "attestation", "agent-skills", "review", "privacy", "git"],
+  featured: false,
+  dateAdded: "2026-07-07",
+  author: {
+    name: "Caio Ribeiro / Pluribus",
+    url: "https://github.com/caioribeiroclw-pixel/pluribus",
+  },
+  repoUrl: "https://github.com/caioribeiroclw-pixel/pluribus/tree/main/skills/evidence-attestation",
+  content: `# Pluribus Evidence Attestation
+
+Use this skill when an agent, reviewer, CI job, or registry needs a compact proof object instead of raw prompts, transcripts, source code, secrets, or customer data.
+
+## What it emits
+
+A \`pluribus.evidence_attestation.v1\` packet with:
+
+- subject: what claim, change, skill, score, approval, or handoff is being attested
+- evidence_refs: privacy-safe pointers to artifacts such as commits, CI runs, docs, checks, or signed outputs
+- claims: supported, contradicted, or unresolved statements
+- omissions and limits: what was not checked and why
+- privacy: booleans proving raw prompts, transcripts, source, secrets, and customer data were not embedded
+- verdict: supported, review_required, contradicted, or unsafe
+- stale_if: the conditions that invalidate reuse of this attestation later
+
+## Good fits
+
+- PR/review evidence where a later reviewer needs to know which checks actually ran
+- agent-change manifests attached to Git commits or trailers
+- leaderboard score provenance without leaking transcripts or diffs
+- skill registry review where the verifier needs source and test evidence
+- approval or handoff records that must survive outside one chat session
+
+## Not a fit
+
+Do not use it to store private transcripts, raw source, secrets, customer data, or as a generic memory layer. The skill is for reduced evidence and replay-safe authority windows.
+
+## Runnable example
+
+Pluribus includes a fixture and checker:
+
+\`examples/evidence-attestation/evidence-attestation.json\`
+\`examples/evidence-attestation/check-evidence-attestation.mjs\`
+
+Use the checker to fail fast when the packet embeds private payloads, lacks evidence references, omits claim status, or forgets staleness conditions.
+`,
+};


### PR DESCRIPTION
Adds the Pluribus Evidence Attestation skill to Claude Directory as a privacy-safe proof/attestation workflow for agent reviews, handoffs, approvals, scores, skill registry review, and Git-adjacent agent changes.

Why this fits:
- Claude Code Skills are a live discovery surface for reusable agent workflows.
- The skill emits reduced claim/evidence/verdict packets rather than raw prompts, transcripts, source, secrets, or customer data.
- It includes a runnable fixture/checker in the source repo and is useful for review, Git workflows, agent handoffs, and registry verification.

Validation:
- `npx tsc --noEmit` passed.
- `npm run build` compiled successfully and passed TypeScript; static page generation was SIGKILLed in this constrained runner after ~7,531/10,042 pages.
- `npm run lint` hit the repo's existing `src/components/universal-search.tsx` `react-hooks/set-state-in-effect` error; this PR only touches `src/data/skills/*`.
- `git diff --check` passed.