### PR TITLE
Add Meanwhile plugin listing

### DIFF
--- a/src/data/plugins/index.ts
+++ b/src/data/plugins/index.ts
@@ -28,6 +28,7 @@ import { swiftLspPlugin } from "./swift-lsp";
 import { testWriterFixerPlugin } from "./test-writer-fixer";
 import { flowNextPlugin } from "./flow-next";
 import { ralphPlugin } from "./ralph";
+import { meanwhilePlugin } from "./meanwhile";
 import { yapuiPlugin } from "./yapui";
 // LSP plugins
 import { typescriptLspPlugin } from "./typescript-lsp";
@@ -142,6 +143,7 @@ const curatedPlugins: Plugin[] = [
   flowNextPlugin,
   ralphPlugin,
   yapuiPlugin,
+  meanwhilePlugin,
   // External plugins
   asanaPlugin,
   awsPlugin,

--- a/src/data/plugins/meanwhile.ts
+++ b/src/data/plugins/meanwhile.ts
@@ -1,0 +1,17 @@
+import { Plugin } from "@/lib/types";
+
+export const meanwhilePlugin: Plugin = {
+  slug: "meanwhile",
+  title: "Meanwhile",
+  description: "Adds a disclosed, revenue-sharing status line to Claude Code: while the agent is thinking it shows a rotating tip, and occasionally a clearly-labeled \"(sponsored)\" line. Half of what a sponsor line earns is paid to you over PayPal. Also works with Copilot CLI and VS Code.",
+  tags: ["statusline", "monetization", "cli", "vscode", "copilot-cli"],
+  author: {
+    name: "Nirmeet Trivedi",
+    url: "https://github.com/heenatrivedi321-max",
+  },
+  repoUrl: "https://github.com/heenatrivedi321-max/deadtime",
+  installCommand: "npx trymeanwhile",
+  commands: [
+    { name: "npx trymeanwhile claim", description: "Check what you've earned and register a payout email" },
+  ],
+};


### PR DESCRIPTION
## Summary
- Adds Meanwhile, a disclosed revenue-sharing status line for Claude Code (also works with Copilot CLI and VS Code)
- While the agent is thinking it shows a rotating tip, and occasionally a clearly-labeled "(sponsored)" line -- half of what that earns is paid to the developer over PayPal
- Install is `npx trymeanwhile`, no signup required to try
- Source: https://github.com/heenatrivedi321-max/deadtime

## Test plan
- [x] `npx tsc --noEmit` passes with the new entry
- [x] Follows the existing `Plugin` type and file layout from CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)