### PR TITLE
Add ProvenSkills hosted MCP server

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -102,6 +102,7 @@ import { findMcpServer } from "./find-mcp";
 import { dottedsignServer } from "./dottedsign";
 import { safeinstallServer } from "./safeinstall";
 import { vibekitServer } from "./vibekit";
+import { provenskillsServer } from "./provenskills";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -225,6 +226,8 @@ const curatedMcpServers: MCPServer[] = [
   productosMcp,
   // Hosting & Deployment
   vibekitServer,
+  // Skill marketplaces
+  provenskillsServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/provenskills.ts
+++ b/src/data/mcp-servers/provenskills.ts
@@ -1,0 +1,24 @@
+import { MCPServer } from "@/lib/types";
+
+export const provenskillsServer: MCPServer = {
+  slug: "provenskills",
+  title: "ProvenSkills",
+  description:
+    "Skill packs written by domain experts, delivered over a hosted MCP connector. Add one link per seller and every pack update arrives on its own. Five free packs: Meeting Ops, Plain Writing, Retention Desk, Claims Desk Field Kit, Skill Author Kit.",
+  tags: ["skills", "productivity", "writing", "business", "sales", "customer-success", "insurance"],
+  author: {
+    name: "ProvenSkills",
+    url: "https://provenskills.ai",
+  },
+  docsUrl: "https://provenskills.ai/how-it-works",
+  dateAdded: "2026-09-07",
+  installCommand: "claude mcp add --transport http provenskills-labs https://mcp.provenskills.ai/labs/mcp",
+  config: `{
+  "mcpServers": {
+    "provenskills-labs": {
+      "type": "http",
+      "url": "https://mcp.provenskills.ai/labs/mcp"
+    }
+  }
+}`,
+};


### PR DESCRIPTION
Adds ProvenSkills, a hosted MCP server that delivers expert-written skill packs (five are free) into Claude and other MCP clients over OAuth 2.1 with dynamic client registration. Follows the hosted-server format used by the Churn Solution and ProductOS entries, with a docsUrl for setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTgz5MtNeePBeqqodsKqs5
