### PR TITLE
Add Parallel Search MCP to the directory

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -17,6 +17,7 @@ import { dockerServer } from "./docker";
 import { e2bServer } from "./e2b";
 import { elasticsearchServer } from "./elasticsearch";
 import { exaServer } from "./exa";
+import { parallelSearchServer } from "./parallel-search";
 import { fetchServer } from "./fetch";
 import { figmaServer } from "./figma";
 import { filesystemServer } from "./filesystem";
@@ -137,6 +138,7 @@ const curatedMcpServers: MCPServer[] = [
   jiraServer,
   tavilyServer,
   exaServer,
+  parallelSearchServer,
   neo4jServer,
   vercelServer,
   grafanaServer,

--- a/src/data/mcp-servers/parallel-search.ts
+++ b/src/data/mcp-servers/parallel-search.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const parallelSearchServer: MCPServer = {
+  slug: "parallel-search",
+  title: "Parallel Search",
+  description:
+    "Search the live web and fetch clean Markdown from URLs through a free remote MCP server, with no account or API key required",
+  tags: ["search", "web", "research", "data-extraction", "official"],
+  featured: false,
+  author: {
+    name: "Parallel",
+    url: "https://parallel.ai",
+  },
+  docsUrl: "https://docs.parallel.ai/integrations/mcp/search-mcp",
+  config: `{
+  "mcpServers": {
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}`,
+};


### PR DESCRIPTION
Claude Directory already helps users compare hosted search MCPs. This adds a separate Parallel Search entry with a no-key remote configuration for live web search and clean Markdown URL fetching.

## What changed

- Added a non-featured `parallel-search` MCP data object with current docs and the Streamable HTTP endpoint.
- Registered it beside the other non-featured search providers; the existing generated Task MCP record is unchanged.

## Validation

- Changed-file ESLint passed
- Next.js production build passed, including TypeScript and 10,290 static pages
- Exact two-file, duplicate-separation, generated-file, whitespace, and docs-link checks passed

Repository-wide lint still reports one existing unrelated `react-hooks/set-state-in-effect` error in `src/components/universal-search.tsx`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.