### PR TITLE
Add Zillow Property Data skill

### DIFF
--- a/src/data/skills/index.ts
+++ b/src/data/skills/index.ts
@@ -47,6 +47,7 @@ import { incidentReportingNavigatorSkill } from "./incident-reporting-navigator"
 import { craVulnerabilityObligationsSkill } from "./cra-vulnerability-obligations";
 import { feynmanItSkill } from "./feynman-it";
 import { layerbaseSkill } from "./layerbase";
+import { zillowPropertyDataSkill } from "./zillow-property-data";
 import { pluribusEvidenceAttestationSkill } from "./pluribus-evidence-attestation";
 
 const curatedSkills: Skill[] = [
@@ -101,6 +102,7 @@ const curatedSkills: Skill[] = [
   craVulnerabilityObligationsSkill,
   feynmanItSkill,
   layerbaseSkill,
+  zillowPropertyDataSkill,
 ];
 
 // Auto-ingested skills from repos containing SKILL.md files.

--- a/src/data/skills/zillow-property-data.ts
+++ b/src/data/skills/zillow-property-data.ts
@@ -1,0 +1,73 @@
+import { Skill } from "@/lib/types";
+
+export const zillowPropertyDataSkill: Skill = {
+  slug: "zillow-property-data",
+  title: "Zillow Property Data",
+  description: "Look up U.S. property records, Zestimates, and for-sale, sold and rental listings from an address, URL, or map area",
+  tags: ["zillow", "real-estate", "property-data", "zestimate", "listings"],
+  featured: false,
+  dateAdded: "2026-08-13",
+  author: {
+    name: "ZeroPointRepo",
+    url: "https://github.com/ZeroPointRepo",
+  },
+  repoUrl: "https://github.com/ZeroPointRepo/zillow-skills",
+  content: `# Zillow Property Data Skill
+
+Pull Zillow-sourced U.S. residential property data straight into Claude Code.
+
+## Overview
+
+This skill lets Claude Code answer property questions without you leaving the terminal:
+
+- **Property lookup** - Full record for any U.S. address, Zillow URL, or zpid
+- **Valuation** - Zestimate and rent Zestimate
+- **Listing search** - For sale, for rent, and sold, filtered by price, beds, baths, and home type
+- **History and context** - Price history, tax history, schools, photos, and listing agent
+
+## Installation
+
+\`\`\`bash
+npx skills add ZeroPointRepo/zillow-skills
+\`\`\`
+
+Install a single focused skill instead of the bundle:
+
+\`\`\`bash
+npx skills add ZeroPointRepo/zillow-skills --skill zillow-zestimate
+\`\`\`
+
+## Requirements
+
+- A Zillapi API key, set as an environment variable
+
+\`\`\`bash
+export ZILLAPI_KEY="zk_..."
+\`\`\`
+
+Get a key at [zillapi.com](https://zillapi.com). Pure Python standard library, no packages to install.
+
+## Skills in the repo
+
+| Skill | Purpose |
+|---|---|
+| \`zillow-full\` | Complete toolkit: address, URL and zpid lookup, Zestimate, search, history, photos, schools, agent |
+| \`zillow-zestimate\` | Valuation lookups only, for a lighter response |
+| \`zillow-search\` | Bounding box and location listing search |
+
+## Example Usage
+
+"What is the Zestimate for 350 5th Ave, New York, NY 10118?"
+"Pull the price and tax history for this Zillow listing: [URL]"
+"Find 3 bed homes for sale under $600k in this map area"
+"Which schools serve this address, and how far are they?"
+
+## Notes
+
+Zillapi is an independent service and is not affiliated with, endorsed by, or sponsored by Zillow Group, Inc. "Zillow" and "Zestimate" are registered trademarks of Zillow Group, Inc.
+
+## Repository
+
+[github.com/ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills)
+`,
+};


### PR DESCRIPTION
### What this adds

One new skill entry, following CONTRIBUTING exactly:

- `src/data/skills/zillow-property-data.ts` (new)
- one import + one array entry in `src/data/skills/index.ts`

`npm run build` passes locally, and `/skills/zillow-property-data` prerenders.

### What it is

[ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills) is a free, MIT-0 licensed set of agent skills that give Claude Code access to U.S. residential property data: address, URL and zpid lookup, Zestimate and rent Zestimate, for-sale, sold and rental listing search, plus price history, tax history, schools, photos and listing agent.

Pure Python standard library, no dependencies. Three skills in the repo: `zillow-full`, `zillow-zestimate`, `zillow-search`. Install with `npx skills add ZeroPointRepo/zillow-skills`.

### Disclosure

I maintain this repo. It is free and MIT-0 licensed, so anyone can fork or sublicense it with no attribution. The entry links only the GitHub repository. Happy to reword or trim if you want it shorter.

The entry also carries the required trademark note: Zillapi is an independent service, not affiliated with, endorsed by, or sponsored by Zillow Group, Inc.

### Checklist

- Shape copied from the existing `src/data/skills/youtube-transcript.ts` entry
- Exported from `src/data/skills/index.ts`
- `npm run build` green
- Slug `zillow-property-data` does not collide with anything curated or ingested
