### PR TITLE
Add RunVouch MCP server

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -102,6 +102,7 @@ import { findMcpServer } from "./find-mcp";
 import { dottedsignServer } from "./dottedsign";
 import { safeinstallServer } from "./safeinstall";
 import { vibekitServer } from "./vibekit";
+import { runvouchServer } from "./runvouch";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -225,6 +226,7 @@ const curatedMcpServers: MCPServer[] = [
   productosMcp,
   // Hosting & Deployment
   vibekitServer,
+  runvouchServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/runvouch.ts
+++ b/src/data/mcp-servers/runvouch.ts
@@ -1,0 +1,21 @@
+import { MCPServer } from "@/lib/types";
+
+export const runvouchServer: MCPServer = {
+  slug: "runvouch",
+  title: "RunVouch",
+  description:
+    "Dead man's switch for unattended agents: ask why last night's run is missing, stalled, failed or unproven, check cost caps, and read the tamper-evident proof of a finished run.",
+  tags: ["monitoring", "observability", "cron", "alerting", "self-hosted"],
+  author: { name: "RunVouch", url: "https://github.com/runvouch/runvouch" },
+  docsUrl: "https://runvouch.com/docs/mcp",
+  config: `{
+  "mcpServers": {
+    "runvouch": {
+      "url": "https://api.runvouch.com/mcp",
+      "headers": {
+        "X-API-Key": "rv_YOUR_KEY"
+      }
+    }
+  }
+}`,
+};


### PR DESCRIPTION
RunVouch is a watchdog for unattended AI agents: it alerts when a scheduled run is missing,
stalled, failed, over its cost cap or finished without evidence that the work was done.

The MCP server is remote (`https://api.runvouch.com/mcp`, free key at runvouch.com) and exposes
status, alerts, runs and the proof of a finished run, so one agent can check on another before
it builds on last night's output.

Source: https://github.com/runvouch/runvouch (MIT, self-hostable)
Docs: https://runvouch.com/docs/mcp
Official MCP registry: com.runvouch/runvouch
