### PR TITLE
Add Churn Solution MCP server

### DIFF
--- a/src/data/mcp-servers/churnsolution.ts
+++ b/src/data/mcp-servers/churnsolution.ts
@@ -1,0 +1,23 @@
+import { MCPServer } from "@/lib/types";
+
+export const churnsolutionServer: MCPServer = {
+  slug: "churnsolution",
+  title: "Churn Solution",
+  description: "Query subscription retention analytics — cancellation-flow metrics, save rates, recovered revenue, offer performance, and customer feedback — for B2C subscription businesses on Stripe. Read-only.",
+  tags: ["churn", "retention", "subscriptions", "stripe", "analytics"],
+  author: {
+    name: "Churn Solution",
+    url: "https://churnsolution.com",
+  },
+  repoUrl: "https://github.com/Churnsolution/Churnsolution-MCP",
+  docsUrl: "https://churnsolution.com/docs/mcp-server",
+  installCommand: "claude mcp add --transport http churnsolution https://mcp.churnsolution.com",
+  config: `{
+  "mcpServers": {
+    "churnsolution": {
+      "type": "http",
+      "url": "https://mcp.churnsolution.com"
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -1,6 +1,7 @@
 import { MCPServer } from "@/lib/types";
 import { productosMcp } from "./productos-mcp";
 import { airtableServer } from "./airtable";
+import { churnsolutionServer } from "./churnsolution";
 import { apidogServer } from "./apidog";
 import { atlassianServer } from "./atlassian";
 import { awsServer } from "./aws";
@@ -155,6 +156,7 @@ const curatedMcpServers: MCPServer[] = [
   // Business Tools
   atlassianServer,
   airtableServer,
+  churnsolutionServer,
   shopifyServer,
   raygunServer,
   // Database & Infrastructure


### PR DESCRIPTION
Adds the official [Churn Solution](https://churnsolution.com) MCP server to `src/data/mcp-servers/`.

**What it does:** read-only access to subscription retention analytics for B2C subscription businesses on Stripe — cancellation-flow metrics, save rates, recovered revenue, offer performance, cancellation reasons, and customer feedback analytics.

- Remote/hosted server: `https://mcp.churnsolution.com` (streamable HTTP, OAuth — no API key needed)
- Repo: https://github.com/Churnsolution/Churnsolution-MCP
- Docs: https://churnsolution.com/docs/mcp-server
- Also published to the official MCP Registry as `com.churnsolution/analytics`

Followed the existing hosted-server pattern (same shape as `dottedsign.ts`), added the export to `index.ts`, and `npx tsc --noEmit` passes with no errors.