### PR TITLE
Add Pragma plugin

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -94,6 +94,8 @@ import { astroPlugin } from "./astro";
 // Market data plugins
 import { quantdataPlugin } from "./quantdata";
 import { appversionPlugin } from "./appversion";
+// iOS development plugins
+import { pragmaPlugin } from "./pragma";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -196,6 +198,8 @@ const curatedPlugins: Plugin[] = [
   // Market data plugins
   quantdataPlugin,
   appversionPlugin,
+  // iOS development plugins
+  pragmaPlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across

--- a/src/data/plugins/pragma.ts
+++ b/src/data/plugins/pragma.ts
@@ -1,0 +1,37 @@
+import { Plugin } from "@/lib/types";
+
+export const pragmaPlugin: Plugin = {
+  slug: "pragma",
+  title: "Pragma",
+  description:
+    "The complete iOS development scaffold for the agentic era. 15 slash commands (/spec, /plan, /feature, /gates, /review, /test, /bugfix, /release, and more) take a feature from idea to merged PR with two human approvals, everything else runs autonomously. CI-enforced gates (not just agent-enforced) re-run the same checks independently in GitHub Actions, and a persistent memory layer (decisions, invariants, rejections) carries context across every session boundary instead of resetting at the conversation edge. Proven on a real, actively-developed, gitflow-integrated codebase — 70+ merged PRs, specs and plans predating every feature, going back to the first commit.",
+  tags: [
+    "ios",
+    "swift",
+    "swiftui",
+    "swiftdata",
+    "xcode",
+    "sdlc",
+    "tdd",
+    "ci-cd",
+    "agentic",
+  ],
+  author: {
+    name: "Akshay Pimprikar",
+    url: "https://github.com/akshaypimprikar",
+  },
+  installCommand:
+    "/plugin marketplace add akshaypimprikar/pragma && /plugin install pragma@pragma",
+  repoUrl: "https://github.com/akshaypimprikar/pragma",
+  commands: [
+    { name: "/spec", description: "Turn a feature idea into an approved design spec — proposes 2-3 approaches, you choose" },
+    { name: "/plan", description: "Turn an approved spec into a task-by-task implementation plan" },
+    { name: "/feature", description: "Execute an approved plan — TDD, one commit per task" },
+    { name: "/gates", description: "Verify build, full test suite, and architecture compliance before opening a PR" },
+    { name: "/review", description: "Review a PR for design compliance and code quality, posts its verdict as a real GitHub review" },
+    { name: "/test", description: "Write comprehensive tests for a feature branch" },
+    { name: "/bugfix", description: "Regression test first, then fix — test-first always" },
+    { name: "/release", description: "Version bump, changelog, PR to main, git tag" },
+    { name: "/pragma-init", description: "Interactive setup — configures CLAUDE.md and invariants.md for your project instead of leaving them as templates" },
+  ],
+};

--- a/src/data/plugins/pragma.ts
+++ b/src/data/plugins/pragma.ts
@@ -32,6 +32,6 @@ export const pragmaPlugin: Plugin = {
     { name: "/test", description: "Write comprehensive tests for a feature branch" },
     { name: "/bugfix", description: "Regression test first, then fix — test-first always" },
     { name: "/release", description: "Version bump, changelog, PR to main, git tag" },
-    { name: "/pragma-init", description: "Interactive setup — configures CLAUDE.md and invariants.md for your project instead of leaving them as templates" },
+    { name: "/pragma:init", description: "Interactive setup — configures CLAUDE.md and invariants.md for your project instead of leaving them as templates" },
   ],
 };


### PR DESCRIPTION
## What
Adds [Pragma](https://github.com/akshaypimprikar/pragma) — an agentic SDLC pipeline scaffold for Claude Code on iOS projects — to `src/data/plugins/`.

15 slash commands (`/spec`, `/plan`, `/feature`, `/gates`, `/review`, `/test`, `/bugfix`, `/release`, and more) take a feature from idea to merged PR with two human approvals; everything else runs autonomously. CI-enforced gates re-run the same checks independently in GitHub Actions (not just agent-enforced), and a persistent memory layer (decisions, invariants, rejections) carries context across every session boundary. Proven on a real, actively-developed, gitflow-integrated codebase — 70+ merged PRs, specs and plans predating every feature.

## Checklist
- [x] Added `src/data/plugins/pragma.ts` following the `Plugin` type in `src/lib/types.ts`
- [x] Wired the import + array entry into `src/data/plugins/index.ts`
- [x] `npm run build` — TypeScript compiled successfully

🤖 Generated with [Claude Code](https://claude.ai/code)