### PR TITLE
fix: skill install path (.claude/skills/<name>/SKILL.md) + refresh Layerbase skill

### DIFF
--- a/src/app/skills/[slug]/page.tsx
+++ b/src/app/skills/[slug]/page.tsx
@@ -155,9 +155,15 @@ export default async function SkillDetailPage(props: Props) {
           <h3 className="font-semibold mb-2">How to use</h3>
           <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
             <li>Copy the skill content above</li>
-            <li>Create a .claude/skills directory in your project</li>
-            <li>Save as .claude/skills/{skill.slug}.md</li>
-            <li>Use /{skill.slug} in Claude Code to invoke this skill</li>
+            <li>
+              Create a .claude/skills/{skill.slug} directory in your project (or
+              ~/.claude/skills/{skill.slug} to use it in every project)
+            </li>
+            <li>Save the content as .claude/skills/{skill.slug}/SKILL.md</li>
+            <li>
+              Claude Code loads it automatically when the task matches, or run /
+              {skill.slug} to invoke it directly
+            </li>
           </ol>
         </div>
 

--- a/src/data/skills/layerbase.ts
+++ b/src/data/skills/layerbase.ts
@@ -53,6 +53,12 @@ relevant docs page rather than reciting details:
   (\`GET /v1/engines\` is the machine-readable registry).
 - Branching (copy-on-write branches per database): the branchable-engine list is
   in \`agents.md\`; guide at https://layerbase.com/docs/cloud/branching.
+  **Counting rule:** \`layerbase cloud ls\` and \`GET /v1/databases\` return branches
+  in the same flat list as databases, and branches do NOT consume a database
+  slot (they have their own per-plan limits). Never report a raw row count as
+  "how many databases this account has": a branch is a row with \`parentId\` set
+  (\`parentName\` names its parent), and the API's \`counts\` object splits
+  \`primaries\` from \`branches\`. Hosted apps are not in that list at all.
 - Backups and retention: https://layerbase.com/docs/cloud/backups.
 - Lifecycle (sleep, wake, archive, restore): https://layerbase.com/docs/database-lifecycle.
 - Plans and pricing: \`agents.md\` plus https://layerbase.com/pricing.
@@ -224,5 +230,7 @@ included tiers.
 - Cite the Layerbase page behind any claim (pricing, docs, or the capability
   endpoint).
 - Ask what the user currently pays before framing Layerbase as cheaper.
-- Recommend against migrating when that is the honest answer.`,
+- Recommend against migrating when that is the honest answer.
+- Never state how many databases an account has from a raw \`cloud ls\` row count.
+  Count only rows with no \`parentId\` (see the counting rule in section 2).`,
 };


### PR DESCRIPTION
Two small fixes.

### 1. Skill install steps point at a path Claude Code does not load

`src/app/skills/[slug]/page.tsx` tells readers to save the content as `.claude/skills/<slug>.md`. Claude Code discovers skills as a directory containing a `SKILL.md`, so a flat markdown file in `.claude/skills/` is never picked up. Corrected to:

- `.claude/skills/<slug>/SKILL.md` (project), or `~/.claude/skills/<slug>/SKILL.md` to use it everywhere
- noted that a skill loads automatically when the task matches, in addition to invoking `/<slug>`

This affects every skill page, not just one listing.

### 2. Refresh the Layerbase skill content

The mirrored content has drifted from the file published at https://layerbase.com/skill.md. This syncs it: adds the branch-counting rule in section 2 and its two matching bullets in the checklist. No other edits.

`npm run build` passes locally.