### PR TITLE
Add Quant Data plugin (backtested market statistics)

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -89,6 +89,8 @@ import { mcpRegistryPlugin } from "./mcp-registry";
 import { shadcnPlugin } from "./shadcn";
 import { bunPlugin } from "./bun";
 import { astroPlugin } from "./astro";
+// Market data plugins
+import { quantdataPlugin } from "./quantdata";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -186,6 +188,8 @@ const curatedPlugins: Plugin[] = [
   shadcnPlugin,
   bunPlugin,
   astroPlugin,
+  // Market data plugins
+  quantdataPlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across

--- a/src/data/plugins/quantdata.ts
+++ b/src/data/plugins/quantdata.ts
@@ -1,0 +1,16 @@
+import { Plugin } from "@/lib/types";
+
+export const quantdataPlugin: Plugin = {
+  slug: "quantdata",
+  title: "Quant Data",
+  description:
+    "Market-statistics skills that report backtested probabilities with their baselines, sample sizes and p-values: five-class day-type probabilities for the session in progress, Weis volume-price wave events with pre-registered win rates (cib_long 51.8% over a 49.3% baseline, n=13,867), options max pain from open interest alone, and estimated dealer gamma exposure. Publishes where the methods fail — crypto, gold, chart patterns — and refuses to present output as trading advice.",
+  tags: ["market-data", "finance", "options", "statistics", "skills"],
+  author: {
+    name: "Celine Yu",
+    url: "https://quantdata.uk",
+  },
+  repoUrl: "https://github.com/celineycn/quantdata-plugin",
+  installCommand:
+    "/plugin marketplace add celineycn/quantdata-plugin && /plugin install quantdata@quantdata",
+};


### PR DESCRIPTION
Adds a curated plugin entry for [Quant Data](https://github.com/celineycn/quantdata-plugin): three skills covering day-type classification for the session in progress, Weis wave volume-price events, and options max pain / gamma exposure, installable from its self-hosted marketplace (`/plugin marketplace add celineycn/quantdata-plugin && /plugin install quantdata@quantdata` — same convention as the anthropic-skills entry).

What distinguishes it: every probability the skills report is backtested and published with its baseline, sample size and p-value — e.g. the `cib_long` volume event measured a 51.8% win rate over a 49.3% baseline on n=13,867 pre-registered instances — and the research documents where the methods fail (crypto, gold, chart patterns) as prominently as where they work. The skills refuse to present any output as trading advice.

Per CONTRIBUTING: new file `src/data/plugins/quantdata.ts` + export added to `src/data/plugins/index.ts`. `npm run build` passes locally with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)