### PR TITLE
Add two blog posts: Fable 5 export-control saga and Sonnet 5 guide

### DIFF
--- a/src/data/blog/claude-fable-5-export-controls.ts
+++ b/src/data/blog/claude-fable-5-export-controls.ts
@@ -1,0 +1,177 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeFable5ExportControls: BlogPost = {
+  slug: "claude-fable-5-export-controls",
+  title: "The 18 Days Fable 5 Was Banned: Inside the First AI Export-Control Takedown",
+  description:
+    "Three days after launch, the US government ordered Anthropic to pull its most capable model offline — worldwide. Here's the full timeline of the Fable 5 suspension, the Amazon report that triggered it, and what the precedent means for everyone building on frontier AI.",
+  publishedDate: "2026-07-09",
+  tags: [
+    "claude-fable",
+    "fable-5",
+    "export-controls",
+    "ai-policy",
+    "ai-safety",
+    "anthropic",
+    "news",
+    "2026",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-fable-5-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-sonnet-5-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-opus-4-8-release",
+      relationship: "recommends",
+    },
+  ],
+  seoTitle: "Why Claude Fable 5 Was Suspended: The Full Export-Control Timeline",
+  seoDescription:
+    "The complete story of the Fable 5 ban: the Amazon jailbreak report, the June 12 export-control directive, Anthropic's pushback, the 18-day shutdown, and what the July 1 redeployment changed.",
+  content: `# The 18 Days Fable 5 Was Banned: Inside the First AI Export-Control Takedown
+
+On June 9, Anthropic shipped the most capable AI model ever made generally available. On June 12, the US government ordered it taken offline. For eighteen days, the frontier of commercial AI was dark — not because of an outage, not because of a safety incident in the wild, but because of a letter from the Commerce Secretary.
+
+Fable 5 came back on July 1. The un-ban got a fraction of the attention the ban did, which is how these things usually go. But the full arc — launch, report, directive, shutdown, dispute, quiet restoration — is worth understanding end to end, because it's the first time a deployed frontier model has been recalled by government order. It will not be the last time someone tries.
+
+This is the definitive timeline, with receipts, and an honest look at what it means for anyone who builds on these models.
+
+---
+
+## The Timeline at a Glance
+
+| Date | What happened |
+|---|---|
+| **June 9** | Fable 5 and Mythos 5 launch. Fable is the generally available model with safety classifiers; Mythos 5 is the same model without them, limited to Project Glasswing participants. |
+| **June 11** | Amazon CEO Andy Jassy raises his researchers' jailbreak findings with Treasury Secretary Scott Bessent. |
+| **June 12** | Commerce Secretary Howard Lutnick sends Anthropic a letter directing it to suspend access for "any foreign national, whether inside or outside the United States." Anthropic pulls both models — for everyone. |
+| **June 12–30** | The shutdown. Requests to Fable 5 fall back to Opus 4.8. Anthropic publicly disputes the basis for the order while complying with it. |
+| **June 26** | The government approves expanded Mythos 5 access for select US organizations. |
+| **June 30** | Export controls lifted. |
+| **July 1** | Fable 5 redeploys globally with a new cybersecurity classifier. Pro, Max, Team, and select Enterprise users get complimentary Fable 5 access through July 7. |
+
+Eighteen days from directive to restoration. Now the details, because the details are where this story actually lives.
+
+---
+
+## The Report That Started It
+
+Within days of launch, researchers at Amazon found a way through Fable 5's safeguards. The technique, as described in Anthropic's own account: prompting the model so that it identified a number of software vulnerabilities. In one instance, the model went further and "produced code demonstrating how the relevant vulnerability could be exploited."
+
+That's a real finding. Fable 5's headline risk area has always been cybersecurity — it's why the model ships with cyber safety classifiers that its Mythos twin doesn't have, and why those classifiers are the thing that separates the generally available product from the restricted one. A prompt pattern that walks the flagship model into producing a working exploit demo is exactly the class of thing those classifiers exist to stop.
+
+What happened next is the part that turned a security finding into a policy event. According to reporting, Jassy raised the findings directly with the Treasury Secretary on June 11 — CEO to cabinet member, one day before the directive landed. Whatever you make of that channel (and it's worth noting Amazon is one of Anthropic's largest investors and infrastructure partners, which makes the whole thing more awkward, not less), it worked. The government moved in twenty-four hours.
+
+---
+
+## The Directive: Why "Foreign Nationals" Meant Everyone
+
+The June 12 order didn't tell Anthropic to shut Fable 5 down. It told them to restrict access for "any foreign national, whether inside or outside the United States, including foreign national Anthropic employees."
+
+Read that requirement as an engineer for a second. How do you verify, per request, the nationality of the human behind an API key? You can't. There is no real-time citizenship check for a curl command. Anthropic said so plainly: "the net effect of this order is that we must abruptly disable Fable 5 and Mythos 5 for **all** our customers to ensure compliance."
+
+This is the load-bearing detail of the whole saga, and most coverage skated past it. An export-control order scoped to "foreign nationals anywhere" is functionally a global recall order, because no provider can comply with it any other way. The government didn't have to say "take it down." The framing did it for them. Anyone thinking about how AI gets regulated from here should sit with that mechanism, because it required no new legislation, no rulemaking, no comment period — just an existing export-control authority and a letter.
+
+---
+
+## Anthropic Pushes Back — While Complying
+
+Anthropic took the models down the same day. But the company's statement was unusually pointed for a regulated party mid-compliance. They said they "disagree that the finding of a narrow potential jailbreak should be cause for recalling a commercial model deployed to hundreds of millions of people" — and that applying this standard consistently would "essentially halt all new model deployments for all frontier model providers."
+
+That second claim wasn't rhetorical. Anthropic ran the Amazon report's technique against other models and found that "many less capable models" — their own Opus 4.8, but also GPT-5.5 and Kimi K2.7 — could identify the same vulnerabilities. Per reporting on the dispute, every model tested could reproduce the report's single exploit demonstration.
+
+Which reframes the question entirely. If the capability that triggered the recall is table stakes for the current frontier — including models that had been deployed for months without incident, including a Chinese open-weights model — then pulling Fable 5 didn't remove the capability from the world. It removed one American company's product from the market for eighteen days while functionally identical capability remained available everywhere else, unregulated.
+
+That's the strongest version of Anthropic's argument, and it's a good one. The honest counterpoint: "everyone else can do it too" is also an argument for taking the *class* of capability more seriously, not for waving one instance through. The uncomfortable truth of June 2026 is that both things are true — the recall was arguably arbitrary in its target, and the underlying concern is arguably legitimate. A policy regime that can't hold both ideas will keep producing outcomes like this one.
+
+---
+
+## What the Shutdown Actually Looked Like
+
+For all the drama, the user-facing experience was mostly a quiet downgrade. Requests to Fable 5 were routed to Opus 4.8 instead — which, as we covered in the [Opus 4.8 release post](/blog/claude-opus-4-8-release), is not exactly a hardship model. Plenty of users likely never noticed. The people who did notice were the ones who had adopted Fable 5 precisely for the work Opus couldn't do: the longest-horizon agentic runs, the hardest reasoning tasks — the workloads that justified [double Opus pricing](/blog/claude-fable-5-guide) in the first place.
+
+There's an irony in the fallback working as smoothly as it did. The same week the government was treating Fable 5 as uniquely dangerous, most of its traffic degraded gracefully onto a model with most of its capability. Both facts — the smooth fallback and the capability overlap it demonstrated — ended up supporting Anthropic's case that the recall's target was arbitrary.
+
+---
+
+## The Quiet Un-Ban
+
+The restoration came in stages, which tells you something about the negotiation happening off-stage. On June 26, the government approved expanded Mythos 5 access for a set of vetted US organizations — the tightly-scoped model first. On June 30, the export controls came off entirely. On July 1, Fable 5 was back for everyone, worldwide, across the Claude Platform, claude.ai, Claude Code, and Cowork.
+
+It didn't come back unchanged. Anthropic "trained an improved safety classifier that targets and blocks the behavior described in the report," and says the new system blocks the specific technique "in over 99% of cases." Affected paid users got complimentary Fable 5 access through July 7 as a make-good.
+
+More interesting than the classifier is what Anthropic committed to alongside it: proposing an industry-wide "consensus framework for assessing the severity of AI jailbreaks," plus deeper government collaboration — including pre-release evaluation access and rapid information-sharing on safeguards. Translate that from press-release: *next time, let's agree on how bad a jailbreak has to be before anyone reaches for the export-control lever — and we'll show you the model before launch so there is no next time.* That's regulatory infrastructure being built in real time, by settlement rather than statute.
+
+---
+
+## What This Means If You Build on Claude
+
+The policy story is fascinating, but you probably came here because you ship things. Four practical takeaways:
+
+**Model access is now a policy variable, not just an engineering one.** For eighteen days, the top model in the lineup was unavailable for reasons no status page could have predicted. If your product hard-depends on one specific model, June should change how you think about that. This is exactly what the API's fallback machinery is for — Fable 5 requests support a server-side \`fallbacks\` parameter that reroutes declined requests to Opus 4.8 within the same call:
+
+\`\`\`typescript
+const response = await client.beta.messages.create({
+  model: "claude-fable-5",
+  max_tokens: 16000,
+  betas: ["server-side-fallback-2026-06-01"],
+  fallbacks: [{ model: "claude-opus-4-8" }],
+  messages: [{ role: "user", content: "..." }],
+});
+\`\`\`
+
+It exists for classifier refusals, but the June lesson generalizes: build so that "this specific model is unavailable" is a degraded mode, not an outage.
+
+**Expect more false positives on security-adjacent work.** The new classifier is tuned to block a vulnerability-identification technique. Classifiers tuned in a hurry err toward caution, and legitimate security work — code review for vulnerabilities, dependency auditing, CTF prep — lives right next to the blocked behavior. If Fable 5 starts refusing work that Opus happily does, this is why; handle \`stop_reason: "refusal"\` and configure your fallbacks rather than fighting it with prompt gymnastics.
+
+**Run your evals on more than one model.** Teams that had benchmarked workloads on both Fable 5 and Opus 4.8 made the June 12 switch in minutes. Teams that hadn't spent the shutdown finding out which of their prompts silently degraded. Multi-model eval baselines used to be diligence; they're now disaster recovery.
+
+**The capability floor keeps rising underneath the policy fight.** While the recall consumed the headlines, [Sonnet 5 shipped](/blog/claude-sonnet-5-guide) with near-Opus capability at a third of the price. Whatever line the government eventually draws around "dangerous" capability, the mid-tier crosses it a release or two later. Any regulatory approach that targets individual models rather than capability classes is going to spend the next decade playing whack-a-mole — June was the proof of concept.
+
+---
+
+## FAQ
+
+**Why was Claude Fable 5 taken down in June 2026?**
+The US government issued an export-control directive on June 12 after Amazon researchers reported a technique that bypassed Fable 5's safeguards to identify software vulnerabilities and, in one case, produce exploit demonstration code. The directive required blocking all foreign nationals — which was technically impossible to do selectively, so Anthropic suspended the model entirely.
+
+**How long was Fable 5 unavailable?**
+Eighteen days: June 12 through June 30, 2026, with global redeployment on July 1.
+
+**Was it a security breach or incident?**
+No. There was no breach, no leaked data, and no reported real-world harm. The trigger was a research report demonstrating a potential misuse technique — one Anthropic says other frontier models could replicate.
+
+**Is Fable 5 safe to use now?**
+It redeployed with an additional cybersecurity classifier that Anthropic says blocks the reported technique in over 99% of cases. The practical side effect is stricter refusal behavior on security-adjacent prompts — legitimate security work may see more false positives than before.
+
+**Could this happen again?**
+Yes — that's the real story. The export-control mechanism worked, required no new law, and is now precedent. Anthropic's proposed jailbreak-severity framework and pre-release government evaluations are attempts to make sure disagreements get resolved before the takedown letter, not after.
+
+---
+
+## The Bottom Line
+
+Strip away the drama and June 2026 established three facts. A sitting government will pull a frontier model off the market on a few days' notice. The legal mechanism to do it already exists, and its "foreign nationals" framing makes partial compliance impossible — so the nuclear option is the only option. And the industry's response is to build private coordination with regulators — severity frameworks, pre-release access — so the next dispute is settled quietly before launch instead of loudly after.
+
+Whether that settlement model is reassuring or unsettling depends on your priors about both AI risk and government competence. What it isn't, anymore, is hypothetical.
+
+## Further Reading
+
+- [Claude Fable 5: Anthropic's New Top Tier, Explained](/blog/claude-fable-5-guide) — what the model actually is, and when it's worth double Opus pricing
+- [Claude Sonnet 5: The New Default in Claude Code](/blog/claude-sonnet-5-guide) — the release that quietly moved the capability floor during the ban
+- [Claude Opus 4.8 Release: What's New](/blog/claude-opus-4-8-release) — the model that carried Fable 5's traffic for eighteen days
+`,
+};

--- a/src/data/blog/claude-sonnet-5-guide.ts
+++ b/src/data/blog/claude-sonnet-5-guide.ts
@@ -1,0 +1,234 @@
+import { BlogPost } from "@/lib/types";
+
+export const claudeSonnet5Guide: BlogPost = {
+  slug: "claude-sonnet-5-guide",
+  title: "Claude Sonnet 5: The New Default in Claude Code, Explained",
+  description:
+    "Sonnet 5 landed June 30 with near-Opus coding ability, a 1M-token context window, and $2/$10 launch pricing through August. Here's what actually changed, the tokenizer fine print that affects your bill, and which model to run when.",
+  publishedDate: "2026-07-09",
+  tags: [
+    "claude-sonnet-5",
+    "claude-code",
+    "new-features",
+    "ai-coding",
+    "agentic-workflows",
+    "model-comparison",
+    "pricing",
+    "2026",
+  ],
+  featured: true,
+  author: {
+    name: "Claude Directory",
+    url: "https://github.com/tmcpa/claudedirectory",
+  },
+  relatedItems: [
+    {
+      type: "blog",
+      slug: "claude-fable-5-guide",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-opus-4-8-release",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "claude-code-best-practices",
+      relationship: "recommends",
+    },
+    {
+      type: "blog",
+      slug: "context-engineering-claude-code",
+      relationship: "recommends",
+    },
+  ],
+  seoTitle: "Claude Sonnet 5 (2026): Pricing, 1M Context, When to Use It",
+  seoDescription:
+    "Claude Sonnet 5 is the new default model in Claude Code. Full guide: $2/$10 launch pricing, 1M context, tokenizer changes, API breaking changes, and how it compares to Opus 4.8 and Fable 5.",
+  content: `# Claude Sonnet 5: The New Default in Claude Code, Explained
+
+June 2026 was a loud month for Anthropic. Fable 5 launched, [got suspended by an export-control directive, and came back](/blog/claude-fable-5-export-controls). Claude Science shipped. And then, on June 30 — almost quietly by comparison — Anthropic released the model most people will actually use every day: **Claude Sonnet 5**.
+
+If you're on a Free or Pro plan, you're probably already running it. Sonnet 5 is now the default model in Claude Code for those plans, and it's available everywhere else — the API, the Claude apps, Managed Agents, and the third-party platforms.
+
+Short version: Sonnet 5 brings near-Opus-4.8 quality on coding and agentic work at Sonnet prices, with a 1M-token context window and launch pricing of $2/$10 per million tokens through August 31. It's the most model most people have ever gotten for the money. But there are two pieces of fine print — a new tokenizer that inflates token counts, and adaptive thinking that changes the latency profile — that you should understand before you assume your bill just dropped.
+
+Let's go through all of it.
+
+---
+
+## What Sonnet 5 Actually Is
+
+The facts, minus the launch-day gloss:
+
+- **Model ID is \`claude-sonnet-5\`.** No date suffix, same alias convention as the rest of the current lineup.
+- **Released June 30, 2026.** It replaced Sonnet 4.6 as the current Sonnet-tier model, the same week Fable 5 was redeployed globally.
+- **It's the new default for Free and Pro.** In Claude Code and the Claude apps, Free and Pro accounts now start on Sonnet 5. Max, Team Premium, and Enterprise pay-as-you-go stay on Opus 4.8 as their default — you can switch either way.
+- **1M-token context window, 128K max output.** The same headline numbers as Opus 4.8 and Fable 5. This is the first time the "budget" tier has had frontier-scale context as a native, no-asterisk feature.
+- **Near-Opus performance.** Anthropic's own framing is that Sonnet 5's performance "is close to that of Opus 4.8, but at lower prices," with a strict improvement over Sonnet 4.6 on agentic benchmarks like BrowseComp and OSWorld-Verified.
+- **The full effort range, including \`xhigh\`.** Sonnet 5 is the first Sonnet-tier model to support the \`xhigh\` effort level that Opus 4.7 introduced — the recommended setting for hard coding and agentic work.
+- **High-resolution vision.** Up to 2576px on an image's long edge (up from 1568px on Sonnet 4.6), which matters most for computer use and screenshot-heavy workflows.
+- **Cyber safeguards on by default.** Sonnet 5 ships with the same cybersecurity classifiers as Opus 4.7/4.8. It's also deliberately not the model for security research — Anthropic notes it performs substantially worse on cyber tasks than Opus 4.8.
+
+One framing worth internalizing: the Sonnet tier used to be the compromise tier. You picked Sonnet when Opus was too expensive and lived with the capability gap. Sonnet 5 shrinks that gap enough that for a large share of everyday coding work, it's not a compromise anymore — it's just the sensible default. Which is exactly why Anthropic made it one.
+
+---
+
+## Pricing: $2/$10 Now, $3/$15 in September
+
+The launch pricing is the most aggressive part of the release:
+
+| Period | Input (per MTok) | Output (per MTok) |
+|---|---|---|
+| Through August 31, 2026 | **$2.00** | **$10.00** |
+| From September 1, 2026 | $3.00 | $15.00 |
+
+The standard price is the same sticker Sonnet 4.6 had, so after the promo ends you're paying Sonnet 4.6 prices for a much better model. During the promo you're paying a third less than that. For comparison across the current lineup: Haiku 4.5 is $1/$5, Opus 4.8 is $5/$25, and Fable 5 is $10/$50.
+
+If you have batch workloads, evals to re-run, or a backlog of "we should really let an agent chew through this" projects, the next few weeks are the cheap window to do it.
+
+### The tokenizer fine print
+
+Here's the part that will surprise people when the invoice arrives: **Sonnet 5 uses a new tokenizer, and the same text produces roughly 30% more tokens than it did on Sonnet 4.6** (Anthropic's range is 1.0–1.35× depending on content type).
+
+Nothing about your code changes — but everything you *measure in tokens* shifts:
+
+- The same prompt reports higher \`input_tokens\` than it did on 4.6.
+- A \`max_tokens\` limit tuned for Sonnet 4.6 can now truncate output that used to fit.
+- The 1M context window holds less *text* than 1M tokens did on the old tokenizer.
+- Cost dashboards calibrated against 4.6 will read high even though per-token pricing didn't change.
+
+So the honest cost math is: during the promo, you're paying ~33% less per token on ~30% more tokens — roughly a wash against Sonnet 4.6, for a significantly smarter model. After August 31, an equivalent request costs modestly more than it did on 4.6. Still an excellent trade, but "same price as before" is not quite true, and you should re-baseline any token-budgeted limits with the \`count_tokens\` endpoint against \`claude-sonnet-5\` rather than reusing numbers measured on older models.
+
+---
+
+## What Changed in Claude Code
+
+If you're on Free or Pro, Sonnet 5 became your default in Claude Code with the rollout. A few practical notes on living with that.
+
+**Checking and switching models.** Use \`/model\` in a session to see what you're running and switch:
+
+\`\`\`bash
+# In a Claude Code session
+/model claude-sonnet-5
+
+# Or from the shell, per invocation
+claude --model claude-sonnet-5
+\`\`\`
+
+To pin it in a project so everyone gets the same model, set it in \`.claude/settings.json\`:
+
+\`\`\`json
+{
+  "model": "claude-sonnet-5"
+}
+\`\`\`
+
+**Mixing tiers where it makes sense.** The model setting isn't all-or-nothing. A pattern that works well: run your main session on Opus 4.8 or Sonnet 5, and pin cheap, mechanical subagents to Haiku via the \`model\` field in an agent's frontmatter. Claude Code also supports \`fallbackModel\` in settings — up to three models tried in order — which is a sensible place to put \`claude-sonnet-5\` as the fallback for an Opus-first setup.
+
+**Org defaults.** Team and Enterprise admins can now set an org-wide default model, so if you administer a deployment, this is the week to decide deliberately rather than letting per-user defaults drift.
+
+**The latency profile is different.** This is the biggest day-to-day change. Sonnet 5 defaults to adaptive thinking — it decides per request whether and how much to think. On hard tasks this is exactly what you want. On trivial ones ("rename this variable," "what does this function do") it can feel slower than Sonnet 4.6, because the model sometimes reasons, verifies, and second-guesses where 4.6 would have just answered. Early reviews consistently flag this: Sonnet 5 spends time running tests even for small changes and revisits its own plan more often than some people would like. Where 4.6 handed back a quick answer, 5 keeps working toward a better one.
+
+You have two levers if that bothers you: drop \`/effort\` to a lower level for quick interactive work, or keep a faster model on hand for throwaway questions. But for the walk-away agentic sessions Claude Code increasingly leans into — long refactors, overnight runs, big-context investigations — the deliberateness is a feature, not a bug.
+
+**The 1M context is the sleeper feature.** Loading an entire mid-size monorepo into a single session and asking real questions across it — "find every instance of this deprecated pattern and its call sites" — now works on the default model of the free plan. That was an Opus-tier capability eighteen months ago. If you've been managing context carefully out of habit, it's worth recalibrating what you can just... include now. (Careful context is still faster and cheaper — see our [context engineering guide](/blog/context-engineering-claude-code) — but the ceiling moved.)
+
+---
+
+## Sonnet 5 vs. Opus 4.8 vs. Fable 5: Which Model, When
+
+With Sonnet 5 landing this close to Opus 4.8 in capability, the model choice is less obvious than it used to be. Here's the current lineup at a glance:
+
+| | Haiku 4.5 | Sonnet 5 | Opus 4.8 | Fable 5 |
+|---|---|---|---|---|
+| Input / output per MTok | $1 / $5 | $2 / $10 (promo) | $5 / $25 | $10 / $50 |
+| Context window | 200K | 1M | 1M | 1M |
+| Effort levels | — | low → \`xhigh\`, \`max\` | low → \`xhigh\`, \`max\` | low → \`xhigh\`, \`max\` |
+| Default for | subagents | Free, Pro | Max, Team Premium, Enterprise | opt-in only |
+
+And the practical heuristics:
+
+- **Default to Sonnet 5** for everyday coding, tool-heavy agentic work, big-context codebase questions, and anything you run in volume. At a fifth to a third of Opus pricing, "close to Opus 4.8" is the right trade for most tasks, most of the time.
+- **Reach for Opus 4.8** when the task is genuinely hard and single-shot correctness matters more than cost: gnarly debugging, architectural decisions, long autonomous runs where a wrong turn at hour one wastes the whole night. Opus also remains ahead on the long-horizon coherence that separates "ran for six hours" from "ran for six hours and was right."
+- **Fable 5 is for the problems you'd otherwise not attempt.** As we covered in the [Fable 5 guide](/blog/claude-fable-5-guide), it's a tier above Opus with pricing to match. If Sonnet 5 or Opus 4.8 can do the job, they should.
+- **Haiku 4.5 still owns the high-volume, low-stakes lane** — classification, extraction, and cheap subagent fan-outs.
+
+The uncomfortable question Sonnet 5 raises is for Opus, not for its competitors: when the mid tier gets this close to the top tier, every Opus invocation needs a reason. Our advice: run Sonnet 5 as the default and escalate deliberately, rather than running Opus everywhere out of habit.
+
+---
+
+## Using Sonnet 5 in the API
+
+Trying it is a one-line change:
+
+\`\`\`typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+const response = await client.messages.create({
+  model: "claude-sonnet-5",
+  max_tokens: 16000,
+  messages: [{ role: "user", content: "Review this diff for bugs..." }],
+});
+\`\`\`
+
+But if you're migrating from Sonnet 4.6, there are real breaking changes. Sonnet 5 adopts the same stricter API surface as Opus 4.7/4.8:
+
+- **Manual thinking budgets are gone.** \`thinking: {type: "enabled", budget_tokens: N}\` returns a 400. Use \`thinking: {type: "adaptive"}\` — or nothing, because...
+- **Adaptive thinking is on by default.** On Sonnet 4.6, omitting the \`thinking\` field ran without thinking. On Sonnet 5, omitting it runs adaptive thinking. If you had a latency-sensitive endpoint that relied on thinking being off by omission, set \`thinking: {type: "disabled"}\` explicitly — and note that \`max_tokens\` now needs headroom for thinking tokens if you leave it on.
+- **Sampling parameters are rejected.** Non-default \`temperature\`, \`top_p\`, or \`top_k\` values return a 400. Steer style with prompting instead.
+- **Thinking display defaults to omitted.** If you stream reasoning to users, set \`thinking: {type: "adaptive", display: "summarized"}\` or your UI will show a long silent pause before output.
+- **Effort is your main dial.** \`output_config: {effort: "high"}\` is the default; \`xhigh\` is the recommended setting for the hardest coding and agentic tasks, and \`medium\` on Sonnet 5 is roughly comparable to Sonnet 4.6 at \`high\` — a useful cost step-down.
+
+None of this is exotic if you've already migrated anything to Opus 4.7 or 4.8 — it's the same surface. If you're coming straight from Sonnet 4.5 or older, budget a real migration pass rather than a find-and-replace.
+
+---
+
+## The First Week: What People Are Actually Saying
+
+Launch-week reactions have sorted into a fairly consistent picture.
+
+**The praise centers on agentic endurance and context.** Teams are loading entire monorepos — 250K+ lines — into single sessions and getting useful whole-codebase answers. The model plans, uses tools, and self-verifies well enough that "start it and walk away" workflows that used to require Opus now run acceptably on Sonnet pricing. For a lot of mid-size teams, that's the difference between agentic workflows being a line item they debate and one they don't.
+
+**The criticism centers on deliberateness.** The same self-verification that makes long runs reliable makes quick interactions slower. Reviewers note it runs tests for one-line changes and reconsiders plans mid-flight. If your mental model of Sonnet is "the fast one," Sonnet 5 will occasionally frustrate you — it's better understood as "the thorough one that happens to be affordable."
+
+**And the pricing debate cuts both ways.** Boosters point at near-Opus capability at 40% of Opus input pricing. Skeptics point at the tokenizer inflation and the September price restoration and argue the effective discount is smaller than the headline. Both are right; the model is still clearly the best value in the lineup either way.
+
+---
+
+## FAQ
+
+**Is Claude Sonnet 5 free?**
+It's the default model on Claude's Free plan, so yes — you can use it at no cost within free-tier limits. API usage is billed at $2/$10 per million input/output tokens through August 31, 2026, then $3/$15.
+
+**Is Sonnet 5 better than Opus 4.8?**
+No — Opus 4.8 is still the more capable model, and it remains the default for Max and Team Premium plans. But Sonnet 5 is close enough on coding and agentic tasks that Opus needs a justification for many workloads, at 2–2.5x the price.
+
+**Does Sonnet 5 have a 1M context window?**
+Yes, natively — no beta flag, no long-context surcharge. Note the new tokenizer means 1M tokens holds somewhat less text than it would have on Sonnet 4.6's tokenizer.
+
+**Why does Sonnet 5 feel slower than Sonnet 4.6?**
+Adaptive thinking is on by default, and the model self-verifies more. Lower the effort level for quick interactive work, or disable thinking explicitly on latency-sensitive API paths.
+
+**Should I migrate from Sonnet 4.6?**
+Almost certainly, and ideally before August 31 while the promo pricing lets you re-run evals cheaply. Just treat it as a real migration: remove \`budget_tokens\` and sampling params, re-baseline token counts, and re-test anything tuned to 4.6's latency profile.
+
+---
+
+## The Bottom Line
+
+Sonnet 5 is the least dramatic release of Anthropic's summer and the one that will change the most people's daily work. Fable 5 redefined the ceiling; Sonnet 5 redefined the default. Near-Opus coding ability, a million tokens of context, and the full effort range — on the free tier's default model, at prices that (for two more months) undercut its own predecessor.
+
+The practical takeaways: let it be your default, escalate to Opus 4.8 deliberately rather than habitually, re-baseline anything you measure in tokens, and use the promo window to run the backlog of agentic experiments you've been putting off.
+
+## Further Reading
+
+- [Claude Fable 5: Anthropic's New Top Tier, Explained](/blog/claude-fable-5-guide) — the other end of the 2026 lineup
+- [Claude Opus 4.8 Release: What's New](/blog/claude-opus-4-8-release) — the model Sonnet 5 is chasing
+- [Claude Code Best Practices](/blog/claude-code-best-practices) — habits that matter more than model choice
+- [Context Engineering for Claude Code](/blog/context-engineering-claude-code) — because a 1M window is not a license to fill it
+`,
+};

--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -37,8 +37,12 @@ import { claudeFable5Guide } from "./claude-fable-5-guide";
 import { claudeCodeBestPractices } from "./claude-code-best-practices";
 import { claudeCodeSkillsVsSubagentsVsMcp } from "./claude-code-skills-vs-subagents-vs-mcp";
 import { claudeCodeLoopGuide } from "./claude-code-loop-guide";
+import { claudeSonnet5Guide } from "./claude-sonnet-5-guide";
+import { claudeFable5ExportControls } from "./claude-fable-5-export-controls";
 
 export const blogPosts: BlogPost[] = [
+  claudeFable5ExportControls,
+  claudeSonnet5Guide,
   claudeCodeLoopGuide,
   claudeCodeSkillsVsSubagentsVsMcp,
   claudeCodeBestPractices,


### PR DESCRIPTION
## What

Two new featured blog posts, both dated 2026-07-09:

**[The 18 Days Fable 5 Was Banned](/src/data/blog/claude-fable-5-export-controls.ts)** (`/blog/claude-fable-5-export-controls`)
A narrative/analysis piece on the June export-control suspension: the Amazon researchers' jailbreak report, the June 12 Commerce directive (and why its "foreign nationals anywhere" scope forced a total shutdown), Anthropic's public dispute while complying, the June 30 lifting, and the July 1 redeployment with the new cyber classifier. Ends with a practical section for developers (`fallbacks` API param, multi-model evals, expected false positives on security work).

**[Claude Sonnet 5: The New Default in Claude Code](/src/data/blog/claude-sonnet-5-guide.ts)** (`/blog/claude-sonnet-5-guide`)
Guide to the June 30 Sonnet 5 release: $2/$10 per MTok promo pricing through Aug 31 (then $3/$15), native 1M context, the ~30% tokenizer inflation and what it does to cost math, Claude Code default/model-switching mechanics, API breaking changes vs. Sonnet 4.6, and a Haiku/Sonnet/Opus/Fable model-picker table.

## Why

The blog had no coverage of either June story. The export-control piece fills a genre gap (news analysis vs. how-to guides) and targets untapped search queries; the Sonnet 5 guide covers the highest-volume Claude topic right now while the promo-pricing window makes it timely.

## Notes for review

- All facts verified against primary sources: Anthropic's suspension statement and redeployment post, the Sonnet 5 announcement, and Claude Code docs. Pricing/model IDs cross-checked against the API reference.
- Both posts cross-link each other and existing posts (Fable 5 guide, Opus 4.8 release, best practices, context engineering); each has a FAQ section plus custom `seoTitle`/`seoDescription`.
- `index.ts` registers both, export-controls post first (newest-first display order).
- Verified: `tsc --noEmit`, `eslint`, and a full `npm run build` pass; both pages prerender with OG images and appear in `/sitemap/blog.xml`.