### PR TITLE
Add SafeInstall MCP server

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -95,6 +95,7 @@ import { googleColabServer } from "./google-colab";
 import { apifyServer } from "./apify";
 import { rnwy } from "./rnwy";
 import { publicGrantsServer } from "./public-grants";
+import { safeinstallServer } from "./safeinstall";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -208,6 +209,7 @@ const curatedMcpServers: MCPServer[] = [
   rnwy,
   // Finance & Grants
   publicGrantsServer,
+  safeinstallServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/safeinstall.ts
+++ b/src/data/mcp-servers/safeinstall.ts
@@ -1,0 +1,23 @@
+import { MCPServer } from "@/lib/types";
+
+export const safeinstallServer: MCPServer = {
+  slug: "safeinstall",
+  title: "SafeInstall",
+  description: "Local-first supply-chain security gate for npm, pnpm, and bun — checks typosquats, release age, and Sigstore provenance before an agent installs",
+  tags: ["security", "supply-chain", "npm", "package-management", "community"],
+  featured: false,
+  author: {
+    name: "Mickdownunder",
+    url: "https://github.com/Mickdownunder",
+  },
+  repoUrl: "https://github.com/Mickdownunder/SafeInstall",
+  installCommand: "npm install -g safeinstall-cli",
+  config: `{
+  "mcpServers": {
+    "safeinstall": {
+      "command": "npx",
+      "args": ["safeinstall-cli", "mcp"]
+    }
+  }
+}`,
+};


### PR DESCRIPTION
Adds [SafeInstall](https://github.com/Mickdownunder/SafeInstall) — a local-first supply-chain security gate for npm/pnpm/bun installs. The MCP server exposes `check_package` (typosquat detection, release age, install scripts, Sigstore provenance + provenance continuity) so agents can check a package before installing; the same engine also ships enforced PreToolUse install guards for Claude Code, Codex, and Cursor. MIT, published to npm as `safeinstall-cli` with Sigstore provenance. Entry follows the existing schema; appended at the end of the curated list.