### PR TITLE
Add charlesashe/backbrief-kit to KNOWN_MARKETPLACES

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -20,6 +20,7 @@ const KNOWN_MARKETPLACES = [
   "claude-world/director-mode-lite",
   "Eliasjunit/vibestretch",
   "Sting25/claude-code-handoff",
+  "charlesashe/backbrief-kit",
 ];
 
 const MARKETPLACE_PATHS = [


### PR DESCRIPTION
One line in `scripts/ingest/marketplaces.mjs`, following #140 and #131.

[backbrief-kit](https://github.com/charlesashe/backbrief-kit) turns a Claude Code project into a coordinated team rather than one long chat. An orchestrator decomposes a goal into units with acceptance criteria and routes each to a specialist agent; a separate verifier then reviews each finished artifact in fresh context against those criteria, receiving the artifact and the criteria only and never the producing agent's reasoning, so the check is not the author marking their own work. `/handoff` writes a brief a fresh session can resume from and `/pickup` reads it back, which is what carries state across context resets.

The repo has a valid `.claude-plugin/marketplace.json` at its root (marketplace `backbrief`, one plugin `backbrief-kit`, category `productivity`), so the existing ingest should read it without changes.

One thing worth stating plainly rather than leaving for you to find: **the licence is custom and source-available, not OSI** — free to use and share unmodified, not for resale. If that puts it outside what you want indexed, closing this is a completely reasonable call and I won't re-open it.