### PR TITLE
Add hush plugin and the foundry marketplace

### DIFF
--- a/scripts/ingest/marketplaces.mjs
+++ b/scripts/ingest/marketplaces.mjs
@@ -20,6 +20,7 @@ const KNOWN_MARKETPLACES = [
   "claude-world/director-mode-lite",
   "Eliasjunit/vibestretch",
   "Sting25/claude-code-handoff",
+  "V-Songbird/foundry",
 ];
 
 const MARKETPLACE_PATHS = [

--- a/src/data/plugins/foreman.ts
+++ b/src/data/plugins/foreman.ts
@@ -1,0 +1,38 @@
+import { Plugin } from "@/lib/types";
+
+export const foremanPlugin: Plugin = {
+  slug: "foreman",
+  title: "Foreman",
+  description:
+    "Keeps your project plan next to the code as a plain roadmap file, so the next session starts where the last one stopped: ask what's next and get the task, why it comes first, and a ready-to-run prompt checked against your real files",
+  tags: ["roadmap", "planning", "prompt-engineering", "workflow", "community"],
+  featured: false,
+  author: {
+    name: "Victor Villegas",
+    url: "https://github.com/V-Songbird",
+  },
+  repoUrl: "https://github.com/V-Songbird/foreman",
+  installCommand: "/plugin marketplace add V-Songbird/foundry && /plugin install foreman@foundry",
+  commands: [
+    {
+      name: "/foreman:foreman",
+      description: "Say what you want in plain words: add work, show status, pick the next task",
+    },
+    {
+      name: "/foreman:init",
+      description: "Set up the roadmap for a project",
+    },
+    {
+      name: "/foreman:roadmap",
+      description: "Pick the next task, add one, fix one, or check the roadmap's health",
+    },
+    {
+      name: "/foreman:survey",
+      description: "Check the next tasks against the actual codebase and repair stale ones",
+    },
+    {
+      name: "/foreman:craft-prompt",
+      description: "Build a standalone, self-contained prompt for a session",
+    },
+  ],
+};

--- a/src/data/plugins/hush.ts
+++ b/src/data/plugins/hush.ts
@@ -1,0 +1,26 @@
+import { Plugin } from "@/lib/types";
+
+export const hushPlugin: Plugin = {
+  slug: "hush",
+  title: "hush",
+  description:
+    "Keeps Claude quiet until the job is done: one short answer at the end that leads with the result and names the file to open, plus hooks that trim long command output and logs before they pile up in the session",
+  tags: ["output-style", "tokens", "hooks", "productivity", "adhd", "community"],
+  featured: false,
+  author: {
+    name: "Victor Villegas",
+    url: "https://github.com/V-Songbird",
+  },
+  repoUrl: "https://github.com/V-Songbird/hush",
+  installCommand: "/plugin marketplace add V-Songbird/foundry && /plugin install hush@foundry",
+  commands: [
+    {
+      name: "/hush:craft-style",
+      description: "Build a voice of your own on hush's quiet frame",
+    },
+    {
+      name: "/hush:pick-style",
+      description: "Switch between your voices, or go back to the stock one",
+    },
+  ],
+};

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -97,6 +97,7 @@ import { appversionPlugin } from "./appversion";
 import { brothersbePlugin } from "./brothersbe";
 // iOS development plugins
 import { pragmaPlugin } from "./pragma";
+import { hushPlugin } from "./hush";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -202,6 +203,8 @@ const curatedPlugins: Plugin[] = [
   brothersbePlugin,
   // iOS development plugins
   pragmaPlugin,
+  // Output and session-noise plugins
+  hushPlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across

--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -98,6 +98,8 @@ import { brothersbePlugin } from "./brothersbe";
 // iOS development plugins
 import { pragmaPlugin } from "./pragma";
 import { hushPlugin } from "./hush";
+import { razorPlugin } from "./razor";
+import { foremanPlugin } from "./foreman";
 
 const curatedPlugins: Plugin[] = [
   // Featured plugins first
@@ -205,6 +207,8 @@ const curatedPlugins: Plugin[] = [
   pragmaPlugin,
   // Output and session-noise plugins
   hushPlugin,
+  razorPlugin,
+  foremanPlugin,
 ];
 
 // Auto-ingested plugins from `.claude-plugin/marketplace.json` files across

--- a/src/data/plugins/razor.ts
+++ b/src/data/plugins/razor.ts
@@ -1,0 +1,22 @@
+import { Plugin } from "@/lib/types";
+
+export const razorPlugin: Plugin = {
+  slug: "razor",
+  title: "razor",
+  description:
+    "Stops Claude from adding code nobody needed: one evidence-backed check before every new package, file or abstraction, so a one-line feature stays a one-line feature instead of a new library and five helper files",
+  tags: ["yagni", "dependencies", "hooks", "code-quality", "community"],
+  featured: false,
+  author: {
+    name: "Victor Villegas",
+    url: "https://github.com/V-Songbird",
+  },
+  repoUrl: "https://github.com/V-Songbird/razor",
+  installCommand: "/plugin marketplace add V-Songbird/foundry && /plugin install razor@foundry",
+  commands: [
+    {
+      name: "/razor:unused",
+      description: "Find dependencies in the manifest that no source file imports",
+    },
+  ],
+};


### PR DESCRIPTION
Adds a curated entry for **hush**, a Claude Code plugin that keeps Claude quiet until the job is done (one short answer at the end, plus hooks that trim long command output), and adds its marketplace `V-Songbird/foundry` to the ingest list so its sibling plugins get picked up on the next refresh.

- `src/data/plugins/hush.ts` — new entry, exported from `index.ts`
- `scripts/ingest/marketplaces.mjs` — `V-Songbird/foundry` added to `KNOWN_MARKETPLACES`

Repo: https://github.com/V-Songbird/hush

🤖 Generated with [Claude Code](https://claude.com/claude-code)