### PR TITLE
Stop fabricating install commands and configs from repo names

### DIFF
--- a/scripts/ingest/awesome-mcp.mjs
+++ b/scripts/ingest/awesome-mcp.mjs
@@ -55,7 +55,9 @@ function parseAwesomeReadme(markdown, sourceRepo, defaultCategory) {
     const repoTitle = titleize(repo);
     const isGeneric = /^(agent|server|servers|mcp|mcp-server|core|client|sdk|tool|tools|api)$/i.test(repo.replace(/[-_](mcp|server|servers)/gi, ""));
     const title = isGeneric ? `${titleize(owner)} ${repoTitle}`.trim() : repoTitle;
-    out.push({
+    const installCommand = guessInstallCommand(cleanDesc);
+    const config = defaultMcpConfig(installCommand);
+    const record = {
       slug,
       title,
       description: truncate(cleanDesc, 280),
@@ -65,12 +67,15 @@ function parseAwesomeReadme(markdown, sourceRepo, defaultCategory) {
         url: `https://github.com/${owner}`,
       },
       repoUrl: `https://github.com/${repoFull}`,
-      installCommand: guessInstallCommand(repoFull, cleanDesc),
-      config: defaultMcpConfig(repo),
       source: "ingested",
       _category: currentCategory,
       _sourceList: sourceRepo,
-    });
+    };
+    // Only attach an install command or config when there is a real one. We do
+    // not synthesise either from the repo name; see the functions below.
+    if (installCommand) record.installCommand = installCommand;
+    if (config) record.config = config;
+    out.push(record);
   }
   return out;
 }
@@ -105,20 +110,27 @@ function titleize(name) {
     .join(" ") || name;
 }
 
-function guessInstallCommand(repoFull, description) {
+function guessInstallCommand(description) {
   const m = description.match(/`(npx[^`]+|pip install[^`]+|uv[xa-z]?\s+[^`]+)`/i);
   if (m) return m[1].trim();
-  // Default to npx pattern using repo name
-  const repo = repoFull.split("/")[1];
-  return `npx -y ${repo}`;
+  // No install command in the source description. Do not build one from the repo
+  // name: the repo name is not the package name, and `npx -y <repo>` routinely
+  // resolves to an unrelated package or to nothing. Return null so the field is
+  // left off rather than published as a guess users would paste into a terminal.
+  return null;
 }
 
-function defaultMcpConfig(repo) {
+function defaultMcpConfig(installCommand) {
+  // Only build a config from a real npx command, and take the package name from
+  // that command, never from the repo name.
+  const m = installCommand && installCommand.match(/^npx\s+(?:-y\s+)?(\S+)/);
+  if (!m) return null;
+  const pkg = m[1];
   return `{
   "mcpServers": {
-    "${repo}": {
+    "${pkg}": {
       "command": "npx",
-      "args": ["-y", "${repo}"]
+      "args": ["-y", "${pkg}"]
     }
   }
 }`;

--- a/src/app/mcp-servers/[slug]/page.tsx
+++ b/src/app/mcp-servers/[slug]/page.tsx
@@ -157,13 +157,15 @@ export default async function MCPServerDetailPage(props: Props) {
           </div>
         )}
 
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Configuration</h2>
-            <CopyButton text={server.config} />
+        {server.config && (
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">Configuration</h2>
+              <CopyButton text={server.config} />
+            </div>
+            <CodeBlock code={server.config} language="json" />
           </div>
-          <CodeBlock code={server.config} language="json" />
-        </div>
+        )}
 
         <div className="bg-accent/50 rounded-lg p-4">
           <h3 className="font-semibold mb-2">How to use</h3>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,7 +39,7 @@ export interface MCPServer {
   slug: string;
   title: string;
   description: string;
-  config: string;
+  config?: string;
   installCommand?: string;
   tags: string[];
   author: Author;


### PR DESCRIPTION
## What this changes

`guessInstallCommand` and `defaultMcpConfig` fall back to the GitHub repo name when a listing has no explicit install command, producing `npx -y <repo>` and a matching config. Repo names are not npm package names, so these guesses often install a different package than the project, or install nothing.

This change makes both functions return null when there is nothing concrete to go on, and derives the config's package name from the resolved install command instead of the repo name. Listings that already carry a backticked command are unaffected and keep using it.

Full write-up and measurements are in #111. Short version, from the `punkpeye/awesome-mcp-servers` source: 90% of listings get a fabricated command, 56% of those point at a name that does not exist, and 353 install a real package owned by an unrelated account, including the ones shown for microsoft/playwright-mcp, github/github-mcp-server, and cloudflare/mcp-server-cloudflare.

## Behavior after this change

- A listing with a backticked `npx`/`pip`/`uv` command: unchanged, that command is used.
- A listing without one: the install command and config are omitted rather than guessed.
- The config is only built for npx-based commands, since the config template is npx-shaped, and its package name comes from the command, not the repo.

## UI note

The renderer needs to skip the install and config blocks when they are null. Happy to include that change here if you point me at the component, or split it into a follow-up.

## Notes for the maintainer

- This is the code change only. The committed `src/data/_ingested/mcp-servers.json` still holds the previously fabricated commands; re-running the ingest will drop them. I did not commit a regenerated file because a full re-ingest also pulls in unrelated upstream drift.
- Verified locally: `tsc --noEmit` passes, `eslint` on the touched files is clean, and I exercised `guessInstallCommand`/`defaultMcpConfig` against real descriptions (npx keeps the command and derives the config package from it; pip/uv keep the command and omit the npx config; no command omits both).
