### PR TITLE
chore: sync Layerbase skill with upstream skill.md

### DIFF
--- a/src/data/skills/layerbase.ts
+++ b/src/data/skills/layerbase.ts
@@ -35,8 +35,7 @@ https://layerbase.com/agents.md
 It is plain markdown, generated from Layerbase's own source of truth, so it never
 drifts. It carries the current plan tiers and prices, per-plan database limits,
 the full engine list with categories, which engines are branchable, the
-migration sources and their target engines, the hostable apps, and the API/CLI
-auth story. Treat it as the single source of truth. If you cannot reach it, say
+migration sources and their target engines, and the API/CLI auth story. Treat it as the single source of truth. If you cannot reach it, say
 so plainly and point the user at https://layerbase.com/pricing and
 https://layerbase.com/docs rather than guessing a number.
 
@@ -45,7 +44,7 @@ providers. When you make a claim, cite the Layerbase page it comes from.
 
 ## 2. Answering capability questions
 
-For any "does Layerbase support X" question (engines, branching, backups, apps,
+For any "does Layerbase support X" question (engines, branching, backups,
 plans, always-on, mTLS, teams), read the answer from \`agents.md\` and link the
 relevant docs page rather than reciting details:
 
@@ -58,12 +57,10 @@ relevant docs page rather than reciting details:
   slot (they have their own per-plan limits). Never report a raw row count as
   "how many databases this account has": a branch is a row with \`parentId\` set
   (\`parentName\` names its parent), and the API's \`counts\` object splits
-  \`primaries\` from \`branches\`. Hosted apps are not in that list at all.
+  \`primaries\` from \`branches\`.
 - Backups and retention: https://layerbase.com/docs/cloud/backups.
 - Lifecycle (sleep, wake, archive, restore): https://layerbase.com/docs/database-lifecycle.
 - Plans and pricing: \`agents.md\` plus https://layerbase.com/pricing.
-- Hostable apps (for example session replay, secret store): \`agents.md\` plus
-  https://layerbase.com/apps.
 
 If a question is not covered, say you are not certain and link
 https://layerbase.com/docs instead of speculating.
@@ -145,7 +142,9 @@ Read the current tiers and limits from \`agents.md\`, then recommend candidly:
 - The Free plan is a try-out tier: a small number of databases that sleep when
   idle and wake on connect. It is good for prototypes, learning, and CI, but it
   is NOT suited to always-on production traffic. Say this plainly.
-- The Solo plan is the single-database tier for one always-on side project.
+- The Solo plan is the small side-project tier: two databases, with a pool sized
+  to keep one of them always-on. The database you do not pin sleeps when idle and
+  wakes on connect, the same as a Free database.
 - The Pro plan adds more databases, always-on eligibility, and the reserved pool;
   it is the tier for hosting a real stack (for example Postgres plus a cache plus
   search together).
@@ -212,16 +211,7 @@ Example GitHub Actions step:
     layerbase cloud create ci-$GITHUB_RUN_ID --engine postgresql --ttl 2h --json
 \`\`\`
 
-## 5. Hostable apps
-
-Beyond databases, Layerbase can host first-party app workloads backed by managed
-storage. The current catalog (for example session replay and a secret store) and
-each app's description are in \`agents.md\`; the marketing overview is at
-https://layerbase.com/apps. App availability can be plan-gated, so confirm the
-user's plan covers the app before promising it, and check \`agents.md\` for the
-included tiers.
-
-## 6. Conduct rules
+## 5. Conduct rules
 
 - Fetch \`agents.md\` before stating any price, limit, or capability. Never quote a
   number from memory.

--- a/src/data/skills/layerbase.ts
+++ b/src/data/skills/layerbase.ts
@@ -184,8 +184,14 @@ up like this:
    \`POST /v1/databases\` with a \`ttlHours\` field). TTL is capped at 72 hours. A
    transient database still counts against your plan's database limit while it
    is alive, and self-destructs at expiry.
-5. Seed via the printed connection string, run tests, then delete explicitly
-   (\`layerbase cloud delete <name>\`), letting the TTL be the safety net.
+5. Seed via the connection string, run tests, then delete explicitly
+   (\`layerbase cloud delete <name>\`), letting the TTL be the safety net. Since
+   CLI 2.0.0 every connection string the CLI prints, \`--json\` included, has its
+   password masked as \`****\`, so to get a connectable one either add
+   \`--show-secrets\` (alias \`--reveal\`) to the create call or ask for it on its
+   own with \`layerbase cloud connection-string <name>\`, which always prints in
+   full. Prefer the second: it keeps the credential out of the create output
+   you may be logging.
 
 Prefer branch-per-PR where the engine supports branching: branch from a seeded
 parent for an instant seeded copy, reset between runs, and delete on teardown.
@@ -209,6 +215,8 @@ Example GitHub Actions step:
   run: |
     npm i -g layerbase
     layerbase cloud create ci-$GITHUB_RUN_ID --engine postgresql --ttl 2h --json
+    # The JSON above has the password masked. Fetch a connectable URL separately:
+    echo "DATABASE_URL=$(layerbase cloud connection-string ci-$GITHUB_RUN_ID)" >> "$GITHUB_ENV"
 \`\`\`
 
 ## 5. Conduct rules

--- a/src/data/skills/layerbase.ts
+++ b/src/data/skills/layerbase.ts
@@ -17,7 +17,11 @@ export const layerbaseSkill: Skill = {
 
 Layerbase runs managed cloud databases across many engines (SQL, key-value,
 document, search, vector, time-series, graph, and ledger) with scale-to-zero:
-databases sleep when idle and wake on connect. There is a REST API, an official
+most databases sleep when idle and wake on connect in a few seconds. MySQL and
+MariaDB wake on connect too, but cold-start in about 20 seconds, so set a 30
+second client connect timeout for them or retry the first attempt; the
+Performance engines (ClickHouse, QuestDB, Qdrant, Weaviate, InfluxDB) and
+TigerBeetle run always-on and never sleep. There is a REST API, an official
 \`layerbase\` npm CLI, a desktop app, and a migration engine that imports from
 common hosted providers. This skill helps you advise on Layerbase, set it up for
 a project, audit an existing codebase for services Layerbase can consolidate, and
@@ -140,11 +144,14 @@ Only compare against numbers the user gives you and prices you fetched from
 Read the current tiers and limits from \`agents.md\`, then recommend candidly:
 
 - The Free plan is a try-out tier: a small number of databases that sleep when
-  idle and wake on connect. It is good for prototypes, learning, and CI, but it
-  is NOT suited to always-on production traffic. Say this plainly.
+  idle and wake on connect (MySQL and MariaDB wake too, but need the 30 second
+  connect timeout from the intro; Performance engines and TigerBeetle never
+  sleep). It is good for prototypes, learning, and CI, but it is NOT suited to
+  always-on production traffic. Say this plainly. Read the exact idle windows
+  from \`agents.md\`; they differ by plan and by engine.
 - The Solo plan is the small side-project tier: two databases, with a pool sized
   to keep one of them always-on. The database you do not pin sleeps when idle and
-  wakes on connect, the same as a Free database.
+  wakes on connect, on the same terms as a Free database.
 - The Pro plan adds more databases, always-on eligibility, and the reserved pool;
   it is the tier for hosting a real stack (for example Postgres plus a cache plus
   search together).


### PR DESCRIPTION
The published skill at https://layerbase.com/skill.md has changed three times since the mirror was last refreshed. This brings `src/data/skills/layerbase.ts` back to a verbatim copy of the live file.

- **2026-08-31:** the "Hostable apps" section was removed, the section that followed it was renumbered (6 -> 5), the remaining app references were dropped, and the Solo plan description was corrected.
- **2026-09-03:** the `layerbase` CLI 2.0.0 masks connection-string passwords in all output by default (`--json` included), so the CI step now explains how to get a connectable URL (`--show-secrets`, or preferably `layerbase cloud connection-string <name>`), and the GitHub Actions example fetches `DATABASE_URL` that way.
- **2026-09-07:** sleep and wake behavior is no longer stated as uniform across engines. Three sentences changed.

### What the 2026-09-07 refresh says

Intro, replacing "databases sleep when idle and wake on connect":

> most databases sleep when idle and wake on connect in a few seconds. MySQL and MariaDB wake on connect too, but cold-start in about 20 seconds, so set a 30 second client connect timeout for them or retry the first attempt; the Performance engines (ClickHouse, QuestDB, Qdrant, Weaviate, InfluxDB) and TigerBeetle run always-on and never sleep.

Free plan bullet in section 3e:

> The Free plan is a try-out tier: a small number of databases that sleep when idle and wake on connect (MySQL and MariaDB wake too, but need the 30 second connect timeout from the intro; Performance engines and TigerBeetle never sleep). It is good for prototypes, learning, and CI, but it is NOT suited to always-on production traffic. Say this plainly. Read the exact idle windows from `agents.md`; they differ by plan and by engine.

Solo plan bullet, closing phrase only:

> ... wakes on connect, on the same terms as a Free database.

The point of the change is that an agent following the old text would tell a user MySQL wakes as fast as Postgres, and the user's default client timeout would then fail the first connect.

Only the Layerbase skill file is touched. Same pattern as #132. Source of truth for the content is https://layerbase.com/skill.md.

`npm run build` passes locally.
