### PR TITLE
Add YapUI plugin (live HTML preview + in-browser feedback loop)

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -27,6 +27,7 @@ import { swiftLspPlugin } from "./swift-lsp";
 import { testWriterFixerPlugin } from "./test-writer-fixer";
 import { flowNextPlugin } from "./flow-next";
 import { ralphPlugin } from "./ralph";
+import { yapuiPlugin } from "./yapui";
 // LSP plugins
 import { typescriptLspPlugin } from "./typescript-lsp";
 import { pyrightLspPlugin } from "./pyright-lsp";
@@ -133,6 +134,7 @@ const curatedPlugins: Plugin[] = [
   deploymentEngineerPlugin,
   flowNextPlugin,
   ralphPlugin,
+  yapuiPlugin,
   // External plugins
   asanaPlugin,
   awsPlugin,

--- a/src/data/plugins/yapui.ts
+++ b/src/data/plugins/yapui.ts
@@ -1,0 +1,19 @@
+import { Plugin } from "@/lib/types";
+
+export const yapuiPlugin: Plugin = {
+  slug: "yapui",
+  title: "YapUI",
+  description: "Live HTML preview with an in-browser feedback loop: talk, point, record, screenshot, or type and a resident Claude agent applies the fix in seconds",
+  tags: ["frontend", "html", "preview", "voice", "community"],
+  featured: false,
+  dateAdded: "2026-07-10",
+  author: {
+    name: "Tatendaz",
+    url: "https://github.com/Tatendaz",
+  },
+  repoUrl: "https://github.com/Tatendaz/yapui",
+  installCommand: "/plugin marketplace add Tatendaz/yapui && /plugin install yapui@yapui-marketplace",
+  commands: [
+    { name: "/yapui", description: "Preview an HTML file in the browser with the live feedback loop" },
+  ],
+};


### PR DESCRIPTION
Adds [YapUI](https://github.com/Tatendaz/yapui) under Community plugins.

YapUI is a Claude Code skill/plugin that serves any HTML file on localhost, injects a feedback widget, and keeps a resident pre-warmed Claude agent listening: talk, point (click-to-pick an element), record a janky animation, screenshot, or type a note, and the agent applies the fix in seconds and replies right in the page — no terminal round-trips.

- MIT, zero npm dependencies, offline test suite, CI on Node 20/22
- Installable as a plugin (`/plugin marketplace add Tatendaz/yapui && /plugin install yapui@yapui-marketplace`), a skill (`npx skills add tatendaz/yapui`), or a plain git clone
- Site: https://tatendaz.github.io/yapui/ · Demo gif in the repo README

Tested locally: `npm run build` passes and `/plugins/yapui` prerenders as a static page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNU2tyihfqeyAEuCRFUTPb