### PR TITLE
Add Yaps plugins marketplace

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -19,6 +19,7 @@ const KNOWN_MARKETPLACES = [
   "Houseofmvps/ultraship",
   "claude-world/director-mode-lite",
   "Eliasjunit/vibestretch",
+  "richawo/yaps-plugins",
 ];
 
 const MARKETPLACE_PATHS = [


### PR DESCRIPTION
Registers [richawo/yaps-plugins](https://github.com/richawo/yaps-plugins) in `KNOWN_MARKETPLACES` so the scheduled ingest picks up its `.claude-plugin/marketplace.json` (marketplace name `yaps`, 11 plugins). The plugins drive the Yaps desktop app for on-device voice dictation, file and meeting transcription, subtitles and captions, audio cleanup, background removal, text-to-speech, translation, and local Markdown memory. Install with `claude plugin marketplace add richawo/yaps-plugins`. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)