### PR TITLE
Add Skills Janitor plugin (khendzel/skills-janitor)

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -1,5 +1,6 @@
 import { Plugin } from "@/lib/types";
 import { portaljsPlugin } from "./portaljs";
+import { skillsJanitorPlugin } from "./skills-janitor";
 import { agentSdkDevPlugin } from "./agent-sdk-dev";
 import { bugDetectivePlugin } from "./bug-detective";
 import { ccpmPlugin } from "./ccpm";
@@ -164,6 +165,7 @@ const curatedPlugins: Plugin[] = [
   storybookPlugin,
   // Community plugins
   portaljsPlugin,
+  skillsJanitorPlugin,
   perfProfilerPlugin,
   i18nManagerPlugin,
   depAuditPlugin,

--- a/src/data/plugins/skills-janitor.ts
+++ b/src/data/plugins/skills-janitor.ts
@@ -1,0 +1,21 @@
+import { Plugin } from "@/lib/types";
+
+export const skillsJanitorPlugin: Plugin = {
+  slug: "skills-janitor",
+  title: "Skills Janitor",
+  description: "Audit, usage-track and prune installed skills — token-cost split and a swipe-to-delete TUI",
+  tags: ["skills", "audit", "cleanup", "token-cost", "productivity"],
+  author: {
+    name: "khendzel",
+    url: "https://github.com/khendzel",
+  },
+  repoUrl: "https://github.com/khendzel/skills-janitor",
+  installCommand: "/plugin marketplace add khendzel/skills-janitor",
+  commands: [
+    { name: "/janitor-report", description: "Health check: inventory, duplicates, broken skills" },
+    { name: "/janitor-fix", description: "Auto-fix issues; --prune removes broken symlinks and empty dirs" },
+    { name: "/janitor-value", description: "Token costs (always-loaded vs on-demand) plus usage, for skills and subagents" },
+    { name: "/janitor-discover", description: "Search GitHub for skills, or vet a URL before installing" },
+    { name: "/janitor-swipe", description: "Interactive TUI: swipe keep/delete/skip through every installed skill" },
+  ],
+};


### PR DESCRIPTION
Adds [Skills Janitor](https://github.com/khendzel/skills-janitor) to the curated plugins.

Skills Janitor audits installed Claude Code and Codex skills (all scopes, including plugin-installed ones), tracks which skills actually get used, splits token cost into always-loaded descriptions vs on-demand bodies, and prunes unused skills via a swipe keep/delete/skip TUI. Zero dependencies, MIT.

Changes:
- new entry at `src/data/plugins/skills-janitor.ts`, mirroring the structure of existing entries
- registered in `src/data/plugins/index.ts` under Community plugins