### PR TITLE
Add TrackMyShares MCP server (portfolio, dividends, AU tax)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ export const myServer: MCPServer = {
   tags: ["tag1", "tag2"],
   author: { name: "Your Name" },
   installCommand: "npm install -g my-server", // optional
+  docsUrl: "https://example.com/docs/mcp", // optional, setup docs
   config: `{
   "mcpServers": {
     "my-server": {
@@ -63,6 +64,22 @@ export const myServer: MCPServer = {
   }
 }`,
 };
+```
+
+For a hosted (remote) server, use a `url` instead of a `command`, and add `headers` if it
+needs authentication. `docsUrl` is handy here to show readers how to get an API key:
+
+```typescript
+config: `{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://example.com/api/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}`,
 ```
 
 ### Hooks (`src/data/hooks/`)

--- a/src/app/mcp-servers/[slug]/page.tsx
+++ b/src/app/mcp-servers/[slug]/page.tsx
@@ -193,6 +193,20 @@ export default async function MCPServerDetailPage(props: Props) {
           </div>
         )}
 
+        {server.docsUrl && (
+          <div>
+            <a
+              href={server.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              View setup documentation
+            </a>
+          </div>
+        )}
+
         {server.relatedItems && server.relatedItems.length > 0 && (
           <>
             <Separator />

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -95,6 +95,7 @@ import { googleColabServer } from "./google-colab";
 import { apifyServer } from "./apify";
 import { rnwy } from "./rnwy";
 import { publicGrantsServer } from "./public-grants";
+import { trackmysharesServer } from "./trackmyshares";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -208,6 +209,7 @@ const curatedMcpServers: MCPServer[] = [
   rnwy,
   // Finance & Grants
   publicGrantsServer,
+  trackmysharesServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/trackmyshares.ts
+++ b/src/data/mcp-servers/trackmyshares.ts
@@ -11,6 +11,7 @@ export const trackmysharesServer: MCPServer = {
     name: "TrackMyShares",
     url: "https://trackmyshares.com",
   },
+  docsUrl: "https://trackmyshares.com/help/mcp-integration",
   installCommand:
     'claude mcp add trackmyshares https://trackmyshares.com/api/mcp --transport http --header "Authorization: Bearer YOUR_API_KEY"',
   config: `{

--- a/src/data/mcp-servers/trackmyshares.ts
+++ b/src/data/mcp-servers/trackmyshares.ts
@@ -1,0 +1,26 @@
+import { MCPServer } from "@/lib/types";
+
+export const trackmysharesServer: MCPServer = {
+  slug: "trackmyshares",
+  title: "TrackMyShares",
+  description:
+    "Query your own investment portfolio from Claude. 13 tools covering holdings and consolidated views across portfolios, transactions, portfolio performance with benchmark comparison, rebalancing status and trade recommendations, projected dividend calendar, and Australian tax reporting (capital gains, franking credits, AMIT/AMMA statements, tax loss harvesting). Also looks up stock quotes and searches symbols. Covers ASX, US, crypto and precious metals. Hosted HTTP server - requires a TrackMyShares Pro plan. Generate your API key under Settings > MCP integration in the dashboard; setup docs: https://trackmyshares.com/help/mcp-integration",
+  tags: ["finance", "investing", "portfolio", "stocks", "tax", "australia"],
+  featured: false,
+  author: {
+    name: "TrackMyShares",
+    url: "https://trackmyshares.com",
+  },
+  installCommand:
+    'claude mcp add trackmyshares https://trackmyshares.com/api/mcp --transport http --header "Authorization: Bearer YOUR_API_KEY"',
+  config: `{
+  "mcpServers": {
+    "trackmyshares": {
+      "url": "https://trackmyshares.com/api/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}`,
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,8 @@ export interface MCPServer {
   dateAdded?: string;
   relatedItems?: RelatedItem[];
   repoUrl?: string;
+  /** Setup/usage docs. Useful for hosted servers with no public repo. */
+  docsUrl?: string;
   seoTitle?: string;
   seoDescription?: string;
   stars?: number;


### PR DESCRIPTION
Thanks for maintaining this directory. Adds **TrackMyShares** to `src/data/mcp-servers/` - a hosted MCP server that lets Claude query your own investment portfolio (ASX, US, crypto, precious metals).

### What it does

13 tools across:
- **Portfolios** - holdings with current market prices, consolidated view across portfolios
- **Transactions** - record and query buys, sells, dividends
- **Performance** - time-series returns with benchmark comparison
- **Rebalancing** - current vs target weights, trade recommendations
- **Dividends** - projected dividend calendar
- **Australian tax** - capital gains, franking credits, AMIT/AMMA statements, tax loss harvesting

### Setup

It's a remote server, so there's nothing to install locally - point your client at the URL and pass an API key:

```
claude mcp add trackmyshares https://trackmyshares.com/api/mcp --transport http --header "Authorization: Bearer YOUR_API_KEY"
```

To get a key: sign in at trackmyshares.com, then **Settings > MCP integration > Create new API key**. Setup docs for Claude Desktop, Claude Code and Cursor: https://trackmyshares.com/help/mcp-integration

The server requires a TrackMyShares Pro plan. I've said so in the description so nobody hits an unexplained 401.

---

### A question, rather than an assumption: may I add an optional `docsUrl` field?

CONTRIBUTING says content lives in `src/data/`, and lists `featured`, `repoUrl` and `relatedItems` as the optional fields - so the second commit here steps outside that. I didn't want to quietly slip a schema change into a submission PR, so I'm asking instead of assuming, and **it's entirely fine if the answer is no.**

The reason I ran into it: this is a hosted server with no public repo, and users need to know where to get an API key. `repoUrl` is the only link field, but it renders under a hardcoded "View source on GitHub" label, which wouldn't be true for a help page. (I noticed `apidog` currently points `repoUrl` at `docs.apidog.com`, so it hits the same label - which suggested the gap isn't unique to me.) Of the four hosted `url`-based entries, `skyvern` also needs an API key and has nowhere to link its docs either.

So commit 2 proposes an optional `docsUrl`, rendered as "View setup documentation", and notes it in CONTRIBUTING alongside the remote-server config shape (`url` + `headers`), since 86 of the 90 current entries are local `command` servers and the remote form isn't written down anywhere.

**If you'd rather not take it, just say so and I'll drop it - or you can revert `4bc3a0b` yourself.** I deliberately isolated the whole proposal in that one commit, and the listing does not depend on it: commit 1 is content-only and stands alone, and the docs URL is also written into the `description` text, so it survives either way. I've checked that reverting commit 2 still typechecks and builds.

Happy to split it into a separate PR (or an issue) if you'd prefer to discuss it on its own.

`npm run build` and `npx tsc --noEmit` both pass.