### PR TITLE
Add Draxlr MCP server

### DIFF
--- a/src/data/mcp-servers/draxlr.ts
+++ b/src/data/mcp-servers/draxlr.ts
@@ -1,0 +1,22 @@
+import { MCPServer } from "@/lib/types";
+
+export const draxlrServer: MCPServer = {
+  slug: "draxlr",
+  title: "Draxlr",
+  description: "Work with your Draxlr databases and dashboards — list databases, inspect schemas, run read-only SQL, save and run queries, export results, and build dashboards. Connects to your data via OAuth.",
+  tags: ["analytics", "database", "sql", "dashboards", "business-intelligence"],
+  author: {
+    name: "Draxlr",
+    url: "https://draxlr.com",
+  },
+  docsUrl: "https://docs.draxlr.com/docs/mcp-server",
+  installCommand: "claude mcp add --transport http draxlr https://api.draxlr.com/mcp",
+  config: `{
+  "mcpServers": {
+    "draxlr": {
+      "type": "http",
+      "url": "https://api.draxlr.com/mcp"
+    }
+  }
+}`,
+};

--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -102,6 +102,7 @@ import { findMcpServer } from "./find-mcp";
 import { dottedsignServer } from "./dottedsign";
 import { safeinstallServer } from "./safeinstall";
 import { vibekitServer } from "./vibekit";
+import { draxlrServer } from "./draxlr";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -149,6 +150,7 @@ const curatedMcpServers: MCPServer[] = [
   snowflakeServer,
   bigqueryServer,
   datadogServer,
+  draxlrServer,
   // Social & Communication
   obsidianServer,
   blueskyServer,


### PR DESCRIPTION
Adds Draxlr, a hosted (remote, OAuth) MCP server for working with Draxlr databases and dashboards: listing databases, inspecting schemas, running read-only SQL, saving/running queries, exporting results, and building dashboards.