### PR TITLE
Add VibeKit MCP server (hosting + deployment)

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -100,6 +100,7 @@ import { trackmysharesServer } from "./trackmyshares";
 import { findMcpServer } from "./find-mcp";
 import { dottedsignServer } from "./dottedsign";
 import { safeinstallServer } from "./safeinstall";
+import { vibekitServer } from "./vibekit";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -220,6 +221,8 @@ const curatedMcpServers: MCPServer[] = [
   dottedsignServer,
   safeinstallServer,
   productosMcp,
+  // Hosting & Deployment
+  vibekitServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/vibekit.ts
+++ b/src/data/mcp-servers/vibekit.ts
@@ -1,0 +1,28 @@
+import { MCPServer } from "@/lib/types";
+
+export const vibekitServer: MCPServer = {
+  slug: "vibekit",
+  title: "VibeKit",
+  description:
+    "Deploy and operate hosted web apps from Claude Code: ship a GitHub repo or starter template to a live URL, tail logs, set env vars, attach Postgres, and message each app's built-in coding agent. Hosted server at mcp.vibekit.bot (Bearer key). Distinct from the unrelated superagent-ai/vibekit sandbox SDK.",
+  tags: ["hosting", "deployment", "devops", "agents", "community"],
+  author: {
+    name: "VibeKit",
+    url: "https://github.com/VibeKit-Bot",
+  },
+  repoUrl: "https://github.com/VibeKit-Bot/vibekit-mcp",
+  docsUrl: "https://vibekit.bot/mcp-server",
+  installCommand:
+    'claude mcp add --transport http vibekit https://mcp.vibekit.bot/mcp --header "Authorization: Bearer vk_your_api_key"',
+  config: `{
+  "mcpServers": {
+    "vibekit": {
+      "type": "http",
+      "url": "https://mcp.vibekit.bot/mcp",
+      "headers": {
+        "Authorization": "Bearer vk_your_api_key"
+      }
+    }
+  }
+}`,
+};


### PR DESCRIPTION
Adds **VibeKit** to the MCP servers directory. There is no Hosting/Deployment entry in the curated list yet, so this fills a gap rather than duplicating one.

**What it does:** deploy a GitHub repo or starter template to a live URL, tail logs, set env vars, attach Postgres, restart/stop apps, and message each app's built-in coding agent. 36 tools.

**Verification (all live as of 2026-08-07):**
- Hosted endpoint answers a standard handshake: `POST https://mcp.vibekit.bot/mcp` returns `protocolVersion 2025-06-18`, `serverInfo {name: "vibekit", version: "0.8.0"}`.
- Source is public and MIT: https://github.com/VibeKit-Bot/vibekit-mcp
- Also published to the official MCP registry as `io.github.VibeKit-Bot/vibekit-mcp`, and on npm as [`vibekit-mcp`](https://www.npmjs.com/package/vibekit-mcp).
- `docsUrl` points at the setup page that explains how to get the `vk_` key, per CONTRIBUTING's note for hosted servers with auth.

**Disclosure:** I work on VibeKit, so this is a self-submission. The description states the third-party-hosting trade-off plainly (apps run in VibeKit's containers, not on your own machine) rather than leaving it out.

**Name collision worth flagging for the directory:** there is an unrelated, discontinued `superagent-ai/vibekit` sandbox SDK that several tool directories list under the bare name "VibeKit". The description names the distinction so this entry does not compound that confusion.

`npx tsc --noEmit` clean and `npm run build` passes; `/mcp-servers/vibekit` prerenders.
