### PR TITLE
Add DemoDay plugin and mrieck/claude-plugins marketplace

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -20,6 +20,7 @@ const KNOWN_MARKETPLACES = [
   "claude-world/director-mode-lite",
   "Eliasjunit/vibestretch",
   "Sting25/claude-code-handoff",
+  "mrieck/claude-plugins",
 ];
 
 const MARKETPLACE_PATHS = [

--- a/src/data/plugins/demoday.ts
+++ b/src/data/plugins/demoday.ts
@@ -1,0 +1,30 @@
+import { Plugin } from "@/lib/types";
+
+export const demodayPlugin: Plugin = {
+  slug: "demoday",
+  title: "DemoDay",
+  description:
+    "Creates demo videos for your projects. Claude is given tools to drive the browser/cli, make recordings, and uses FAL.ai, ElevenLabs, and remotion to build a demo video with scene transitions. Supports both 16:9 promo/tutorial demos, and Short cut 9:16 listicle/cohost videos. Open source and MIT licensed.",
+  tags: ["demo-video", "ai video", "indie hacker tools", "eleven labs", "fal ai", "remotion", "screen-recording", "macos"],
+  featured: false,
+  dateAdded: "2026-08-25",
+  author: {
+    name: "Mark Rieck",
+    url: "https://github.com/mrieck",
+  },
+  repoUrl: "https://github.com/mrieck/demoday-claude-plugin",
+  installCommand:
+    "/plugin marketplace add mrieck/claude-plugins && /plugin install demoday@productive-mark",
+  config: `{
+  "enabledPlugins": {
+    "demoday@productive-mark": true
+  }
+}`,
+  commands: [
+    {
+      name: "/demoday:create-demo-video",
+      description:
+        "Plan, rehearse, record, narrate and render a demo video of the current project (16:9 launch/tutorial/explainer styles, or a 9:16 Short cut from the same captures)",
+    },
+  ],
+};

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -97,6 +97,7 @@ import { appversionPlugin } from "./appversion";
 import { brothersbePlugin } from "./brothersbe";
 // iOS development plugins
 import { pragmaPlugin } from "./pragma";
+import { demodayPlugin } from "./demoday";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -202,6 +203,7 @@ const curatedPlugins: Plugin[] = [
   brothersbePlugin,
   // iOS development plugins
   pragmaPlugin,
+  demodayPlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across


### PR DESCRIPTION
- `src/data/plugins/demoday.ts`: curated listing for **DemoDay** — a Claude Code plugin that creates demo videos for your projects. Claude is given tools to drive the browser/CLI, make recordings, and uses FAL.ai, ElevenLabs and Remotion to build a demo video with scene transitions. Supports 16:9 promo/tutorial demos and 9:16 Short listicle/cohost cuts. macOS, open source, MIT. Repo: https://github.com/mrieck/demoday-claude-plugin
- `scripts/ingest/marketplaces.mjs`: add `mrieck/claude-plugins` to `KNOWN_MARKETPLACES` so the marketplace's other plugins (socialcue, seoblog, overboard) are ingested from its `.claude-plugin/marketplace.json`.

`tsc --noEmit` passes.
