### PR TITLE
Correct Selvedge’s npm install command and setup link

### DIFF
--- a/src/data/mcp-servers/index.ts
+++ b/src/data/mcp-servers/index.ts
@@ -102,6 +102,7 @@ import { findMcpServer } from "./find-mcp";
 import { dottedsignServer } from "./dottedsign";
 import { safeinstallServer } from "./safeinstall";
 import { vibekitServer } from "./vibekit";
+import { selvedgeServer } from "./selvedge";
 
 const curatedMcpServers: MCPServer[] = [
   // Featured servers first
@@ -225,6 +226,7 @@ const curatedMcpServers: MCPServer[] = [
   productosMcp,
   // Hosting & Deployment
   vibekitServer,
+  selvedgeServer,
 ];
 
 // Auto-ingested MCP servers from curated awesome-mcp-servers lists.

--- a/src/data/mcp-servers/selvedge.ts
+++ b/src/data/mcp-servers/selvedge.ts
@@ -1,0 +1,25 @@
+import { MCPServer } from "@/lib/types";
+
+export const selvedgeServer: MCPServer = {
+  // Preserve the existing ingested URL and override its guessed npm package.
+  slug: "masondelan-selvedge",
+  title: "Selvedge",
+  description:
+    "Local decision history for AI coding agents. Record reasons and rejected approaches, then query prior attempts and outcomes by entity before editing. SQLite storage; recording and retrieval require tool calls.",
+  tags: ["developer-tools", "ai", "agent"],
+  author: {
+    name: "masondelan",
+    url: "https://github.com/masondelan",
+  },
+  repoUrl: "https://github.com/masondelan/selvedge",
+  docsUrl: "https://selvedge.sh/start/quickstart/",
+  installCommand: "npx -y selvedge-mcp",
+  config: `{
+  "mcpServers": {
+    "selvedge": {
+      "command": "npx",
+      "args": ["-y", "selvedge-mcp"]
+    }
+  }
+}`,
+};


### PR DESCRIPTION
The existing Selvedge entry points to `npx -y selvedge`, but the npm launcher is `selvedge-mcp`. Add a curated entry using the existing `masondelan-selvedge` slug, correct both the install command and MCP configuration, and link the canonical quickstart.

The curated entry overrides the ingested entry through the existing slug deduplication, preserving the listing URL. This is a maintainer-submitted correction.

Validation: `npm run build` passed (10,365 static pages); an import of the merged server list confirmed exactly one Selvedge entry with the corrected package/configuration and documentation link; `git diff --check` passed.
