### PR TITLE
Add Find MCP server listing

### DIFF
--- a/src/data/mcp-servers/find-mcp.ts
+++ b/src/data/mcp-servers/find-mcp.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const findMcpServer: MCPServer = {
+  slug: "find-mcp",
+  title: "Find MCP",
+  description:
+    "Search 17,000+ MCP servers from the official MCP registry - remote Streamable HTTP (catalog.agentage.io/mcp, no auth for search) or stdio (npx @agentage/find-mcp)",
+  tags: ["search", "discovery", "registry", "developer-tools"],
+  author: {
+    name: "agentage",
+  },
+  repoUrl: "https://github.com/agentage/find-mcp",
+  installCommand: "npx -y @agentage/find-mcp",
+  config: `{
+  "mcpServers": {
+    "find-mcp": {
+      "command": "npx",
+      "args": ["-y", "@agentage/find-mcp"]
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -95,6 +95,7 @@ import { googleColabServer } from "./google-colab";
 import { apifyServer } from "./apify";
 import { rnwy } from "./rnwy";
 import { publicGrantsServer } from "./public-grants";
+import { findMcpServer } from "./find-mcp";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -208,6 +209,8 @@ const curatedMcpServers: MCPServer[] = [
   rnwy,
   // Finance & Grants
   publicGrantsServer,
+  // MCP Discovery
+  findMcpServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.


### PR DESCRIPTION
Adds Find MCP to src/data/mcp-servers/ (find-mcp.ts) and exports it from index.ts, following the existing MCPServer entry shape.

Find MCP is an MCP server for discovering other MCP servers. It searches the agentage MCP Catalog: 17,000+ servers synced from the official MCP registry (registry.modelcontextprotocol.io).

- GitHub: https://github.com/agentage/find-mcp
- npm: @agentage/find-mcp (stdio: npx -y @agentage/find-mcp)
- Remote: Streamable HTTP https://catalog.agentage.io/mcp (no auth needed for search)
- Web UI: https://catalog.agentage.io/mcp
- Official registry entry: io.agentage/find-mcp - Tools: mcp_search, mcp_get, mcp_categories

Disclosure: I maintain Find MCP.
