### PR TITLE
Add Sting25/claude-code-handoff to KNOWN_MARKETPLACES

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -19,6 +19,7 @@ const KNOWN_MARKETPLACES = [
   "Houseofmvps/ultraship",
   "claude-world/director-mode-lite",
   "Eliasjunit/vibestretch",
+  "Sting25/claude-code-handoff",
 ];
 
 const MARKETPLACE_PATHS = [


### PR DESCRIPTION
One line in `scripts/ingest/marketplaces.mjs`.

[claude-code-handoff](https://github.com/Sting25/claude-code-handoff) is a Claude Code plugin that hands session state from one session to the next: a SessionEnd/PreCompact hook snapshots a curated handoff to `.claude/handoff_current.md`, a SessionStart hook loads it into the next session, and an HMAC provenance stamp (per-machine secret) separates locally-written standing rules — loaded as trusted — from narrative content, which loads defanged as reference data so a cloned repo can't plant instructions. Pure bash 3.2-compatible shell (macOS default; BSD and GNU coreutils), no runtime dependencies, 1100+ test assertions in CI.

Follow-up to #137, which I closed while the project was still a scripts-plus-installer: the skills there depended on companion hooks, which didn't match the self-contained shape a skills listing implies. It has since shipped as a proper plugin (v0.14.1) with the hooks and scripts bundled, and the repo carries its own `.claude-plugin/marketplace.json` — so this goes through the ingest path per #131, and the weekly job keeps the listing in sync on its own.

`node --check` passes on the edited file; no generated `_ingested/*.json` touched, since the scheduled workflow regenerates those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)