### PR TITLE
Add BrotherSBE plugin listing

### DIFF
--- a/src/data/plugins/brothersbe.ts
+++ b/src/data/plugins/brothersbe.ts
@@ -1,0 +1,24 @@
+import { Plugin } from "@/lib/types";
+
+export const brothersbePlugin: Plugin = {
+  slug: "brothersbe",
+  title: "BrotherSBE",
+  description:
+    "A senior backend and data engineering colleague for Claude Code. Designs systems in order (purpose, process, architecture, data, expression, verification) and holds the result to gates that actually run, reporting absent evidence as NO-DATA rather than a pass.",
+  tags: ["backend", "data-engineering", "verification", "migrations", "code-review"],
+  featured: false,
+  dateAdded: "2026-08-07",
+  author: {
+    name: "Khalil Maaouni",
+    url: "https://github.com/khalilmaaouni",
+  },
+  repoUrl: "https://github.com/khalilmaaouni/BrotherSBE",
+  installCommand:
+    "claude plugin marketplace add khalilmaaouni/BrotherSBE && claude plugin install brothersbe@brothersbe",
+  commands: [
+    { name: "/brothersbe:start", description: "Looks at where you are, a new project or one in progress, and takes it from there" },
+    { name: "/brothersbe:next", description: "Recommends exactly one next action" },
+    { name: "/brothersbe:status", description: "Explains where the work stands in plain language" },
+    { name: "/brothersbe:help", description: "Lays out the whole map on request" },
+  ],
+};

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -94,6 +94,7 @@ import { astroPlugin } from "./astro";
 // Market data plugins
 import { quantdataPlugin } from "./quantdata";
 import { appversionPlugin } from "./appversion";
+import { brothersbePlugin } from "./brothersbe";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -196,6 +197,7 @@ const curatedPlugins: Plugin[] = [
   // Market data plugins
   quantdataPlugin,
   appversionPlugin,
+  brothersbePlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across


### PR DESCRIPTION
## What this adds

A listing for BrotherSBE, a free, MIT licensed Claude Code plugin I built and maintain (https://github.com/khalilmaaouni/BrotherSBE): a senior backend and data engineering colleague that designs systems in order and holds the result to gates that actually run, reporting absent evidence as NO-DATA rather than a pass.

## Files

- `src/data/plugins/brothersbe.ts`, new entry following the existing Plugin shape (matched against `astro.ts`: slug, title, description, tags, featured false, dateAdded, author, repoUrl, installCommand, commands).
- `src/data/plugins/index.ts`, one import line and one entry appended to `curatedPlugins`.

Both changes follow CONTRIBUTING.md. Happy to adjust format or category if you prefer it elsewhere.
