### PR TITLE
Add three Ansvar EU compliance skills

### DIFF
--- a/src/data/skills/cra-vulnerability-obligations.ts
+++ b/src/data/skills/cra-vulnerability-obligations.ts
@@ -1,0 +1,47 @@
+import { Skill } from "@/lib/types";
+
+export const craVulnerabilityObligationsSkill: Skill = {
+  slug: "cra-vulnerability-obligations",
+  title: "CRA Vulnerability & Reporting Obligations",
+  description:
+    "Maps a product with digital elements to EU Cyber Resilience Act scope, product classification, and Article 14 reporting duties role-by-role, with application dates checked against served legal text.",
+  tags: ["security", "compliance", "cra", "vulnerability-management", "eu-regulation", "mcp"],
+  featured: false,
+  dateAdded: "2026-07-22",
+  author: {
+    name: "Ansvar Systems AB",
+    url: "https://github.com/Ansvar-Systems",
+  },
+  repoUrl: "https://github.com/Ansvar-Systems/cra-vulnerability-obligations-skill",
+  content: `# CRA Vulnerability & Reporting Obligations
+
+Given a product and, optionally, a concrete vulnerability, this skill produces a cited obligations assessment under the EU Cyber Resilience Act (Regulation (EU) 2024/2847): whether the product is in scope, its classification, the standing vulnerability-handling duties for the user's role, which reporting duties fire and on what timeline, and which neighbouring regimes (NIS2, GDPR, DORA) may also apply.
+
+## Overview
+
+Every legal claim is fetched at answer time from official sources (EUR-Lex, ENISA) with citations, and live vulnerability intelligence — CVE records, the CISA KEV catalog, EPSS scores, and exploit metadata — comes via the Ansvar Gateway MCP connector. The "actively exploited vulnerability" legal test is applied to fetched data, never assumed.
+
+## Requirements
+
+- The Ansvar Gateway MCP connector: \`https://gateway.ansvar.eu/mcp\` (OAuth 2.1 with Dynamic Client Registration; free signup at ansvar.eu).
+- Works in MCP-capable agents: Claude, ChatGPT, Microsoft Copilot, Gemini, and others.
+
+## Key Features
+
+- **Scope determination** — applies the CRA's product and connectivity tests from Articles 2–3.
+- **Product classification** — maps to important (Class I/II) and critical categories using the annexes and Commission Implementing Regulation (EU) 2025/2392.
+- **Role-specific duties** — separate branches for manufacturers, importers, distributors, and open-source stewards, with Annex I vulnerability-handling requirements.
+- **Article 14 reporting** — early warning, notification, final report, and the severe-incident path.
+- **Live CVE intelligence** — CVE records, CISA KEV status, and EPSS scores applied to the CRA's own legal tests.
+- **Entity-level screening** — NIS2, GDPR Articles 33/34, and DORA overlays where relevant.
+- **Timeline analysis** — application dates and transitional rules from Articles 69–71, checked against served text rather than assumed.
+
+## Example Usage
+
+"Does the CRA apply to our IoT device, and what do we have to report for this CVE?" — the skill determines scope and role, classifies the product, screens the named CVE against KEV and EPSS, applies the CRA's reporting tests, and returns a cited duty-by-duty assessment with the relevant application dates.
+
+## Repository
+
+[github.com/Ansvar-Systems/cra-vulnerability-obligations-skill](https://github.com/Ansvar-Systems/cra-vulnerability-obligations-skill)
+`,
+};

--- a/src/data/skills/incident-reporting-navigator.ts
+++ b/src/data/skills/incident-reporting-navigator.ts
@@ -1,0 +1,45 @@
+import { Skill } from "@/lib/types";
+
+export const incidentReportingNavigatorSkill: Skill = {
+  slug: "incident-reporting-navigator",
+  title: "Incident Reporting Navigator (EU)",
+  description:
+    "Screens one security incident across NIS2, GDPR, DORA, and the Cyber Resilience Act, resolving the receiving authority per EU member state and reporting deadlines with citations fetched live from official sources.",
+  tags: ["security", "compliance", "incident-response", "gdpr", "nis2", "dora", "eu-regulation", "mcp"],
+  featured: false,
+  dateAdded: "2026-07-22",
+  author: {
+    name: "Ansvar Systems AB",
+    url: "https://github.com/Ansvar-Systems",
+  },
+  repoUrl: "https://github.com/Ansvar-Systems/incident-reporting-navigator-skill",
+  content: `# Incident Reporting Navigator (EU)
+
+One security event can trigger several EU reporting regimes at once, each with its own trigger test, receiving authority, and clock. Given the incident facts and the organisation's profile, this skill produces a cited notification map: which regimes fire for which legal entity, which do not and why, which authority to notify, and by when.
+
+## Overview
+
+Screens a single incident across four EU reporting regimes — NIS2, GDPR, DORA, and the Cyber Resilience Act — determining which duties fire for each involved entity's roles, resolving the receiving authority per regime and member state from served national law, and producing a deadline table in which every duty, authority, and deadline is cited from official publisher text fetched live through the Ansvar Gateway MCP connector.
+
+## Requirements
+
+- The Ansvar Gateway MCP connector: \`https://gateway.ansvar.eu/mcp\` (OAuth 2.1 with Dynamic Client Registration; free signup at ansvar.eu).
+- Works in MCP-capable agents: Claude, ChatGPT, Microsoft Copilot, Gemini, and others.
+
+## Key Features
+
+- **Four-regime screening** for NIS2, GDPR, DORA, and CRA applicability, per involved entity and role.
+- **Member-state authority resolution** using national transposition texts, not the directive alone.
+- **Per-entity timestamp tracking** so each entity's clock starts from its own awareness date.
+- **In-force verification** checking the temporal applicability of each duty before citing it.
+- **Honest failure modes** distinguishing answered, unmatched, and retrieval-failed outcomes — never guessing an authority or a deadline from model memory.
+
+## Example Usage
+
+"We just discovered a breach affecting customer data — who do we need to notify and by when?" — the skill gathers the incident facts and the organisation's entity/role profile, screens each regime's trigger test against fetched legal text, resolves the receiving authority per member state, and returns a deadline table with every duty, authority, and deadline cited to its source.
+
+## Repository
+
+[github.com/Ansvar-Systems/incident-reporting-navigator-skill](https://github.com/Ansvar-Systems/incident-reporting-navigator-skill)
+`,
+};

--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -40,6 +40,9 @@ import { consolidateMemorySkill } from "./consolidate-memory";
 import { webappTestingSkill } from "./webapp-testing";
 // Community skills
 import { ansibleOpsSkill } from "./ansible-ops";
+import { regulatoryThreatModelSkill } from "./regulatory-threat-model";
+import { incidentReportingNavigatorSkill } from "./incident-reporting-navigator";
+import { craVulnerabilityObligationsSkill } from "./cra-vulnerability-obligations";
 
 const curatedSkills: Skill[] = [
   sqlOptimizerSkill,
@@ -85,6 +88,9 @@ const curatedSkills: Skill[] = [
   webappTestingSkill,
   // Community skills
   ansibleOpsSkill,
+  regulatoryThreatModelSkill,
+  incidentReportingNavigatorSkill,
+  craVulnerabilityObligationsSkill,
 ];
 
 // Auto-ingested skills from repos containing SKILL.md files.

--- a/src/data/skills/regulatory-threat-model.ts
+++ b/src/data/skills/regulatory-threat-model.ts
@@ -1,0 +1,49 @@
+import { Skill } from "@/lib/types";
+
+export const regulatoryThreatModelSkill: Skill = {
+  slug: "regulatory-threat-model",
+  title: "Regulatory Threat Model (STRIDE + LINDDUN)",
+  description:
+    "STRIDE and LINDDUN threat modeling with a cited EU security-obligations screen (GDPR, NIS2, CRA, AI Act) and live CVE/CISA-KEV/EPSS dependency screening, run through the Ansvar Gateway MCP connector.",
+  tags: ["security", "compliance", "threat-modeling", "gdpr", "nis2", "eu-regulation", "mcp"],
+  featured: false,
+  dateAdded: "2026-07-22",
+  author: {
+    name: "Ansvar Systems AB",
+    url: "https://github.com/Ansvar-Systems",
+  },
+  repoUrl: "https://github.com/Ansvar-Systems/regulatory-threat-model-skill",
+  content: `# Regulatory Threat Model (STRIDE + LINDDUN)
+
+Turns an agent into the orchestrator of a real security review: a server-enforced STRIDE threat model, a LINDDUN privacy threat model when personal data flows, a dependency exposure screen against live vulnerability data, and a selected, non-exhaustive screen of EU security obligations — each cited from officially published legal text with its scope, role, and application-date limits stated.
+
+## Overview
+
+The threat-modeling workflows run on the Ansvar Gateway's workflow engine, which enforces steps and quality gates server-side. The skill's job is to feed the engine well and ground the regulatory layer; it never simulates the engine's output or answers legal questions from model memory.
+
+## Requirements
+
+- The Ansvar Gateway MCP connector: \`https://gateway.ansvar.eu/mcp\` (OAuth 2.1 with Dynamic Client Registration; free signup at ansvar.eu).
+- Works in MCP-capable agents: Claude, ChatGPT, Microsoft Copilot, Gemini, and others.
+- The STRIDE and LINDDUN workflow runs require a Premium plan or above (metered monthly). The dependency exposure screen and the obligations screen work on the Free plan.
+
+## What It Covers
+
+- **STRIDE threat modeling** — component-level threats, severity, asset impact, mitigations.
+- **LINDDUN privacy analysis** — privacy threats for personal data flows.
+- **Dependency exposure screen** — live CVE leads with CISA KEV status and EPSS scores, reported as confirmed / possible / unmatched with source attribution.
+- **EU obligations screen** — GDPR (Articles 25, 32, 35), NIS2 (Articles 2, 21), CRA (Articles 2, 3, 13, 14, 69, 71), and AI Act (Article 15), each screened against scope, role, and application date and cited from the fetched text — never presented as a compliance verdict.
+
+## Data Handling
+
+Prose-only: the skill describes the system architecturally in the user's own words and never uploads source code, secrets, credentials, hostnames, or files.
+
+## Example Usage
+
+"Threat model this system" or "run a STRIDE and LINDDUN review before we ship" — the skill checks the connected plan, gathers an architecture-level system description, gets explicit consent before spending a metered workflow run, and assembles a deliverable with the workflow reports, the dependency exposure table, the obligations screen, and a record of what was searched, fetched, or left unresolved.
+
+## Repository
+
+[github.com/Ansvar-Systems/regulatory-threat-model-skill](https://github.com/Ansvar-Systems/regulatory-threat-model-skill)
+`,
+};


### PR DESCRIPTION
Adds three curated skill entries under `src/data/skills/`, following the documented CONTRIBUTING.md Skill shape (slug/title/description/tags/author/content), registered in `src/data/skills/index.ts`:

- `regulatory-threat-model` — STRIDE and LINDDUN threat modeling with a cited EU security-obligations screen (GDPR, NIS2, CRA, AI Act) and live CVE/CISA-KEV/EPSS dependency screening.
- `incident-reporting-navigator` — screens one security incident across NIS2, GDPR, DORA, and the Cyber Resilience Act, resolving the receiving authority per EU member state and reporting deadlines.
- `cra-vulnerability-obligations` — maps a product to EU Cyber Resilience Act scope, product classification, and Article 14 reporting duties role-by-role.

All three run through the Ansvar Gateway MCP connector and cite officially published legal text and live vulnerability data at answer time. Each `repoUrl` points at its canonical, public, CC BY 4.0 repo under `Ansvar-Systems/`.

Verified with `npx tsc --noEmit` (clean, no errors touching the new/changed files).

Disclosure: I am affiliated with Ansvar Systems AB, the author of these three skills.