### PR TITLE
Add Eliasjunit/vibestretch to KNOWN_MARKETPLACES

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -18,6 +18,7 @@ const KNOWN_MARKETPLACES = [
   "2389-research/claude-plugins",
   "Houseofmvps/ultraship",
   "claude-world/director-mode-lite",
+  "Eliasjunit/vibestretch",
 ];
 
 const MARKETPLACE_PATHS = [


### PR DESCRIPTION
One line in `scripts/ingest/marketplaces.mjs`.

[vibestretch](https://github.com/Eliasjunit/vibestretch) is a Claude Code plugin that nudges you to stretch, move, or rest your eyes while your agent grinds through a long turn — one line in the session, a soft bundled chime, and an optional status line segment. The nudge only fires after real agent-wait time has accumulated, so short turns and quick back-and-forth stay silent, and it reads the OS idle clock on macOS so an overnight run never chimes at an empty chair. Three POSIX shell hooks, zero dependencies, no telemetry, no links printed into anyone's terminal.

Went through the ingest path rather than a curated `src/data/plugins/*.ts` entry because the repo carries its own `.claude-plugin/marketplace.json` — the weekly job then keeps title, description and author in sync on its own, and the listing can't drift from the plugin the way a hand-written entry would.

`node --check` passes on the edited file; no generated `_ingested/*.json` touched, since the scheduled workflow regenerates those.