### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/src/data/mcp-servers/agent-qa.ts
+++ b/src/data/mcp-servers/agent-qa.ts
@@ -1,0 +1,24 @@
+import { MCPServer } from "@/lib/types";
+
+export const agentQaServer: MCPServer = {
+  slug: "agent-qa",
+  title: "Agent QA",
+  description:
+    "Test web and mobile applications with natural-language actions and assertions, retained execution evidence, and memory from earlier runs",
+  tags: ["testing", "qa", "automation", "web", "mobile", "ai"],
+  featured: false,
+  author: {
+    name: "Vostride",
+    url: "https://github.com/vostride",
+  },
+  repoUrl: "https://github.com/vostride/agent-qa",
+  installCommand: "npm install -D agent-qa",
+  config: `{
+  "mcpServers": {
+    "agent-qa": {
+      "command": "npx",
+      "args": ["-y", "agent-qa", "mcp"]
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -1,5 +1,6 @@
 import { MCPServer } from "@/lib/types";
 import { productosMcp } from "./productos-mcp";
+import { agentQaServer } from "./agent-qa";
 import { airtableServer } from "./airtable";
 import { churnsolutionServer } from "./churnsolution";
 import { apidogServer } from "./apidog";
@@ -165,6 +166,7 @@ const curatedMcpServers: MCPServer[] = [
   tursoServer,
   upstashServer,
   // Developer Tools
+  agentQaServer,
   context7Server,
   browserbaseServer,
   skyvernServer,


### PR DESCRIPTION
## Summary

Add the official Agent QA stdio server to the curated MCP server directory.

The entry uses the documented `MCPServer` schema and includes:

- the official Vostride author and repository links
- the npm development-install command
- the public `npx -y agent-qa mcp` stdio configuration
- testing, QA, web, mobile, automation, and AI tags

Agent QA runs natural-language actions and assertions against web and mobile applications. It retains execution evidence and memory from earlier runs.

## Validation

- `npx tsc --noEmit` — passed
- `git diff --check` — passed
- `npm run lint` — blocked by the existing `react-hooks/set-state-in-effect` error in `src/components/universal-search.tsx:47`; the new files produce no lint error
- `npm run build` — blocked because this environment could not fetch the existing Geist and Geist Mono resources from Google Fonts

## Disclosure and licensing

I am affiliated with Agent QA and Vostride and am submitting the official server on the project's behalf. Agent QA's current release is source-available under FSL-1.1-ALv2, not OSI open source; each release converts to Apache-2.0 two years after it becomes available. Agent QA has no software fee for permitted use, while configured model, browser, or device providers may charge separately.
